### PR TITLE
Fix more OCR errors in 1935 scan

### DIFF
--- a/proofread/1935-12-15.txt
+++ b/proofread/1935-12-15.txt
@@ -34,8 +34,8 @@ Abrecht, Emil Ed., Sub.-Dir., Südbahnhofstrasse 17 [36.054]
 – Walter, Ausläufer, Belpstrasse 67
 Abt, Alb., Schmied, Murifeldweg 21
 – Emma, Bureaulistin, Eschmannstrasse 7
-– Jos. L,, Kaufmann, Muldenstr. 25 [36.396]
-– Wilh. Hch., eidg. Beamter. Scheuerrain 14
+– Jos. L., Kaufmann, Muldenstr. 25 [36.396]
+– Wilh. Hch., eidg. Beamter, Scheuerrain 14
 Acar AG., Auto-Ersatzteile, Effingerstrasse 6a [26.085]
 Acatos, Alex., Obering. d. S. B. B., Aegertenstrasse 65 [27.526]
 – Markus Const., Architekt, Aegertenstr. 65
@@ -85,16 +85,15 @@ Adamek, Elsa, Bureaulistin, Flurstrasse 25
 – H., chirurg.-mechan. Werkstätte, Flurstrasse 25 [32.326]
 – Ottilie, Bureaulistin, Flurstrasse 25
 – Roh. Wilh., Chirurg.-feinmech. Werkstätteu. allg. Handelsvertretungen, Flurstr. 25
-Adamina, Viktor A., Notar, Sekr. d. kant.
-Polizeidir.. Kirchenfeldstr. 63 [32.966]
-Adamoli, Emilia Car.. Schneiderin, Elisabethenstrasse 35
+Adamina, Viktor A., Notar, Sekr. d. kant. Polizeidir., Kirchenfeldstr. 63 [32.966]
+Adamoli, Emilia Car., Schneiderin, Elisabethenstrasse 35
 – Giacomo, Gipser, Hofweg 5a
 – Giuseppe, Maurerpolier, Seidenweg 1
 – Rosina 0-. Verkäuferin, Lorrainestrasse 13
 Adamson-Trüb, E1., Altenbergstr. 53 [32.761]
 Adank, Aug., Kaufm., Morellweg 8 [34.679]
 – Frieda E. (Liechti), Wwe., Monbijoustr. 28 [36.355]
-– Rud.. Viktcriastrasse 51
+– Rud., Viktcriastrasse 51
 Additions-Rechenmaschinen AG., Spitalg. 4
 Addor, Alb. Ch., Biskuitsfabrikation, Militärstrasse 45
 – Ernst Alfr., Beamter B. L. S., Attinghausenstrasse 31
@@ -114,7 +113,7 @@ Adler, Albert, Stadtmissionar, Wylerringstr. 7
 – Theodor H., Schildermaler, Wylerringstrasse 7
 Adolf, Gottfr., Lehrer, Freiburgstrasse 509, Bümpliz [46.623]
 – Hans, Buchhalter, Gartenstrasse 8
-– Max A.. Schlosser, Länggassstrasse 34a
+– Max A., Schlosser, Länggassstrasse 34a
 Adrema A.-G., Adressiermaschinen, Christoffelgasse 5 [23.743]
 Adressbuch [28.222] der Stadt Bern, Redaktion und Verlag, Breitenrainstrasse 97
 Adressen- u. Werbezentrale des Vereins zur
@@ -140,7 +139,7 @@ Aeberhard u. Aeberhardt, s. auch Eberhard
 – Ernst (Lüthi), Magaziner, Munzingerstr. 17
 – Ernst, Telephonmonteur, Breitenrainstr. 39
 – Ernst, Beamter S. B B., Blumensteinstr. 8
-– Ernst W.. kaufm Angest., Mühlemattstr. 20
+– Ernst W., kaufm Angest., Mühlemattstr. 20
 – Erwin, Dekorateur, Hopfenweg 11
 – Friedr., Mech. Spenglerei, Kehrgasse 16, Bümpliz
 – Fritz, Fräser, Kramgasse 11
@@ -151,7 +150,7 @@ Aeberhard u. Aeberhardt, s. auch Eberhard
 – Gottfr., Monteur, Hopfenweg 11
 – Gottfr., Spezereihdlg., Militärstrasse 40
 – Hans, Kaminfeger, Bühlstrasse 55
-– Hans Rud.. Vertreter, Morillonstrasse 2
+– Hans Rud., Vertreter, Morillonstrasse 2
 – Hans Werner, kaufm. Angest., Feilenbergstrasse 1
 – Hedwig Elsa, Bureaulistin, Muldenstr. 57
 – Hermann, Chauffeur, Marktgasse 5
@@ -170,7 +169,7 @@ Aeberhard u. Aeberhardt, s. auch Eberhard
 – Johanna, Weissnäherin, Waldheimstr. 27
 – Karl, Kohlenarbeiter, Muldenstrasse 57
 – Karl, Schlosser, Kasernenstrasse 48
-– Kath.. Schneiderin, Tiefmattstrasse 12
+– Kath., Schneiderin, Tiefmattstrasse 12
 – Lina, pens. Münzarbeiterin, Kirchenfeldstrasse 34
 – Louise, Liebeggweg 18b
 # Date: 1935-12-15 Page: 26020306/3
@@ -391,17 +390,16 @@ Aegerter, Fritz, gew. Angestellter, Wylerstrasse 43
 – Niklaus (Spycher), Angestellter b. Kindler & Cie., Brunnmattstrasse 21
 – Otto (v Arx). Südbahnhofstr. 6 [33.383]
 – Otto (Nafzger), Kaufmann, Wylerstr. 49
-– Paul. Maschinenmeister. Wiesenstrasse 73
+– Paul. Maschinenmeister, Wiesenstrasse 73
 – Paul Joh., Schneider, Lorrainestrasse 19
-– Rob.. Polizist, Thunstrasse 38
+– Rob., Polizist, Thunstrasse 38
 – Rosette, Wwe., Blumenweg 1
 – Rud., Lok.-Führer, Lorrainestrasse 8
-– Walter. Elektromonteur, Wiesenstrasse 73
+– Walter, Elektromonteur, Wiesenstrasse 73
 – Walter, Postchauffeur, Zähringerstr. 69
-– Wilh.. Pferdewärter, Brunngasse 6
-Aegler, Hedw Marg. Erl.. Optingenstr. 47
-– J. E. (KehrJi), Vizedirektor d. Eidg. Bank
-A.-G.. Jubiläumsstrasse 71 [31.913]
+– Wilh., Pferdewärter, Brunngasse 6
+Aegler, Hedw Marg. Erl., Optingenstr. 47
+– J. E. (KehrJi), Vizedirektor d. Eidg. Bank A.-G., Jubiläumsstrasse 71 [31.913]
 Aegyptische Gesandtschaft, Kanzlei, Bellevue-Palace
 Aellen, A E.,- Bureaulist. Balmweg 29
 – Anna, Damenschneiderin, Wittigkofenw. 21
@@ -419,7 +417,7 @@ Aellig, Alfr. Rud., Buchhalter, Lorystrasse 8
 – Gottfr., Privatier. Engerain 52
 – Gust. Arth., Magazinchef T.-W., Cäcilienstrasse 7
 – lda Hosa. Privatpension Flora, Laupenstrasse 5
-– Job Alfred. Hilfsarbeiter. Sonneggring 16
+– Job Alfred. Hilfsarbeiter, Sonneggring 16
 – Louise (Linder), Wwe. des Bankdir., Obere
 Dufourstrasse 43 [33.681]
 – Louise Klara, Chemikerin, Obere Dufourstrasse 43 [33.681]
@@ -428,7 +426,7 @@ Dufourstrasse 43 [33.681]
 – Rob., Versieh.-Angestellter, Römerweg 22
 – Rosa (Hubschmid), Wwe., Römerweg 22
 Aellig, Rosette (Dällenbach), Wwe., Birkenweg 19
-– Walter. Bahnbeamter, Wachtelweg 11
+– Walter, Bahnbeamter, Wachtelweg 11
 – Walter, Hilfsarbeiter, Schärerstrasse 7
 – Wilhelm Eduard, kaufm. Angest., Effingerstrasse 4 [24.383]
 – Wilh., Metzger, Schwarzenburgstrasse 25
@@ -442,7 +440,7 @@ Aeppli, Jacques, Beamter der Generaldirektionder S B. B., Schillingstrasse 17
 – Marie. Bureaulistin. Bernastrasse 58
 Aerni, s. auch Arni und Erni
 – Alb., Kondukteur S. B. B., Gutenbergstr. 4
-– Alb.. Küfer, Bahnhöbeweg 86, Bümpliz
+– Alb., Küfer, Bahnhöbeweg 86, Bümpliz
 – Armin, Notar, Konsul (Effingerstrasse 60 [35.636]), Neuengasse 20 (Bürgerhaus) [23.232]
 – Christian K., Handlanger, Postgasse 27
 – Ed. Ernst. Bankbeamter, Beaulieustr. 37 [36.825]
@@ -490,7 +488,7 @@ Aaregg weg 34
 – Hans Ed., Drogerie, Länggassstrasse 40 [35.661]
 – Hedwig Gertr., Zahnarztassistentin, Marktgasse 4
 – Jakob Fr., Angestellter, Erlachstrasse 23
-– Joh.. gew Rangiermeister Hochfeldstr. 49
+– Joh., gew Rangiermeister Hochfeldstr. 49
 – Marg., Filialleiterin, Eigerplatz 8
 – O. W., pens. Lokomotivführer, Muldenstrasse 27
 – Walter, Schlosser, Schöneggweg 12
@@ -508,7 +506,7 @@ Aeschbacher, s. auch Eschbacher
 – Emil, kaufm. Angest., Schwarztorstr. 55
 – Emil, Hausbursche, Bundesgasse 8
 – Emma, Hochfeldstrasse 98
-– Emma El.. Jennerweg 5
+– Emma El., Jennerweg 5
 – Ernst, pens. Postverwalter, Daxeihoferstrasse 9 [21.998]
 – Ernst, Restaurateur, Rodtmattstrasse 56
 – Ernst (Germann), Seminarlehrer, Gryphenhübeliweg 2 [29.839]
@@ -516,15 +514,15 @@ Aeschbacher, s. auch Eschbacher
 – Erwin, kaufm. Angest., Muldenstrasse 39 [27.929]
 – Flora, Schneiderin, Eggimannstrasse 21
 – Frieda, Postgehilfin, Monbijoustrasse 21
-– Friedr.. Zimmermann, Flurstrasse 12
+– Friedr., Zimmermann, Flurstrasse 12
 – Fritz, Handlanger, Ladenwandstrasse 27
 – Hans, Wagenmaler, Murtenstrasse 37
 – Herm., Wertschriftenverwalter der Kantonalbank, Spitalackerstrasse 5 [27.774]
-– Herm.. Dr. rer pol., Sekretär der «Alpar», Bern, Zinggstrasse 20 [24.673]
+– Herm., Dr. rer pol., Sekretär der «Alpar», Bern, Zinggstrasse 20 [24.673]
 – Herm., gew. Bureauchef S. B. B., Daxelhoferstrasse 9 [27.579]
 Aeschbacher, s. auch Eschbacher
-– Herm.. Photohaus Bern (Choisystrasse 17 [34.168]), Christoffelgasse 3 [22.955], Bureau: Christoffelgasse 4
-– Herm. Arth.. Bureaulist, Scliärerstrasse 7
+– Herm., Photohaus Bern (Choisystrasse 17 [34.168]), Christoffelgasse 3 [22.955], Bureau: Christoffelgasse 4
+– Herm. Arth., Bureaulist, Scliärerstrasse 7
 – Joh., Bahnarbeiter, Eggimannstrasse 21
 – Karl, Schriftsetzer, Tulpenweg 4
 – Käthe Elisab., Buchbinderin, Kirchgasse 6
@@ -549,7 +547,7 @@ Aeschimarm, Elisabeth (Hauser), Wwe., Hopfenweg 37
 Aeschlimann, Adolf, Magaziner, Pappelweg 8
 – Adolf, Flurstrasse 26
 – Alb., Wirt, Länggassstrasse 85 [23.287]
-– Alb.. Sch reibmaschinen u. Bureauartikel, Rep.-Werkstätte, Effingerstr. 9 [27.462]
+– Alb., Sch reibmaschinen u. Bureauartikel, Rep.-Werkstätte, Effingerstr. 9 [27.462]
 – Alb., Schäfter W.-F., Kasthoferstrasse 69 [25.966]
 – Aifr. (Meier), Buchhalter, Konsumstr. 10
 – Anna, Bureaulistin, Spitalgasse 17
@@ -562,7 +560,7 @@ Aeschlimann, Adolf, Magaziner, Pappelweg 8
 – Elise, Krankenpflegerin, Wasserwerks. 4
 – Emil, Mechaniker, Kasthoferstrasse 69
 – Emma Frieda, Ladentochter, Aarbergergasse 35
-– Ernst Gottl.. Mechaniker, Jolimontstr. 12
+– Ernst Gottl., Mechaniker, Jolimontstr. 12
 – Ernst, Billetteur d. S. S. B., Karl-Staufferstrasse 31
 – Ernst. Bureauangestellter, Frikartweg 8
 – Ernst. Maler. Metzgergasse 74
@@ -580,7 +578,7 @@ Aeschlimann, Friedr., Gärtnermeister, Werkgasse 16, Bümpliz [46.288]
 – Fritz, Mech. der S. S. B., Lentulusrain 7
 – Fritz (Rothen), pens. Mandatträger, Lorystrasse 12
 – Fritz, Sattler, Freiburgstrasse 57
-– Gertrud M.. Bureaulistin, Donnerbühlw. 15
+– Gertrud M., Bureaulistin, Donnerbühlw. 15
 – Gottfr., Kondukteur d. S. B. B., Länggassstrasse 40a
 — Gottfr., alt Lehrer, Dittlingerweg 12 [28.885]
 – Gottfr., Waldarbeiter, Wohlenstrasse 51
@@ -595,7 +593,7 @@ Aeschlimann, Friedr., Gärtnermeister, Werkgasse 16, Bümpliz [46.288]
 – Jakob. Schlosser, Kasernenstrasse 21b
 – Jean Fred., Verkäufer, Brunnmattstr. 32
 – Joh., Pferdewärter, Wiesenstrasse 75
-– Joh.. Kutscher. Dählhölzliweg 3
+– Joh., Kutscher. Dählhölzliweg 3
 – Joh., Postchauffeur, Attinghausenstr. 23
 – Joh. Friedr., Buchhalter, Greyerzstrasse 36
 – Jules, Verm.-Techniker, Dalmazirain 32 [27.747]
@@ -609,13 +607,13 @@ Kabelaufrollern, Kalcheggweg 7 [27.180]
 – Olga (Christen), Cafe Weissenstein, Hopfenweg 23 [28.283]
 – Oswald, Bauschreiner, Bümplizstrasse 60
 – Paul, Angestellter, Neufeldstrasse 120
-– Paul, eidg. Beamter. Simonstrasse 23
+– Paul, eidg. Beamter, Simonstrasse 23
 – Paul, Magaziner, Rossfeldstrasse 31
 – R. (Michon), Wwe., gew. Wirtin, Sennw. 15
 – Rob., AG., Allg. Versicherungsbüro, Schauplatzgasse 26 [22.398]
 – Rosa, Fabrikarbeiterin, Holzikofenweg 16
 – Rosa, Weissnäherin, Stalden 17
-– Rosa (Pfister), Wwe.. Schwarztorstr. 61
+– Rosa (Pfister), Wwe., Schwarztorstr. 61
 – Rud., Parkettleger, Breitfeldstrasse 36 [26.337]
 – Rud., Privatpension, Waisenhausplatz 27 [34.332]
 – Susanna, Postgasse 18
@@ -654,10 +652,10 @@ Affolter, Albert, pens. Beamter, Schanzeneckstrasse 25
 – Paul, Uhrmacher, Breitenrainplatz 31
 – Rosa (Gfeller), Wwe., Kalcheggweg 4
 – Theresia Fl. (Ganz), Wwe., Wäscherei und Glätterei, Bridelstrasse 40 [45.483]
-– Walter. Hilfsarbeiter. Flurstrasse 10
+– Walter, Hilfsarbeiter, Flurstrasse 10
 Agence Cosmographique S. A., Bollwerk 15 [27.521]
 Agence telegraphique suisse (siehe Schweiz. Depeschenagentur)
-Agenstein, Christ.. Masseur und Fusspfleger, Spitalackerstrasse 25
+Agenstein, Christ., Masseur und Fusspfleger, Spitalackerstrasse 25
 – Emma, Hausfräulein, Spitalackerstr. 25
 – Marie, Spitalackerstrasse 25
 Agentur des Blauen Kreuzes, städt.: Zeughausgasse 39 [21.156]; Verlag: Lindenrain 5 [29.857]
@@ -665,7 +663,8 @@ Agentur des Blauen Kreuzes, städt.: Zeughausgasse 39 [21.156]; Verlag: Lindenra
 Agentur « Pro Arte » A.-G., Konzert- u. Theatertruppen-Vermittlung, Mühlemattstr. 14a
 Agostinetti, Emilio, Sekretär, Junkerngasse 52
 Agrikulturchemische Anstalt, Eidg., Liebefeld-Bern (Vorst.: Dr. E. Truninger) [45.039]
-Apustoni, Gustav. Ingenieur, Effingerstr. 13v. Ah, Anna Louise, Verkäuferin, Balderstr. 23
+Apustoni, Gustav. Ingenieur, Effingerstr. 13
+v. Ah, Anna Louise, Verkäuferin, Balderstr. 23
 Ahorn, Ernst, Polizist, Steigerweg 12
 Aich, Marg. El., Ladentochter, Greyerzstr. 47
 – Paul Alb., kaufin. Angest., Molchthalstr. 15 [20.603]
@@ -731,7 +730,7 @@ Albrecht, Aug., Prokurist, Mattenhofstr. 22 [33.430]
 – Emilie (Gassmann), Damenschneiderin, Dietlerstrasse 48 [45.628]
 – Ernst Joh., Stadtgeometer, Tavelweg 32 [36.872]
 – F. Gottl., Coiffeur, Altenbergstr. 18
-– Joh. Bapt.. pens. Postangest., Martiweg 14
+– Joh. Bapt., pens. Postangest., Martiweg 14
 – Julius Cäsar, Mechaniker, Dietlerstrasse 48
 – Marg. Rosalie, Haushaltungslehrerin, Tavelweg 32
 – Walter, Sulgeneckstrasse 36
@@ -792,7 +791,7 @@ Allenbach, Berta (Marti), Wwe., Wyttenbachstrasse 33
 Allensbach, Aug., Bereiter, Herzogstrasse 5
 Alienspach, P., Coiffeurgeschäft, Optingenstrasse 35
 Allet, Alice Fl., Bureaulistin. Kasernenstr. 42
-– Gertrud Helene, Ladentochter. Kasernenstrasse 42
+– Gertrud Helene, Ladentochter, Kasernenstrasse 42
 – Maria (Streit), Wwe., Kasernenstrasse 42
 Allg. Leichenbestattungs-Ges. A.-G. besorgt und liefert alles 24 777bei Todesfall. Leichentransporte, Be- tti i i istattung, Kremation, Predigergasse 4
 Allgemeine Plakatgesellschaft, Bundesg. 45 (Hirschengraben) [28.911]
@@ -800,7 +799,8 @@ Allgem. Schweizer. Militärzeitung, Redaktion, Wildermettweg 22d [42.292]
 Allgemeine Versicherungs - Aktiengesellschaftin Bern, Bundesgasse 18 [28.555]
 Allgem. Versieh.-Ges. «Helvetia» in St. Gallen, Generalag. Bern: Dr, Aus der Au, Otto, Laupenstrasse 3 [23.410]
 Alli mann, Fritz. Reklameberater u. Verkaufsorganisator, Aegertenstrasse 77
-Allioli, Pompeo, Postkommis, Wylerstrasse 49v. Allmen, Alfred Alb., Elektriker, Greyerzstrasse 28
+Allioli, Pompeo, Postkommis, Wylerstrasse 49
+v. Allmen, Alfred Alb., Elektriker, Greyerzstrasse 28
 – Anna R., Ladentochter, Ulmenweg 9
 – Christian (Lüthi), Seifenhandel, Weissensteinstrasse 62
 – Christ., Elektromonteur, Lentulusstr. 43
@@ -866,16 +866,16 @@ Althaus, Christ., Mechaniker, Freiburgstrasse Nr. 159
 – Friedr., gew. Landwirt, Melchenbühlw. 36 [34.073]
 – Friedr. Alfr., Elektriker. Engehaldenstr. 199
 – Friedr. (Krieg), Wickler, Federweg 59
-– Friedr.. Techniker, Morillonstr. 4 [27.857]
+– Friedr., Techniker, Morillonstr. 4 [27.857]
 – Fritz, Hilfsarbeiter, Weberstrasse 12
 – Fritz, Maler, Talweg 5
 – Fritz Otto, Notar, Stadtbuchhalter, Humboldtstrasse 41 [20.985]
-– Gottfr.. Landwirt, Melchenbühlweg 36
+– Gottfr., Landwirt, Melchenbühlweg 36
 – Hans, Fürsprecher, Haspelweg 34 [31.231]
 – Hans, Maler, Effingerstrasse 93
 – Hedwig, Bureaulistin, Marktgasse 46
 – Jak. Friedr., Goldschmied, Spitalackerstr. lb
-– Joh.. Prokurist, Hallwylstr. 39 [31.653]
+– Joh., Prokurist, Hallwylstr. 39 [31.653]
 – Joh., Sek.-Lehrer, Haspelweg 34 [34.231]
 – Johanna, Bureaulistin, Zaunweg 20
 – Leonie. Verkäuferin. Mühlemattstr. 59
@@ -913,7 +913,7 @@ Altorfer, Ernst. Elemente- und Batteriefabrik
 – Hans, Vergolder, Engerain 50
 – Otto, Spengler, Engerain 50
 – Walter, Magaziner, Engerain 50
-Altwegg, Alb.. Sektionschef beim eidg. Eisenbahndepartement. Spitalackerstrasse 63
+Altwegg, Alb., Sektionschef beim eidg. Eisenbahndepartement. Spitalackerstrasse 63
 – Bertha (Ducommun), Alleeweg 18
 – Franz, in Fa. Mollet & Cie., Alleeweg 18 [32.824]
 Aluvisetti, Giuseppe, Hutmacher, Standstr. 35
@@ -958,11 +958,11 @@ G.-D., Sonnenbergrain 51 [24.0t22]
 – Alfr., Maler, Moritzweg 20
 – Alice (Schweizer), Wwe., Thunstrasse 30 [33.294]
 – Anna, Haushaltungslehrerin, Pavillonw. la [27.947]
-– .Anna, Taglöhnerin, Lagerweg 12
+– Anna, Taglöhnerin, Lagerweg 12
 – Anna, Taglöhnerin, Stauffacherstrasse 8
 – Berta. Buchhalterin. Laupenstrasse 57
 – Christ. Jak., Bereiter, Bantigerstrasse 20
-– Christ.. Spengler. Freiburgstrasse 63
+– Christ., Spengler. Freiburgstrasse 63
 – Clara, Ladentochter, Weyermannsstr. 42
 – Dora. Sekretärin, Breitenrainstrasse 73
 – E. (Hafner), Wwe., Monbijoustrasse 21 [22.059]
@@ -979,10 +979,10 @@ G.-D., Sonnenbergrain 51 [24.0t22]
 – Hans, Versich.-Beamter, Viktoriastrasse 45
 – Hch., Postbureauchef, Viktoriastrasse 45 [26.117]
 – Herm. Th., Kaufmann, Sandrainstrasse 98
-– J E., gew Angestellter. Weyermannsstr 42
+– J E., gew Angestellter, Weyermannsstr 42
 – Jakob, Prokurist der B. L. S., Breitenrainstrasse 29 [32.591]
 – Joh., Apotheker, Spitalackerstrasse 19
-– Joh., pens. Arbeiter E. W. B.. Aarbergergasse 43
+– Joh., pens. Arbeiter E. W. B., Aarbergergasse 43
 – Joh. Friedr., Gärtnermeister, Länsrgassstrasse 32 [33.804]
 – Joh. Friedr., Handlanger, Burgunderstr. 43, Bümpliz
 – Jos. Emil, Wagenführer der S. S. B., Sch warzenburgstrasse 14h
@@ -1001,7 +1001,7 @@ Ammann, Marie L., Ladentochter, Gerechtigkeitsgasse 77
 – Marianne (Zulauf), Wwe., Pavilloenweg la
 – Milly, Bankangestellte, Monbijoustr. 21
 – Olga Gertr., Ladentochter, Wylerstrasse 79
-– Rud.. Handlanger, Mattenenge 13
+– Rud., Handlanger, Mattenenge 13
 – Walter, Chauffeur, Scheibenstrasse 32
 – Walter F., Lehrer, Freiburgstrasse 63
 Ammon, Adele, Krankenpflegerin, Gewerbestrasse 12
@@ -1015,7 +1015,7 @@ Ammon, Adele, Krankenpflegerin, Gewerbestrasse 12
 – Joh., Vertreter, Belpstrasse 39 [36.988]
 – Johanna, Bureaulistin, Fischerweg 17
 – Walter, Schreiner, Federweg 29c
-– Wilh.. Bureauangestellter, Rathausgasse 4
+– Wilh., Bureauangestellter, Rathausgasse 4
 Amon, Rieh., Musikdirektor, Marktgasse 44
 – Fuhrmann, Frau, Tanzinstitut, Marktg. 44
 Amonn, Alfred, Professor a. d. Universität, Bitziusstrasse 53 [23.198]
@@ -1047,7 +1047,7 @@ Amstutz, Alb. Joh., Schreiner, Murtenstr. 5
 – Emma (Meister), Kramgasse 28
 # Date: 1935-12-15 Page: 26020315/12
 Amstutz, Frieda (Kunz), Wwe., Redakteurinam «Bund», Junkerngasse 43 [24.935]
-– Friedr.. Hilfsarbeiter, Brunngasse 50
+– Friedr., Hilfsarbeiter, Brunngasse 50
 – Fritz, Hilfsarbeiter, Viktoriastrasse 59
 – Fritz Eugen, Handlanger, Quartierhof 14
 – Gottfried, Schmied, Stöckackerstrasse 77, Bümpliz
@@ -1075,7 +1075,7 @@ Amt. eidg., für Arbeitslosenfürsorge, Bundesgasse 8 [61]
 Amthaus, Ferdinand-Hodlerstrasse
 Amtsblattdruckerei, Thunstrasse 8 und 8a [21.810]
 Amtsbürgschaftsgenossenschaft für den Kanton Bern, Spitalgasse 35 [23.899]
-Amtsersparniskasse, bern.. Amthausgasse 14 [22.360]
+Amtsersparniskasse, bern., Amthausgasse 14 [22.360]
 Amtsgericht (Amthaus), Ferdinand-Hodlerstr.
 Amtsgerichtsschreiberei (Amthaus), Ferdinand-Hodlerstrasse
 Amtsschaffnerei, Münsterplatz 12 [27.211]
@@ -1120,7 +1120,7 @@ Anderfuhren, Anna M. (Milt), Wwe., Gantrischstrasse 21
 – Werner, Vertreter, Viktoriastrasse 91
 Anderhub, Gertrud, Damenschneiderin, Murtenstrasse 155g
 – Lina (Müller), Wwe., Hilfsarbeiterin, Brunngasse 8
-– Rob.. Maschinenschlosser, Murtenstr. 155g
+– Rob., Maschinenschlosser, Murtenstr. 155g
 Anders, O., Goiffeurgeschäft, Gerechtigkeitsgasse 6
 Andersen, H. Chr., gew. Chefmonteur, Fabrikstrasse 31
 Anderwert, Rosa M., Bureaulistin, Blumenbergstrasse 51
@@ -1145,7 +1145,7 @@ Andre, Gab. (Waser), Hotel de la Poste, Neuengasse 43 [22.864], Cafe: [22.478]
 – Ida, Schiösslistrasse 51
 – Leon, Kaufmann. Neuengasse 43
 – Martha Maria, Neuengasse 43
-– Rud.. Bodenleger, Belpstrasse 47
+– Rud., Bodenleger, Belpstrasse 47
 – Wilh., Maler, Ladenwandstrasse 47
 Andres, Auguste, Frl., Laupenstrasse 57
 – Werner (Holzer), Sekretär, Sulgenauw. 25 [27.459]
@@ -1196,7 +1196,7 @@ Neuheiten, Effingerstrasse 97 [20.086]
 Angst, Ad., Polstermöbel-Werkstätte (Balmweg 11), Wagnerstrasse 10 [31.308]
 – Ed., Lokomotivführer, Erlachstrasse 20
 – Eug. Arth., Garagechef, Tscharnerstr. 19 [32.435]
-– Joh. Heinr.. Beamter S. B. B., Berchtoldstrasse 5
+– Joh. Heinr., Beamter S. B. B., Berchtoldstrasse 5
 – K. Alfr., Typograph. Hopfenrain 23
 – Martha, Ladentochter, Waisenhausplatz 27
 – Robert, Autolackschutz- und Poliermittel
@@ -1214,7 +1214,7 @@ Amt für Wasserwirtschaft, Eschenweg 13 [32.862]
 – H. (Steiner), Techniker d. eidg. Amtes für
 Wasserwirtschaft. Freiestrasse 47
 – & Cie., F., Getreide- und Fouragehandel, Spitalgasse 30 [21.937]
-Anklin, Leo, Postbeamter. Weissensteinstr. 47 [20.063]
+Anklin, Leo, Postbeamter, Weissensteinstr. 47 [20.063]
 Ankly, Marie, Damenschneiderin, Dorngasse 2 [27.047]
 Anliker, Adolf, Buchbindermeister (Neufeldstrasse 17), Helvetiastrasse 19 [32.613]
 – Alb., Abwart der Kantonalbank, Heinrich-Wildstrasse 7
@@ -1240,7 +1240,7 @@ Antiker, Karl, Hilfsarbeiter, Freiburgstr. 70
 Samuel, Maschinist, Seidenweg 60
 – Werner Emil. Buchhalter, Standstrasse 7
 – Werner, Maurer, Neubrückstrasse 51
-Annaheim, Erw. H., Bankangest.. Jennerw. 7
+Annaheim, Erw. H., Bankangest., Jennerw. 7
 Anneler, Peter, & Sollberger, E., Schweinezüchter, Murtenstr. 332, Bümpliz [46.022]
 Annen, Karl, Bankabwart, Gurtengasse 5
 – Lina Gertrud, Bankangestellte, Gurteng. 5
@@ -1248,7 +1248,7 @@ Annoncen- u. Verlags-Genossenschaft, Marktgasse 37
 Anrig, Hans Alb., Küfer, IJlmenweg 4
 – Max, Chauffeur, Wylerfeldstrasse 41 [20.667]
 Anschel, Alex., Metzgermeister, Maulbeerstr. 5 [27.670]
-Anselmi-Moser, Rosetta, Wwe.. Marzilistr. 15
+Anselmi-Moser, Rosetta, Wwe., Marzilistr. 15
 Anselmier, Klara, Privatiere, Steinerstr. 17
 – O. J., Beamter der eidg. Finanzkontrolle, Untere Dufourstrasse 22 [34.813]
 Ansichtskartenverlag A.-G., Bern, Spitalgasse
@@ -1258,7 +1258,7 @@ Antenen, Elise. Privatiere, Thunstrasse 43
 – Fritz, Beamter, Breitenrainstrasse 69
 – Friedr., Uhrmacher, Gerbergasse 31
 – Marie Fr., Ladentochter, Schauplatzg. 39
-– Otto, Bankbeamter. Tillierstrasse 48
+– Otto, Bankbeamter, Tillierstrasse 48
 – Rud., Bankangestellter, Berchtoldstr. 46
 Antener, Alb. Rud., Marmorist, Gesellschaftsstrasse 4
 – Elise, Bureaulistin, Speichergasse 29
@@ -1274,7 +1274,7 @@ Vito, eidg. Beamter, Fischerweg 20
 Antoine, Jean Alex., Uhrmacher, Spitalackerstrasse 49
 – Pauline (Thomet), Viktoriastrasse 53
 – Th., Coiffeurgeschäft, Spitalackerstr. 49 [32.179]
-Antonini, Luigi, Fabrikarbeiter. Brunng. 36
+Antonini, Luigi, Fabrikarbeiter, Brunng. 36
 Anwander, Lothar, Automechaniker, Elisabethenstrasse 27
 Anzeigerbureau, Ryffligässchen 5 [27.351]
 Anzeiger für die Landgemeinden des Amtes Bern, Bücbler & Co., Marienstr. 8 [27.733], Filiale: Gerechtigkeitsgasse 76 [29.849]
@@ -1286,7 +1286,8 @@ Appel, Georg. Bahnarbeiter, Waldheimstr. 23
 Appenzeller, Agnes. Sek.-Lehrerin. Mezenerweg 8
 – Elisabeth M., Klavierlehrerin, Mezenerw. 8
 Appoloni, Elise, Lehrerin der Breitenrainschule, Elisabethenstrasse 4
-– Gottl., Schneider, Seidenweg 38v. Arb - Felber, Mina, Wwe., Privat-Pension, Schwarztorstrasse 23b
+– Gottl., Schneider, Seidenweg 38
+v. Arb - Felber, Mina, Wwe., Privat-Pension, Schwarztorstrasse 23b
 Arbeiter-Sekretariat, stadtbernisches, Volkshaus, Zeughausgasse 9 [23.046]
 Arbeiter-Touring-Bund der Schweiz «Solidarität», Monbijoustrasse 61 [27.279]
 Arbeitgeber-Verband f. d. Schneidergewerbe, Schweiz., Beaumontweg 8 [31.765]
@@ -1363,7 +1364,7 @@ Arn, s. auch Arm
 – Erw. Joh., Bankbeamter, Elisabethenstr. 43 [31.383]
 – Flora A., Bureaulistin, Mühlemattstr. 35
 – Friedr., Spenglermeister, Chutzenstr. 21
-– Friedr.. Spenglermstr., Blockw. 5 [35.393]
+– Friedr., Spenglermstr., Blockw. 5 [35.393]
 – Friedr., pens. Telephonarbeiter, Hochfeldstrasse 51 [35.455]
 – Friedr. Wilh., Sekretär beim eidg. Veterinäramt, Erlachstrasse 12 [25.637]
 – Fritz, Maler. Neubrückstrasse 51
@@ -1392,7 +1393,7 @@ Arni, s. auch Aerni und Erni
 – Lina Gertr., Weissnäherin, Freiburgstr. 18
 – Marg. El., Bankangest., Beundenfeldstr. 14
 – Maria, Pensionshalterin, Reichenbachstr.39
-– Paul Alex., kant Beamter. Beaulieustr. 43
+– Paul Alex., kant Beamter, Beaulieustr. 43
 – Paul J. J., Dr., Fürspr., Miislinweg 30
 – Robert, eidg. Beamter, Wildhainweg 12
 Arnold, Cam. (Guala), Bankkassier, Sennweg 10 [26.074]
@@ -1407,7 +1408,7 @@ Arnold, Cam. (Guala), Bankkassier, Sennweg 10 [26.074]
 Arnold, Lina Marie (Sutter), Wwe., Pension, Scheibenstrasse 18
 – Marie Rosine, Directrice, Seilerstrasse 22 [28.593]
 – Martha. Bureaulistin, Theaterplatz 7
-– Paul Jos.. Mechaniker. Schulweg 15
+– Paul Jos., Mechaniker. Schulweg 15
 – Rosa (Jutzi), Wwe., Postgasse 6
 – Rosa (Jakob), Musikinstrumentenhandlg., Schulweg 15
 – Walter, Polizist, Hopfenweg 31
@@ -1418,13 +1419,14 @@ Arpagaus-Gammenthaler, Lina, Wwe., Amselweg 21
 Arrighi, Ottilio, Maler, Effingerstrasse 51
 Artaria, Giov. G. E., Zollbeamter, Weingartstrasse 47
 Artmann, Marie, Spezereihdlg., Weiherg. 17
-– Otto, Mechaniker. Standstrasse 54v. Arx, Agathe, Lehrerin, Wildermettweg 53
+– Otto, Mechaniker. Standstrasse 54
+v. Arx, Agathe, Lehrerin, Wildermettweg 53
 – Anna (Dubs), Wwe., Rest. Amerikanerstübli, Speichergasse 15 [23.729]
 – Arnold, Maler, Gesellschaftsstrasse 10a
 – Arnold. Bildhauer, Grabsteingesch., Ostermundigenstrasse 57/59
 – Eduard, Niggelerstrasse 6
 – F. Ludwig, Bankangestellter, Pestalozzistrasse 32
-– Friedr.. Schlosser S. S. B., Bridelstr. 56
+– Friedr., Schlosser S. S. B., Bridelstr. 56
 – Heinr., Hilfsarbeiter, Wiesenstrasse 68
 – Ida, Weberstrasse 25
 – Joh. Rob., Feinmechaniker, Eigerweg 5
@@ -1447,7 +1449,7 @@ Arzner, Emil, Schreiner, Amthausgasse 12
 – Martha, Modisti.i. Amthausgasse 12
 Asarny, Iris, Bureaulistin, Wyttenbachstr. 17
 Ascheneller, Joh., Mützenmacher, Lenzweg 10
-Asderys, Georges, Angestellter. Hallerstr. 60
+Asderys, Georges, Angestellter, Hallerstr. 60
 Asher, Elise Doris L., Effingerstrasse 101
 – Leon, Dr. med., Prof., Effingerstrasse 101 [22.820]
 Asmus, Herbert, Chemigraph, Rosenweg 7
@@ -1465,7 +1467,7 @@ Asyl für entlassene Sträflinge in Köniz, Leitung: der Kommissär der Heilsarm
 – für obdachlose Frauen, Heimgarten. Muristrasse 29 [31.45]
 Athanasiou, Constantin, in Fa. Beck & Athanasiou, Bollwerk 35
 – Emma (Knersch), Wwe., Effingerstrasse 4
-– J.. & Cie.. A.-G., Fabrik oriental. Zigarett., Habsburgstrasse 19, Bureau: Seminarstr.24 [23.161]
+– J., & Cie., A.-G., Fabrik oriental. Zigarett., Habsburgstrasse 19, Bureau: Seminarstr.24 [23.161]
 – Max Franz Leop., Vertreter, Effingerstr. 4 [24.228]
 Attiger, Alice Lina, Photographin, Weissensteinstrasse 26
 – Gertrud, Modistin, Weissenstemstrasse 26
@@ -1495,7 +1497,7 @@ Audria, Ernst M., Radiotelegraphist, Greyerzstrasse 29
 – Jos. Marc., Postangestellter, Greyerzstr. 29
 Auer, Hans Jürgen, Dr. jur., Junkerng. 15
 – Karoline, Nischenweg 11
-– Kath.. Damensohneiderin, Marktgasse 42
+– Kath., Damensohneiderin, Marktgasse 42
 Aufdermaur, Franz, Insp. b. d. Generaldirektion P. T. T., Sulgenauweg 8 [31.621]
 – Franz, Kaufmann, Sulgenauweg 8
 Aufenast. Ernst Rud., Gärtnermeister, Fricktreppe 5 [34.921]
@@ -1520,7 +1522,7 @@ Augsburger, s. auch Augstburger
 – Jeanne Blanche, Schneiderin, Spitalackerstrasse 51
 – Marg. Hel., Klavierlehrerin, Spitalackerstrasse 51
 – Marie, Hilfsarbeiterin, Brunngasse 24
-– Marie L.. Ladentochter, Zährmgerstr. 73
+– Marie L., Ladentochter, Zährmgerstr. 73
 – Theodor Frid., Hilfsarbeiter, Badgasse 37
 – Walter, Kübler, Eggimannstrasse 23
 – Werner, Redaktor, Viktoriastrasse 63
@@ -1532,7 +1534,7 @@ Augstburger, Alfred, Magaziner, Muesmattstrasse 36
 – Friedr. Ed., Kolporteur, Lorrainestr. 19
 – Friedr. Rud., Kommis, Holzikofenweg 31
 – O. A., Pferdewärter C. R. D., Wylerringstrasse 9
-– Rud.. gew. Beamter b. eidg. stat. Bureau, Lorrainestrasse 21
+– Rud., gew. Beamter b. eidg. stat. Bureau, Lorrainestrasse 21
 – Werner. Kaufm., Murifeldweg 27 [29.013]
 Augustin, Ida, Beamtin, Burgernzielweg 18a [26.293]
 – Paul, Buchbinder, Grüner Weg 3
@@ -1541,10 +1543,10 @@ Aus der Au, Elisabeth (Mötteli), Wwe., JubiläumssD-asse 9 [22.663]
 – Otto. Dr., Generalag. d. «Helvetia». Schweiz.
 Feuer- u. Transportversicherungs-Gesellschaft in St. Gallen (Jubiläumsstrasse 9 [23.731]), Laupenstrasse 3 [23.410]
 Auskunftei Hermes, Schauplatzgasse 23 [20.785]
-Auskunftei Wimpf 27.057v. Werdt-Passage 5 (ab 1. Mai 1936: Effingerstr. 4a)
+Auskunftei Wimpf 📞 27.057 v. Werdt-Passage 5 (ab 1. Mai 1936: Effingerstr. 4a)
 Auslandschweizer - Sekretariat der N. H. G., Bundesgasse 40 [22.079]
 Ausrüstungssektion (kriegstechn. Abteilung), Papiermühlestrasse 21c [24.605]
-Auswanderungsamt, eidg.. Bundesh. Nord 3 (Nationalhankgebäude Ostflügel) [61]
+Auswanderungsamt, eidg., Bundesh. Nord 3 (Nationalhankgebäude Ostflügel) [61]
 Auto-Garagen A.-G., Auto-Garage und -Handel, Seilerstrasse 1 [28.444]
 Auto-Gewerbeverband der Schweiz, Zentralsekretariat und Sekretariat der Sektion Bern, Neuengasse 24 [21.747]
 Automaten-Gesellschaft, Schweiz., A.-G., Laupenstrasse 8 [22.474]
@@ -1581,8 +1583,8 @@ Ausserkantonale, Breitfeldstr. 29e [26.158]
 Bach, Friedr. Jul., kaufm. Angest., Forsthausweg 7
 – Karl Friedr., Pflasterer, Freieckweg 9, Bümpliz
 – Theresia, Empfangsfräulein, Monbijoustrasse 28
-Bacharach, Eugen, Dr. med. dent.. Zahnarzt (Rainmattstr.il [34.253]), Schwaneng. 3 [35.318]
-– Louis, Dr. med.. Arzt. Riedweg 1 [24.494]
+Bacharach, Eugen, Dr. med. dent., Zahnarzt (Rainmattstr.il [34.253]), Schwaneng. 3 [35.318]
+– Louis, Dr. med., Arzt. Riedweg 1 [24.494]
 Bachem, Anna, Hilfsarbeiterin, Wabernstr. 36i— Karl, Hilfsarbeiter, Rütlistrasse 15
 – Paul, Hilfsarbeiter, Wabernstrasse 36
 Bacher, Alfred, Schneider, Stöckackerstr. 99a, Bümpliz
@@ -1594,7 +1596,7 @@ Bächler, Anna Louise, Schirmgeschäft, Herzogstrasse 22
 – Hans, Direktor der Schweiz. Volksbank, Kalcheggweg 9 [34.837]
 – Joh. Alb., Magaziner, Wylerringstr. 52c
 – Joh. Cäsar (Eggen), Charcuterie vaudoise (Bernastr. 69), Spitalgasse 4, Karl-Schenkhaus [21.567]
-– Joh.. Reisender, Aarbergergasse 47
+– Joh., Reisender, Aarbergergasse 47
 – Jos. Ludw., Lehrer, Bierhübeliweg 35
 – Karl Rudolf, Telephonmonteur, Wiesenstrasse 78
 – Lucie M., Damenschneiderin, Murtenstr. 7
@@ -1607,7 +1609,8 @@ Bachmann, Adolf, Maurer, Weidmattweg 18, Bümpliz
 – Adolf, Mech. S. B. B., Bierhübeliweg 33
 – Agnes, Ladentochter, Bühlstrasse 51
 – Albert, Dreher, Turnweg 28
-– Alb., Telpphonarbeiter. Muesmattstr. 51i—Alb., Polizeikorporal, Elisabethenstr. 24ai—Albrecht, Handlanger, Marzilistrasse 24a
+— Alb., Telpphonarbeiter, Muesmattstr. 51i
+— Alb., Polizeikorporal, Elisabethenstr. 24ai—Albrecht, Handlanger, Marzilistrasse 24a
 Bachmann, Alfred, Giesser, Schreinerweg 9
 – Alfred, Schlosser, Brunnmattstrasse 39
 – Anna Maria. Schneiderin, Jurastr. 38
@@ -1626,7 +1629,7 @@ Bachmann, Alfred, Giesser, Schreinerweg 9
 – Emma, Bureaulistin, Schreinerweg 13
 – Ernst Alb, kaufm Angest., Elisabethenstrassß 24-ci
 – Ernst, Chauffeur, Schauplatzg. 9 [26.003]
-– Ernst Gottl. Hilfsarbeiter. Gewerbestr. 18
+– Ernst Gottl. Hilfsarbeiter, Gewerbestr. 18
 – Ernst, Güterarbeiter, Zähringerstrasse 46
 – Ernst, Milch-, Butter- u. Käsehdlg., Marziiistrasse 8 [35.679]
 – Ernst. Möbelschreiner, Sandrainstrasse 35
@@ -1636,22 +1639,22 @@ Bachmann, Alfred, Giesser, Schreinerweg 9
 – Eugen, Coiffeur, Rodtmattstrasse 52
 – Frieda Hedwig, Bahnhofplatz 4
 – Friedr., Landarbeiter, Riedbachstrasse 350, Riedbach
-– Fr.. Bauarbeiter Bernstr. 68. Bümpliz
+– Fr., Bauarbeiter Bernstr. 68. Bümpliz
 – Friedr., jun., Hilfsarbeiter, Felsenaustr. 18
-– Friedr., Fabrikarbeiter. Felsenaustrasse 18
+– Friedr., Fabrikarbeiter, Felsenaustrasse 18
 – Friedr. Joh., Hilfsarbeiter, Murtenstr. 133
 – Friedr., Schreiner, Dalmazirain 34
 – Fritz, Kraftwagenführer S. O. B., Brückenstrasse 15
 – Fritz, kaufm. Angest., Zähringerstr. 46
 – Fritz Gottfr., Kraftwagenführer S. O. B., Balderstrasse 21 [34.872]
 – Georges K. H., Buchhaltungs- und Revisionsbureau, Breitenrainstr. 47 [25.875]
-– Gottfr., Bäckermeister. Schreinerweg 13 [24.589]
+– Gottfr., Bäckermeister, Schreinerweg 13 [24.589]
 – Gottfr., pens. Beamter S. B. B., Neufeldstrasse 23a [34.861]
 – Gottfr., Elektromonteur, Altenbergstr. 82
 – Gottfr., Elektrotechniker, Simplonweg 13
 – Gottfr., Gärtner, Militärstrasäe 42
 – Gottfr. (Horisberger), Privatier, Militärstrasse 42 [20.577]
-– Gottl.. Gasarbeiter. Murifeldweg 60
+– Gottl., Gasarbeiter, Murifeldweg 60
 – Gottl. (Burri), eidgen. Angestellter, Jurastrasse 63
 – Gottlieb, Droschkenhalter, Autotransporte, Zaunweg 23 [33.075]
 – Gottl., Magaziner, Ulmenweg 9
@@ -1672,10 +1675,10 @@ Bachmann, Hans Paul, Kaufmann, Beundenfeldstrasse 10 [28.099]
 – Ida Martha, Einlegerin, Sulgeneckstr. 66
 – J. A., Sattler. Wylerringstr. 43
 – Joh. Gottfr., Hilfsarbeiter, Weidmattweg 7, Bümpliz
-– Joh., Weichenwärter d. S. B. B.. Lorrainestrasse 54
+– Joh., Weichenwärter d. S. B. B., Lorrainestrasse 54
 – Joh., Pferdewärter, Standstrasse 17
 – Joh. Rud., Phot., Fröschmattw. 10, Bümpliz
-– Jos., Güterarbeiter S. B. B.. Effingerstr. 81
+– Jos., Güterarbeiter S. B. B., Effingerstr. 81
 – Jos. Otto, Zuschneider, Humboldtstr. 19
 – Josue, Spengler, Breitenrainstrasse 87
 – Julie. Damenschneid., Elisahethenstr. 24a
@@ -1701,7 +1704,7 @@ Bachmann, Hans Paul, Kaufmann, Beundenfeldstrasse 10 [28.099]
 – Maria, Verkäuferin, Karl-Schenkstr. 11
 – Marie (Waser), Wwe., Milchprodukte (Kesslergasse 10), Waffenweg 20
 – Marie (Käppeli), Wwe., Zaunweg 23
-– Martha,, Ladentochter, Wylerringstr. 43
+– Martha., Ladentochter, Wylerringstr. 43
 – Melanie, Krankenschwester, Eigerplatz 8
 – Oskar (Iselin), gew. Revisor der Handelsstatistik. Klaraweg 10 [35.852]
 – Paul Fritz D. (Reber), Mechaniker, Muesmattstrasse 47
@@ -1723,7 +1726,7 @@ Bachofner, Adolf, Handlanger, Bethlehemstrasse 118, Bümpliz
 – Bertha, Verkäuferin, Blockweg 8
 – Christ., Hilfsarb., Bernstr.il, Bümpliz
 – Elisabeth (Studer), Frau, Kolonialwarenhandlung, Neufeldstrasse 27 [29.109]
-– Ernst, Milch-, ButteT- u. Käsehdlg.. Brünnenstrasse 113, Bümpliz [46.174]
+– Ernst, Milch-, ButteT- u. Käsehdlg., Brünnenstrasse 113, Bümpliz [46.174]
 – Ernst, Polierer, Metzgergasse 26
 – Gottfr., eidg. Angestellter, Bernstrasse 1, Bümpliz
 – Gottfr., Sägenfeiler, Neuhäuserweg 8
@@ -1865,21 +1868,21 @@ Bähler, GottL, Briefträger, Murifeldweg 27
 – Otto. Gärtner. BoIIigenstrasse 117
 – Rene, Buchhändler, Effingerstrasse 58
 – Rudolf, in Fa. Maier & Bähler in Köniz, Schärerstrasse 3
-– Siemund Walter. Mechaniker. Luisenstr. 7
+– Siemund Walter, Mechaniker. Luisenstr. 7
 – Walter, Beamter B. L. S., Hauensteinw. 16
 – Wilh Rnd, in Fa. Bähler & Cie., Effinsrerstrasse 58 [33.773]
 – Willy Lud., Kaufmann, Effingerstrasse 58
-– & Cie.. Eisen- und Gusswarenhandlung, Effingerstrasse 14 [23.838]
+– & Cie., Eisen- und Gusswarenhandlung, Effingerstrasse 14 [23.838]
 Bahnhof, Hotel. Neuengasse 25 [27 541]
 – Restaurant Personenbahnhof [23.421]
 – Inspektion, Personenbahnhof [66.567]
 Bähni u Bäni
 – Albert. Fostangestellter, Flurstrasse 34
 – Charles Aug., Handlanger, Schönauweg 4
-– Chr.. gew Galvaniseur. Kirchbergerstr. 10
+– Chr., gew Galvaniseur. Kirchbergerstr. 10
 – Herm. Friedr., Schneider, Bümplizstr. 109
 – Jakob, Magaziner, Kasernenstrasse 41
-– Karl Rud.. Handlanger, Standstrasse 68
+– Karl Rud., Handlanger, Standstrasse 68
 – M., Frau, Kunststopferei Moderna (Effingerstrasse 69), Waisenhauspl. 16 [31.309]
 – Theophil. Heizer, Speichergasse 14
 Bahningenieur I, Dienstgebäude, Personenbahnhof [23.041]
@@ -1913,24 +1916,24 @@ Baidinger, Alb., Kaufmann, Hopfenweg 54 [22.399]
 – Karolina (Kappeier), Wwe., Hopfenweg 54
 Baldini, Corrado, Violinist, Wyttenbachstr. 35 [29.911]
 – Giov., Schneider, Wyttenbachstr. 35 [29.911]
-Balimann. Albr.. Wagner im Zeughaus, Stockerenweg 13
+Balimann. Albr., Wagner im Zeughaus, Stockerenweg 13
 – Fritz. Zentralheizungsmonteur, Stockerenweg 13
-Ball, Edm Friedr.. Magaziner, Kirchgasse 22
+Ball, Edm Friedr., Magaziner, Kirchgasse 22
 – Horst Weiner, Maler. Kirchgasse 22
 – Hugo Georg Maler. Herzogstrasse 16
 Ballaman, Ferd. Charles, Mech., Ahornweg 5
 Ballenegger, Georg Louis, Kürschner, Effingerstrasse 4a
 Balli, s. auch Bälli u. Bally
-– Alexander Hilfsarbeiter. Seftigenstr. 51
+– Alexander Hilfsarbeiter, Seftigenstr. 51
 – Alice M., Bureaulistin, Moserstrasse 52
 – Christ., gew. Bauamtarbeiter, Kirchbergerstrasse 3
 – Elisa, Fabrikarbeiterin, Kirchbergerstr. 3
 – Emma. Bureauangestellte. Kirchbergerstr. 3
 – Ernst, Vertrieb von Manufakturwaren und Konfektion. Lentulusstrasse 21
-– Friedr.. Angestellter. Dalmazirain 36
+– Friedr., Angestellter, Dalmazirain 36
 – F. Rud., Verwalter, Gerechtigkeitsgasse 64
 – Gertrud, Bureaulistin, Schanzenstrasse 23
-– Gottl.. Heizer. Schanzeustrasse 23a
+– Gottl., Heizer. Schanzeustrasse 23a
 – Hermann, Ausläufer. Sonneggring 14
 – Joh., Hutformenfabr., Damen- und Herrenhüte, Papiermühle; Filiale: Neuengasse 41 [23.841]
 – Lina. Bureaulistin. Schanzenstrasse 23
@@ -1959,7 +1962,7 @@ Balsigerv. Ballmoos, Hans, Mechaniker, Flurstrasse 16
 — K. Ferd., Kaminfegermeister, Jungfraustrasse 2 [34.020]
 – Karl (Burri), Einzüger, Holzikofenweg 1
 – Martha. Pension, Gesellschaftsstrassp 14a [28.106]
-– Paul Ferd.. Kaminfeger. Jungfraustr 2
+– Paul Ferd., Kaminfeger. Jungfraustr 2
 — —Rosa (Lüthi), Wwe., Tscharnerstrasse 19
 – Walter Hans, Automechaniker, Bernstr. 8, Bümpliz
 – Walter (Hilf iker), Koch, Gesellschaftsstrasse 14a
@@ -1973,24 +1976,24 @@ Balmelli, Ester, Damenschneiderin, Gotthelfstrasse 18
 Balmer, Adolf, Gipser, Jurastrasse 24
 – Albrecht. Sekretär der Oberpostdirektion, Florastrasse 6
 – Alfred. Küfer, Muesmattstrasse 37
-– Aug.. Handlanger Neuengasse 12
+– Aug., Handlanger Neuengasse 12
 – Christ-, Maurer, Seidenweg 33
 – Bertha, Herrenschneiderin, Maulbeerstr. 17
 – Elisab. Hedwig, Bureaulistin, Jubiläumsstrasse 88
 – Elise (Althaus). Jurastrasse 24
 – Elise (Häubi), Beaumontweg 14
-– Emil, eidg. Beamter. Waldhöheweg 7 [32.626]
+– Emil, eidg. Beamter, Waldhöheweg 7 [32.626]
 – Emma, Bureaulistin. Waldhöheweg 7 [32.626]
 – Emma (Blank), Wwe., Konsumstrasse 12
 – Emma (Köhler). Wwe., Gemüsehandlung, Scheibenstrasse 31 [36.251]
-– Ernst W.. Arch. B. S. A. (Wabern). Kramgasse 81 [24 174]
+– Ernst W., Arch. B. S. A. (Wabern). Kramgasse 81 [24 174]
 – Ernst, Parkettleger, Pestalozzistrasse 15
 – Ernst, Schmied, Wylerringstrasse 52b
 – Ernst Telephonarbeiter, Mattenenge 9
 – Ernst Walter, Gärtnermeister, Scheibenstrasse 16
 – Erwin Moritz, kaufm. Angestellter, Beaumontweg 14
 – Eugen, Sattler, Römerweg 26
-– Friedr.. Notar, Angestellter der Hypothekarkasse. Monbiioustrasse 69 [34 780]
+– Friedr., Notar, Angestellter der Hypothekarkasse. Monbiioustrasse 69 [34 780]
 – Friedr. (Engi), Reisender, Rameggweg 3
 – Friedr. (Blau), Tapezierer, Dekorateur, Kramgasse 16f— Fritz (Stauffer), alt Bahninspektor, Gesellschaftsstrasse 14 [32.298]
 — Fritz, Hilfsarbeiter, Platanenweg 12
@@ -2050,7 +2053,7 @@ Baisiger, Anna Elisabeth, Schäftemacherin, Breitfeldstrasse 44
 – Arnold, Elektriker, Gesellschaftsstrasse 73
 – Arthur Adolf, Schlosser, Rosenweg 9a
 – Bertha (Regez). Modiste, Schöneggweg 14
-– Bertha (Zwahlen), Wwe., in Fa. Baisiger & Co.. Scheuerram 1
+– Bertha (Zwahlen), Wwe., in Fa. Baisiger & Co., Scheuerram 1
 – Christ., Schuhmachermeister, Weissensteinstrasse 20a [36.593]
 – E. Robert, Kommis, Muesmattstrasse 34
 – Elisabeth, Schönheitspflege-Salon Madeleine (Herzogstrasse 26), Bärenplatz 2 [28.876]
@@ -2066,7 +2069,7 @@ Baisiger, Anna Elisabeth, Schäftemacherin, Breitfeldstrasse 44
 – Ernst Emil, Vertreter, Steigerweg 24
 – Fel., Dr. phil., Gymnasiallehrer, Scheuerrain 1 [31.844]
 – Franz Otto, Gipser, Wildermettweg 12
-– Frieda A.. Ladentochter. Kirchbühlweg 22
+– Frieda A., Ladentochter, Kirchbühlweg 22
 – Frieda, Ladentochter, Dietlerstrasse 10
 – Frieda. Verkäuferin, Stauffacherstrasse 39
 – Friedr., Hilfsarbeiter, Haldenweg 16
@@ -2081,19 +2084,19 @@ Baisiger, Anna Elisabeth, Schäftemacherin, Breitfeldstrasse 44
 – Gottfr., Metzger. Morgenstr. 79, Bümpliz
 – Gottfr., pens. Weichenwärter, Stauffacherstrasse 39
 – Gottfr., Zimmermann, Könizstrasse 39a
-– Gottl., Nachtwächter. Könizstrasse 20
+– Gottl., Nachtwächter, Könizstrasse 20
 – Gustav Walter, Ausläufer, Neufeldstr. 36a
 – H. (Glanzmann), Damenfrisiersalon. Neufeldstrasse 36a [21.281]
 – Hans Gottfr., kant. Angest., Stauffacherstrasse 39
 – Hans (Rudolf), Hilfsarbeiter, Hohgantw. 5a
-– Hans. Hilfsarbeiter. Monbijoustrasse 68a
+– Hans. Hilfsarbeiter, Monbijoustrasse 68a
 – Hans, kaufm Angest., Schöneggweg 14
 – Hedw Marg., Verkäuferin, Schützenw. 11
 – Hedwig, Verkäuferin, Stauffacherstr. 39
 – Heidi Rosa, Bureaulistin. Waffenweg 15
 – Ida, Falzerin, Herzogstrasse 26
 – J. F., Photograph, Gerechtigkeitsgasse 10
-– J. G., Einleger .O P. D., Schützenweg 11
+– J. G., Einleger O. P. D., Schützenweg 11
 – Joh., Fabrikarbeiter, Waffenweg 15
 Baisiger, Joh. R., Hilfsarbeiter, Steckweg 17
 – Joh. Gottl., Automechaniker, Brunng. 70
@@ -2115,7 +2118,7 @@ Baisiger, Joh. R., Hilfsarbeiter, Steckweg 17
 – Marie, Pflegerin, Fischerweg 7
 – Martha Magdalena, Fabrikarbeiterin, Bottigenstrasse 33, Bümpliz
 – Mina Hedwig, Damenschneiderin, Elisabethenstrasse 22
-– Otto W.. Autospengler, Stationsweg 34
+– Otto W., Autospengler, Stationsweg 34
 – Rob. Paul, Schreiner, Landoltstrasse 67
 – Rosa, Hilfsarbeiterin, Wylerfeldstrasse 60
 – Rud., Coiffeurgeschäft (Herzogstrasse 26), Metzgergasse 68
@@ -2125,10 +2128,10 @@ Baisiger, Joh. R., Hilfsarbeiter, Steckweg 17
 – Rud., Gerbergasse 34
 – Walter Ernst, Lehrer, Seftigenstrasse 79 [28.466]
 – Walter, Mechaniker, Velogeschäft, Seidenweg 9
-– Werner. Dr. jur.. Beamt, d. Bundesanwaltschaft, Höheweg 38 [33.442]
+– Werner. Dr. jur., Beamt, d. Bundesanwaltschaft, Höheweg 38 [33.442]
 – Werner, Schuhmacher. Weissensteinstr. 20a
 – Wilhelm, Dr., & Schorer, Paul, Dr., Advokaturbüro, Amthausgasse 28 [21.694]
-– Wilh.. Schmied, Bottigenstr. 69, Bümpliz
+– Wilh., Schmied, Bottigenstr. 69, Bümpliz
 – Wilhelm, jun., Hilfsarbeiter, Bottigenstr.69, Bümpliz
 – & Cie., Weinhandlung, Sauerkrautfabrik, Scheuerrain la [21.609]
 Baltensperger, Jakob, eidgen. Vermessungsdirektor, Humboldtstrasse 45 [36.918]
@@ -2165,7 +2168,7 @@ Balzli, A. E. (Mosimann), Tavelweg 8
 – Ernst, Maschinenmeister, Thunstrasse 103
 – Frieda, Fabrikarbeiterin. Sonneggweg 13
 – Frieda, Ladentochter, Tavelweg 8
-– Fritz, kaufm. Angest.. Papiermühlestr. 17c
+– Fritz, kaufm. Angest., Papiermühlestr. 17c
 – Gottfr., Postkommis, Hubelmattstrasse 46
 – Gottl., Fräser W.-F., Flurstrasse 1
 – Helene M., Bureanlistin, Stationsweg 42
@@ -2234,7 +2237,7 @@ Bannwart, Emma Frieda (Järmann), Wwe., Zigarrengeschäft, Länggassstr. 16 [27.
 – Ernst, Feinmechaniker, Lentulusstr. 39
 – Erwin, Radiotechniker, Spitalackerstr 66 [20.581]
 – Gertrud, Spitalackerstrasse 66
-– Hans Gemüsehandlg., Brünnenstrasse 114, . Bümpliz [46.122]
+– Hans Gemüsehandlg., Brünnenstrasse 114, Bümpliz [46.122]
 – Hans, kaufm. Angest., Spitalackerstr. 66
 – Hans, pens. Beamter des städt. Elektrizitätswerkes, Spitalackerstrasse 66
 – K. Fritz E., Bankbeamter, Altenbergstr. 88
@@ -2245,12 +2248,12 @@ Bansen, Rud. Jul., Schneider. Moserstr. 14
 Bantle, Anna Marg., Bureaulistin, Breitfeldstrasse 44
 – Elisabeth Marie, Bureaulistin, Breitfeldstrasse 44
 – Fritz. Packer, Breitfeldstrasse 44
-Bänziger. Heinr.. Polierer. Spezereihandlung.
+Bänziger. Heinr., Polierer. Spezereihandlung.
 Bottigenstrasse 58, Bümpliz [46.114]
 – Johannes. Drogist. Prokurist, Steinauw. 28
 Bär u. Baer
 – Adolf, gew. Fabrikaufseher, Reichenbachstrasse 4
-– Albert Jos.. Bereiter. Moserstrasse 4
+– Albert Jos., Bereiter, Moserstrasse 4
 – Albert Alph., Feinmechaniker, Moserstr. 16
 – Albert, Zügler, Brunngasse 19
 – Alfred Emil, Opernsänger, Breitenrainstrasse 59
@@ -2270,8 +2273,8 @@ Bär u. Baer
 – O. (Fehlmann), Konditor, Murifeldweg 27
 – Otto (Kindler). Cafe du Commerce. Gerechtigkeitsgasse 74 [21.161]
 – Rene B , Kaufmann, Spitalackerstrasse 62
-– Rob. (Grünig), Beamter. Steinauweg 28
-– Walter. Krankenwärter, Fabrikstrasse 31
+– Rob. (Grünig), Beamter, Steinauweg 28
+– Walter, Krankenwärter, Fabrikstrasse 31
 « Bäraq », Bäienplatz 2 [27.432]
 Baranowsky, Vinzenz, kunstgewerbl. Werkstätte (Gerechtigkeitsgasse 64), Schiffl. 46 [34.949]
 Baratelli, Maria Angela, Bureaulistin, Seidenweg 14
@@ -2300,7 +2303,7 @@ Bärfuss, Elisab. (Götschmann), Wwe., Schneiderin K. K K., Konsumstrasse 11
 – Emil, Maschinentechn., Landoltstrasse 61
 – Ernst Rud., Beamter, Breiteweg 28
 – Ernst Rud., Automechaniker, Breiteweg 28
-– Friedr., Billetteur der S. S. B.. Monbijoustrasse 132 [20.869]
+– Friedr., Billetteur der S. S. B., Monbijoustrasse 132 [20.869]
 – Gertrud, Bureaulistin, Monbijoustr. 132
 – Joh., Bäcker, Brunnmattstrasse 48
 – Joh., pens. Bahnarbeiter, Monbijoustr. 132
@@ -2338,23 +2341,23 @@ Barras, August. Schriftsetzer. Ahornweg 7
 – Charles, Kondukteur der S. B. B., Mattenhofstrasse 29
 – Karoline, Frau. Buchbindereiarbeiterin, Ahornweg 7
 Barraud, Julia Martha Tabea, Jägerweg 15
-– Max Alfr., Angestellter. Jägerweg 15
+– Max Alfr., Angestellter, Jägerweg 15
 – Oswald Benjamin. Kaufmann, Jägerweg 15 [34.649]
 Barreiet, Pierre, Gymn.-Lehrer, Karl-Staufferstrasse 28
 Barrer, Marie (Häberli), Wwe., Tannenw. 12a
 – Theodor Walter, Mechaniker, Brunnmattstrasse 75
-– Th., pens. Postangest.. Brunnmattstr 75de Barros, Francesco Xavier, Ing., Wylerstrasse 47
+– Th., pens. Postangest., Brunnmattstr 75de Barros, Francesco Xavier, Ing., Wylerstrasse 47
 BarrOt, Anita Mercedes, Sekretärin, Spitalackerstrasse 7 [20.038]
 – Berta, Spitalackerstrasse 7 [20.038]
 – Jose, kaufm. Angest., Spitalackerstrasse 7
-– Th. (Oliveras). Wwe.. Predigergasse 2 [31.361]
+– Th. (Oliveras). Wwe., Predigergasse 2 [31.361]
 Bartel, Paul Willy, Koch, Schläflirain 7
 Bartenbach, Eug. Ed., Schäfer, Spitalackerstrasse 16
 Barth, A., pens Planton, Polygonweg 9
 – Alfred, Schneidermeister, Mittelstrasse 19
 – Arnold, Maler, Grabenpromenade 5
 – Elise (Küng). Wwe., Wachtelweg 17
-– Emil, pens. Tramangestellter. Schwarztorstrasse 80
+– Emil, pens. Tramangestellter, Schwarztorstrasse 80
 – Emma. Arbeitslehrerin, Wachtelweg 17
 – Ernst, Maschinensetzer, Landoltstrasse 79
 – Ernst, Postverwalter, Kursaalstrasse 9
@@ -2363,14 +2366,14 @@ Barth, A., pens Planton, Polygonweg 9
 – F. Ernst, Schlosser, Murtenstrasse 16
 – Fr. Otto, Sattler, Seftigenstrasse 47
 – Fritz, Maschinenmeister, Allmendstr. 40
-– Gottl., pens. Pferdewärter. Zielweg 23
+– Gottl., pens. Pferdewärter, Zielweg 23
 – Hanna Marie, Pamenschneiderin, Zaunweg 16
 – Hans Franz, Autotransporte, Beaumontw. 1 [27.807]
 – Hans, Schreinermstr. (Zaunw. 16 [32.486]), Turnweg 24a
 – Hans, Chauffeur, Weissensteinstrasse 20
 – Hans Willy, Goldschmied, Moserstrasse 10
 – Hedwig, Ladentochter, Zielweg 23
-– Herm.. Maler, Freiburgstr 190, Bümpliz
+– Herm., Maler, Freiburgstr 190, Bümpliz
 – Karl, Hilfsbereiter, Elisabethenstrasse 32
 – Kath., Modiste, Seidenweg 24
 – Mathilde, Dr. med. dent., Zahnärztin, Schanzenstrasse 4 [22.501]
@@ -2427,30 +2430,30 @@ Bärtschi, s. auch Bertschi
 – Fritz, Bahnbeamter, Hochfeldstrasse 73
 # Date: 1935-12-15 Page: 26020330/27
 Bärtschi, siehe auch Bertschi
-– - Friedr.. Handlanger, Brunngasse 14
+– - Friedr., Handlanger, Brunngasse 14
 – Friedr., Schreiner, Murifeldweg 34
 – Fritz, Hilfsarbeiter, Lenzweg 7
 – Fritz, Kassenschlosser, Stöckackerstr. 70, Bümpliz
 – Gottfr., Schneidermeister, Bottigenstr. 55, Bümpliz
 – Gottfr., Schuhmachermeister, Münsterpl. 4
-– H. (Hügli), Wwe.. Bahnstrasse 03
+– H. (Hügli), Wwe., Bahnstrasse 03
 – Hanny Alice, Bahnstrasse 63
-– Hans. Führer S. B. B.. Simplonweg 17
+– Hans. Führer S. B. B., Simplonweg 17
 – Hans Friedrich, Tel.-Monteur, Hochfeldstrasse 98
 – Hedwig, Telephonistin, Hochfeldstr. 73
 – Hedwig (Rhyn), Wwe., Bethlehemstr. 19, Bümpliz
-– Herm. Jos. Friedr,, Postbeamter, Beundenfeldstrasse 48
+– Herm. Jos. Friedr., Postbeamter, Beundenfeldstrasse 48
 – Hermann, Elektriker, Bottigenstrasse 55, – Hermine u. Tschaggelar-Bärtschi, Roseli, Fusspflegesalon, Spitalgasse 27 [36.331]
-– Jak.. Handlanger. Freiburgstr. 474, Bümpliz
-– J. Fr.. Schreiner, Rütlistrasse 10
+– Jak., Handlanger. Freiburgstr. 474, Bümpliz
+– J. Fr., Schreiner, Rütlistrasse 10
 – Joh., Schreiner, Federweg 57
-– Joh. Friedr.. Hilfsarbeiter, Altenbergstr. 88
+– Joh. Friedr., Hilfsarbeiter, Altenbergstr. 88
 – Joh. (Wyss), Postbeamter, Hallerstr 62 [23.272]
 – Joh. Friedr, Schreiner, Effingerstr. 99
 – Joh. Friedr., Mechaniker, Weingartstr. 53
 – Karl, Bahnarbeiter, Raineggweg 7
 – Karl Ernst (Ducart), Wirt zum Rössli, Brunnmattstrasse 21 [22 251]
-– Lina, Frl.. Altenbergstrasse 132 [32.466]
+– Lina, Frl., Altenbergstrasse 132 [32.466]
 – Margrit. Einlegerin, Bottigenstr. 55, Bümpliz
 – Marie, Bureaulistin, Schifflaube 20
 – Maria, Damenschneiderin, Turnweg 28
@@ -2466,7 +2469,7 @@ Bärtschi, siehe auch Bertschi
 – Walter Adolf, Vertreter, Freiburgstr. 51
 – Walter, Kaufmann. Schwarztorstrasse 101
 – Walter, Lokomotivführer d. S. B. B., Hochfeldstrasse 73
-– Werner, Dr. med.. prakt. Arzt und Spezialarzt für Kinderkrankheiten. Pestalozzi-Strasse 26 [36.930]
+– Werner, Dr. med., prakt. Arzt und Spezialarzt für Kinderkrankheiten. Pestalozzi-Strasse 26 [36.930]
 – Werner P., Dr. phil., Arzt, Bolligenstr. 117
 – Willy, Molkereiangestellter, Rohrweg 6
 Bärtschiger, Anna, Bureaulistin, Beaulieustrasse 17
@@ -2627,7 +2630,7 @@ Baugenossenschaft Rodtmattstrasse - Militärstrasse, Neuengasse 28
 – Villette, Monbijoustrasse 61
 – Wankdorffeld, Länggassstrasse 48
 – Weissensteinstrasse, Effingerstrasse 17
-Baugeschäft Muesmatt A.-G.. Eabrikstr. 14 [20.677]
+Baugeschäft Muesmatt A.-G., Eabrikstr. 14 [20.677]
 Baugesellschaft Aarehof, Laupenstrasse 11
 – Beaumont, A.-G., Bubenbergplatz 9
 – Belpa A.-G., Spitalgasse 32
@@ -2636,7 +2639,7 @@ Baugesellschaft Aarehof, Laupenstrasse 11
 – Brückfeld A.-G., Snitalgasse 32
 – Bubenbergplatz A.G., Schwanengasse 7
 – Effingerstrasse A.-G., Schwanengasse 4
-– Eigenes Heim, Bern, Bollwerk 41 [26.166] .
+– Eigenes Heim, Bern, Bollwerk 41 [26.166]
 – Liebefeld, Niggelerstrasse 11
 – Lorraine A.-G., Neuengasse 28
 – Monbijou A.-G., Spitalgasse 32
@@ -2678,7 +2681,7 @@ Baumann, Alfred Ernst, Mechaniker, Pestalozzistrasse 12
 – Arthur, Angestellter, Alpeneckstrasse 5
 – August (Schmid), Landoltstrasse 28
 – Bertha (Mollet), Wwe., Neubrückstr. 80
-– Christ.. Tramangestellter, Länggassstr. 101
+– Christ., Tramangestellter, Länggassstr. 101
 – Christ., Mechaniker, Länggassstrasse 48
 – Christ. (Schneiter), Notar, Amtsschreiber, Morellweg 8 [31.468]
 – E. (Augsburger), Vertreter, Kl. Murist. 3a
@@ -2735,7 +2738,7 @@ Baumann, Fritz, Versicherungsangestellter, Gesellschaftsstrasse 90
 – Hans, Import u Export aller Art, Lebensmittel, Rohmaterialien für Fabrikationszwecke, Metall-Artikel, Blumenbergstr. 16 [27.289]
 – Hans, Maschinenschlosser, Stalden 1
 – Hans (Gerber), Vertreter, Sulgeneckstr. 62
-– Hans, Zugführer S. B. B.. Simplonweg 9
+– Hans, Zugführer S. B. B., Simplonweg 9
 – Hans, Elektrotechniker, Simplonweg 9
 – Herm., Fabrikarbeiter, Hopfenweg 54
 – Herm., Landwirt. Niederbottigenweg 108, Bümpliz
@@ -2803,7 +2806,7 @@ Baumann, Karl, Schlossermeister, Brunnmattstrasse 45 [21.176]
 – Rob., eidg. Beamter, Gotthelfstrasse 14
 – Rob. (Wyss), Notar, im Bureau. Baumann & Leuthold (Böcklinstrasse 19 [33.085]), Marktgasse 32 [28.673]
 – R., & Leuthold, Fritz, Notariats- und Verwaltungsbureau, Marktgasse 32 [28.673]
-– Rosa D.. Bureaulistin. Gesellschaftsstr. 46
+– Rosa D., Bureaulistin. Gesellschaftsstr. 46
 – Rosa, Hilfsarbeiterin, Brunnhof weg 23
 – Rosa (Wenger), Metzgergasse 39
 – R. S., Beamter S. B. B., Brückfeldstr. 8a [36.736]
@@ -2874,7 +2877,7 @@ Baumgartner, Ch. A., Kaufmann, Muristr. 59 [25.303]
 – Christ., Kl. Muristalden 36
 – Elise (Bärtschi), Militärschneiderin, Marktgasse 27
 – Elise, Schneiderin, Muristrasse 6d
-– Emil (Geiser), Beamter d. O. T. D.. Aebistrasse 11 [24.733]
+– Emil (Geiser), Beamter d. O. T. D., Aebistrasse 11 [24.733]
 – Emil (Röthlin), Beamter d. Gaswerk und Wasserversorgung, Schwarztorstrasse 1
 – Emil, pens. Beamter, Berchtoldstrasse 25
 – Emil, Küchenchef, Greyerzstrasse 72
@@ -2921,7 +2924,7 @@ Baumgartner, Ch. A., Kaufmann, Muristr. 59 [25.303]
 Baumgartner, Hilda I., Stenodactylographin, Parkstrasse 3
 – Jakob, Zimmermstr., Muristr. 21 [24.464]
 – Joh. Emil, pens. Beamter d. S. B. B., Finkenrain 15 [27.098]
-– Joh. Friedr.. Holzhauer, Mattenenge 15
+– Joh. Friedr., Holzhauer, Mattenenge 15
 – Joh. (Lengacher), Kä.ssalzer, Dorngasse 10
 – Joh. Gottfr., Messgehilfe beim städt. Tiefbauamt, Hopfenweg 40
 – Joh. Jak., Kupferschmied, Nydeckgasse 2
@@ -2964,7 +2967,7 @@ Baumgartner & Cie., Mattenhofstrasse 42 [23.212]
 – Otto, eidg. Beamter, Viktoriastrasse 33
 – Paul, Konfiserie, Länggassstr. 38 [33.037]
 – Pauline E., Haspelweg 40
-– Robert. Bankangestellter. Optingenstr.il
+– Robert. Bankangestellter, Optingenstr.il
 – Rosa (Sommer), Wwe., Junkerngasse 52
 – Rud., Hilfsarbeiter, Tscharnerstrasse 27
 – R., & Co., Molkereiartikel, Speicherg. 14 [22.641]
@@ -2989,7 +2992,7 @@ Baur, s. auch Bauer
 – A. (Vogel), Wwe., Priv., Falkenhöhew. 19
 – Adrian Alb., Kontrolleur W.-F., Meisenweg 20
 – Alb., Bierdepot Salmenbräu Rheinfelden, Chutzenstrasse 10 [22.085]
-– Alfred. Bahnarbeiter. Waldheimstrasse 23
+– Alfred. Bahnarbeiter, Waldheimstrasse 23
 – Amalie Anna, Fabrikarbeiterin, Jurastr. 6
 – Anna M., Apothekerin, Mittelstrasse 44
 – Anna, Pension, Falkenhöheweg 19
@@ -3009,7 +3012,7 @@ Baur, s. auch Bauer
 – Joh. Jak., Mechaniker, Belpstrasse 51
 – Johanna (Potthoff), Wwe., Blumenbergstrasse 4
 – Jules, Planton, Weissenbühlweg 8
-– Karl Jos.. Bureaulist. Mon.bijoustrasse 11
+– Karl Jos., Bureaulist. Mon.bijoustrasse 11
 – Lucie, Privatiere, Zähringerstrasse 46
 – Ludwig, gew. Architekt, Bubenbergplatz 4
 – Marg. El., Arbeitslehrerin. Erlachstr. 22
@@ -3018,7 +3021,7 @@ Baur, s. auch Bauer
 – -Werner, Karrer, Kesslergasse 28
 Baustoffe, Kommandit - A.-G., Dr. Schauwecker, Blatter & Co., Südbahnhofstr. 13 [22.934]
 # Date: 1935-12-15 Page: 26020336/33
-Bavaud, Alb.. Kommis, Karl-Schenkstrasse 9
+Bavaud, Alb., Kommis, Karl-Schenkstrasse 9
 v. Bavier, Theodora Math., Vorsteherin des Feldeggspitals, Fischerweg 7
 Bay, Hans (Hofmann), Techniker, Neufeldstrasse 128
 – Karl, Handel mit Früchten und Gemüsen, Elisabethenstrasse 26 [22.557]
@@ -3059,7 +3062,7 @@ Beck, Adolf, in Fa. Beck & Athanasiou, Bollwerk 35
 – Emil, Prof. Dr. jur., Kistlerw. 38 [22.933]
 – Emil,. Giesser, Kirchgasse 12
 – Emma, Bureaulistin, Lorrainestrasse 6a
-– Ernst Friedr., städt. Beamter. Landhausweg 3 [34.593]
+– Ernst Friedr., städt. Beamter, Landhausweg 3 [34.593]
 – Ernst, Bankangestellter, Florastrasse 24
 – Ernst, Kaufmann, Junkerng. 23 [34.461]
 – Ernst Friedrich, kaufm. Angest., Kornhausstrasse 12
@@ -3067,7 +3070,7 @@ Beck, Adolf, in Fa. Beck & Athanasiou, Bollwerk 35
 Beck, Ernst, Vertreter, Jurastrasse- 25a
 – Ernst, Walzenführer. Standstrasse 74
 – F. Diethelm (Häring), Musiklehrer, Gerbergasse 7a
-– Friedr.. Abwart, Herrengasse 3
+– Friedr., Abwart, Herrengasse 3
 – Friedr., Dr. jur., Bankbeamter, Humboldtstrasse 33
 – Friedr., Chauffeur, Rütlistrasse 15
 – Friedr., Geschäftsführer der Firma Burger-Kehl & Co., Kornhausstrasse 12 [32.578]
@@ -3110,7 +3113,7 @@ Beck, Ernst, Vertreter, Jurastrasse- 25a
 – Willy Otto, Landwirt, Effingerstrasse 29p
 # Date: 1935-12-15 Page: 26020337/34
 Beck & Athanasiou, Atelier für Dekorationen, Bollwerk 35 [36.442]
-– & Co., A.-G.. Handel mit Südfrüchten und Gemüsen, Gurtengasse 6 [24.121]
+– & Co., A.-G., Handel mit Südfrüchten und Gemüsen, Gurtengasse 6 [24.121]
 van Beck, Joli. Corn., Opernsänger, Waisenhausplatz 16
 Beckel, Alb., Uhrmacher, Humboldtstrasse 9
 Becker, Frz. Herm., Zigarrenhdlg., Viktoriarain 19
@@ -3121,7 +3124,7 @@ Becker, Frz. Herm., Zigarrenhdlg., Viktoriarain 19
 Beckert, Johanna Barbara, Bureaulistin, Schlösslistrasse 43
 – Karl Friedr., Mechaniker, Schlösslistr. 43
 – Lilly Julie, Gryphenhübeliweg 2
-– Willy Alfr.. Kaufmann, Schlösslistrasse 43
+– Willy Alfr., Kaufmann, Schlösslistrasse 43
 Becky, Heinr., Goldschmied, Kasernenstr. Ile
 – Heinr. E., kaufm. Angest., Kasernenstr. Ile
 Bederf, Alex Henri, Kaufmann, Gutenbergstrasse 11
@@ -3140,7 +3143,7 @@ Beer, Alfred, kaufm Angest., Sennweg 12
 – Gertr. Lina. Damenschneiderin, Schreinerweg 9
 – Hans, Dr., Fürspr. (Brückenstr. 1 [34.009]), Laupenstrasse 4 [20.115]
 – Hans Walter, Postangestellter, Gryphenhübeliweg 41
-– Herm. W.. Sattler, Zähringerstrasse 47
+– Herm. W., Sattler, Zähringerstrasse 47
 – Jak., Malermstr., Berchtoldstr. 17 [26.218]
 – Johann, Direktor d. Schweiz. Strassenbaugesellschaft. Brückenstrasse 1 [35.577]
 – Joh. Fr., Steinhauer, Veilchenweg 7, Bümpliz
@@ -3165,7 +3168,7 @@ Beetschen, Eduard (Christeier), Kaufmann, Landoltstrasse 56 j
 – Hans, Coiffeur, Wylerstrasse 41
 – J. Alfr., Bahnangestellter, Greyerzstr. 39
 – Joh., Schreiner, Lagerweg 11
-– Paul Herm.. Mechan.. Militärstrasse 57
+– Paul Herm., Mechan., Militärstrasse 57
 – Rosina, Knabenschneiderin, Hochfeldstr. 26
 – Wilhelm, Polizeigefreiter, Wiesenstr. 48
 Beez, Elise, Heimpflegerin, Humboldtstr. 41
@@ -3174,7 +3177,7 @@ Begert, Ad. (Wiedmer), Kolonialwarenhandlung, Weissensteinstrasse 82
 – Elsa Johanna, Bundesangestellte, Kirchgasse 10
 – Ernst Arn , Bankangestellter, Kyburgstr. 5
 – Ernst, Eierhdlg., Gerechtigkeitsgasse 8
-– Franz. Metzgermeister. Bottigenstrasse 16, Bümpiiz [46.285]
+– Franz. Metzgermeister, Bottigenstrasse 16, Bümpiiz [46.285]
 – Fritz, Chauffeur, Bahnhofstr. 23, Bümpiiz
 – Hans Alb., Packer, Brunnmattstrasse 69
 – Jakob, pens Polizeigefr., Greyerzstr. 19
@@ -3183,7 +3186,7 @@ Begert, Ad. (Wiedmer), Kolonialwarenhandlung, Weissensteinstrasse 82
 – Joh. Fr., Bureaulist, Cäcilienstrasse 37
 – Lea. Wirtschaft zur Nordstation, Bahnhofstrasse 23, Bümpiiz [46.045]
 – Martha, pens. Telegraphengehilfin, Allmendstrasse 36
-– Max, Schlachthofarbeiter. Allmendstr 36 [27.056]
+– Max, Schlachthofarbeiter, Allmendstr 36 [27.056]
 – Rosa Hilda, Bureaulistin, Cäcilienstr. 37
 – Werner, Chauffeur, Weihergasse 8
 – Werner, Landw., Bottigenstr. 16, Bümpiiz
@@ -3206,7 +3209,7 @@ Beier, Karl, Modellschreiner, Bümplizstr. 109
 Beieier siehe Beyeler
 Beigel, Jak., Vertr., Viktoriastr. 43 [28.495]
 Beil, Otto, Metalldrückerei (Standstrasse 29), Grundweg 14 [29.062]
-Bein, Max C.. eidg. Beamter, Seilerstrasse 27
+Bein, Max C., eidg. Beamter, Seilerstrasse 27
 – Roman. Klaviermacher u. Klavierstimmer, Länggassstrasse 55 [29.468]
 # Date: 1935-12-15 Page: 26020338/35
 Beiner, Alb., Postangestellter, Gryphenhübeliweg 24
@@ -3258,7 +3261,7 @@ Bendit, Albert, Hilfsarbeiter, Centralweg 24
 Benedict-Schule, vorm. Institut Labor, Amthausgasse 24 [32.699]
 Bengel, Luise, Frau, Gotthelfstrasse 18
 Benguerel-dit-Jacot, Fern., Bureaulist, Beundenfeldstrasse 7
-Benkert, Ed. Fabrikarbeiter. Seftigenstr. 25
+Benkert, Ed. Fabrikarbeiter, Seftigenstr. 25
 – Paul Willi, Elektriker, Weingartstrasse 57
 – Walter, Hutmacher, Seftigenstrasse 25
 Benett, Arnold C., kaufm. Angest., Kasernenstrasse 29
@@ -3268,7 +3271,7 @@ Benninger, Anna Marg., Bureaulistin u. Klavierlehrerin, Distelweg 9 [22.316]
 – Joh., Handlanger, Ladenwandstrasse 94
 – Max M., Zahntechn. Laboratorium (Beundenfeldstrasse 6 [34.555]), Bubenbergpl. 10 [28.394]
 Benois, Franz, Buchhändlergehilfe, Burgernzielweg 18a
-Benoit, Charles Fred.. Maler, Schöneggweg 12
+Benoit, Charles Fred., Maler, Schöneggweg 12
 – Charles, Schriftsetzer, Schöneggweg 12
 – Edgar Frang. Ls., Typograph, Gutenbergstrasse 19
 – Emil, mechan. Schlosserei, Grabenpromenade 1 [34.349]
@@ -3276,7 +3279,8 @@ Benoit, Charles Fred.. Maler, Schöneggweg 12
 – Herm., Schlosser, Grabenpromenade 1
 – Maurice (Blunier), Chef-Fakteur, Fischerweg 21
 – Rene (Schädler), Postangest., Fischerw. 15
-– Robert Adrien, eidgenössischer Beamter, Hochfeldstrasse 101v. Benoit, Georges Fred. Andre, Laupenstr. 45 [31.196]
+– Robert Adrien, eidgenössischer Beamter, Hochfeldstrasse 101
+v. Benoit, Georges Fred. Andre, Laupenstr. 45 [31.196]
 Benovici, Nehemia, Merceriewaren, Eichmattweg 5
 Benteli, Alb. Ludw. Wilh., Fabrikdirektor, Bümplizstrasse 97 [46.191]
 – Alb. Wilh., Chemiker, Peterweg 5, Bümpliz [46.173]
@@ -3365,7 +3369,7 @@ v. Bergen, Ad. R. (Bertolini), Mechaniker, Effingerstrasse 53
 – Bernh. (Schär), Angestellter, Aebistr. 10
 – Eduard, Bankangestellter, Talweg 1
 – Elis. L. C., Zahnarztgehilfin, Bürkiweg 2
-– Ernst, Umdrucker. Flurstrasse la
+– Ernst, Umdrucker, Flurstrasse 1a
 – Frieda (Spichiger), Wwe., Gerechtigkeitsgasse 17
 – Kaspar, Alpeneckstrasse 10
 – — Klara Gertr., Bureaulistin, Bollwerk 35
@@ -3391,10 +3395,10 @@ Berger, Ad., Tapetenhandlung (Schützenw. 1), Stauffacherstrasse 11a [22.098]
 – Alfred, Bäcker, Freiburgstrasse 68
 – Alfred, Handlanger, Allmendstrasse 28
 – Alfred, Kaufmann, Lorrainestrasse 27 [27.071]
-– Alice, Laboratoriumsgeh.. Murtenstr. 155 E
+– Alice, Laboratoriumsgeh., Murtenstr. 155 E
 – Alwin H. E., Gärtner, Wabernstrasse 40
 – Anna Elisab., gew. Lingere, Wylerfeldstrasse 41
-– Anna (Hirter), Möbelhdlg.. Metzgerg. 14
+– Anna (Hirter), Möbelhdlg., Metzgerg. 14
 – Arthur, Handlanger, Mattenhofstrasse 29
 – Aug., Bureauangestellter, Spitalackerstr. 1
 – Aug. O., Radiotelegraphist. Länggassstr. 69
@@ -3410,7 +3414,7 @@ Berger, Ad., Tapetenhandlung (Schützenw. 1), Stauffacherstrasse 11a [22.098]
 – Eduard, Gen.-Vertr. d. Elite A.-G., Chem.techn. Prod., Vevey (Fischerweg 22), Bollwerk 19 [29.504]
 – Eduard G., Postangestellter, Seidenweg 46
 – Elise (Läderach), Wwe., Fabrikstrasse 34
-– Ella Lina. Ladentochter, Militärstrasse 59
+– Ella Lina, Ladentochter, Militärstrasse 59
 – Elsa Erika, Angestellte, Schwarztorstr. 22
 – Elsa, Ladentochter, Gutenbergstrasse 29
 – Emil Joh. (Kofmehl), Depotbuchhalter der S. N. B., Allmendstrasse 10
@@ -3440,11 +3444,11 @@ Berger, Emma Rosette, Lehrerin, Mittelstr. 13
 – Fel. F., Bahnangestellter, Lentulusstr. 33
 – Ferd. Paul, kaufm. Angestellter, Mittelstrasse 28 [24.269]
 – Ferd., Sattler, Badgasse 39
-– Franz. Postangestellter. Jurastrasse 21
+– Franz. Postangestellter, Jurastrasse 21
 – Frieda, Damenschneiderin, Kramgasse 58 [36.077]
 – Frieda, Hilfsarbeiterin, Landhausweg 6a
 – Frieda Klara, Schützemveg 1
-– Friedr. Ad.. Kaufmann. Stauffacherstr 11a
+– Friedr. Ad., Kaufmann. Stauffacherstr 11a
 – Friedr. Alb., Ausläufer, Rodtmattstr. 85.
 – Friedr., Bauamtarbeiter, Weberstrasse 9
 – Friedr., Kommis, Standstrasse 33
@@ -3491,7 +3495,7 @@ Berger, Herm., Asphalter, Weissensteinstr. 1
 – Joh. Gottl. (Mainardi), Kaufmann, Beundenfeldstrasse 10 [20.721]
 – Johann Ad., Monteur, Flurstrasse 30
 – Johanna, Bankangest., Schwarztorstr.53 [33.513]
-– Johanna El.. Bureaulistin. Effingerstr. 10
+– Johanna El., Bureaulistin. Effingerstr. 10
 – Johanna Gertr., Korrespondentin, Eschenweg 15
 – Johannes, Milchprodukte, Früchte, Weinetc., Alleeweg 1 [35.791]
 – Johannes, gew. Wegmeister, Tunnelweg 10
@@ -3505,11 +3509,11 @@ Berger, Herm., Asphalter, Weissensteinstr. 1
 – Louise (Schranz), Wwe., Schwarztorstr. 53
 – Lydia, Arbeitslehrerin, Asylweg 6, Bümpliz
 – Lydia, Damenschneiderin, Murtenstr. 155e
-– M . Buchhinder. Mittelstrasse 26
+– M., Buchhinder. Mittelstrasse 26
 – M. (Stettier), Käse- u. Butterhdlg., Freiestrasse 40 [34.047]
 – Madeleine Maria, Hügelweg 2
 – Marcel, Techniker, Breitfeldstrasse 4
-– Margaritha A.. Bureaulistin. Neufeldstr.122
+– Margaritha A., Bureaulistin. Neufeldstr.122
 – Margr.,. Bureaulistin, Gesellschaftsstr. 42
 – Margaritha H., Verkäuferin, Schönauweg 2
 – Maria. Einlegerin Moserstrasse 27
@@ -3518,7 +3522,7 @@ Berger, Herm., Asphalter, Weissensteinstr. 1
 – Marie. Fabrikarbeiterin, Schönauweg 2
 – Marie, Frau, Spezereihandlung, Gerechtigkeitsgasse 37 [33.988]
 – Marie, Weissnäherin, Kramgasse 58
-– M. Helene (Ischi), Wwe.. Muristrasse 7 [36.748]
+– M. Helene (Ischi), Wwe., Muristrasse 7 [36.748]
 — Martha Bertha, Bureaulistin, Monbijoustrasse 67
 – Max. Promenadenaufseher. Muristrasse 95
 – Mina Cäcilia, Fabrikarbeiterin, Bümplizstrasse 148
@@ -3536,11 +3540,11 @@ Berger, Oskar, Monteur, Weissensteinstr. 14
 – Paul (ßieri). Revisor d. Generaldirektion P. T. T., Ludwig-Forrerstr 20 [29.147]
 – Rosa (Kindler). Länggassstrasse 26
 – Rosa (Pfister), Wwe., Schneiderin, Standstrasse 28
-– Rosalie, Frl., Bureaulistin B. K. W., Länggassst lasse 26
+– Rosalie, Frl., Bureaulistin B. K. W., Länggassstrasse 26
 – Rudolf, Chauffeur, Wyttenbachstrasse 14
-– S. Sigm.. Bankangestellter. Allmendstr. 42
+– S. Sigm., Bankangestellter, Allmendstr. 42
 – Viktor, Angestellter, Länggassstrasse 53
-– W. Ad... Beamter S. B. B.. Simonstr 15 [25.623]
+– W. Ad.., Beamter S. B. B., Simonstr 15 [25.623]
 – Walter (Huber), Beamter der S. B B., Effingerstrasse 97 [27.265]
 – W., Dr. med., Spezialarzt f. innere Krankheiten. Praxis: Bärenplatz 9, 13½ bis 15½ und nach Uebereinkunft [29.421]; Wohng.: Gotthelfstrasse 18 [25.328]
 – Walter F., Handlanger, Schanzenbergstr. 7
@@ -3550,12 +3554,12 @@ Berger, Oskar, Monteur, Weissensteinstr. 14
 – Walter, Maler. Sennweg 17
 – Werner, Chauffeur S. O. B., Pestalozzistr.24
 – Werner Fritz, Autosattlerei, Brunnmattstrasse 43 [33.814]
-– Werner O.. Baumeister, in Fa. Sigrist- & Berger, Moserstrasse 50 [27 394]
+– Werner O., Baumeister, in Fa. Sigrist- & Berger, Moserstrasse 50 [27 394]
 – Wilh. Alfred. Schneidermeister, Militärstrasse 59
 – Wilhelm. Güterarbeiter, Wylerfeldstr. 44
 – Wilhelm, Malergeschäft (Wiesenstrasse 1), Beundenfeldstrasse 31a [31 354]
 – Willi., Schneider, Murtenstr. 5 [26.169]
-– Willi Viktor, kaufm Angest.. Eschenw. 15
+– Willi Viktor, kaufm Angest., Eschenw. 15
 – Willy Konrad, Coiffeur, Kramgasse 31
 – & Schmiedlin. Zahnarztl. Privat-Institut, Bollwerk 17 [23 054]
 Berggemüsebau A.-G., Filiale: Brunnadernstrasse 28 [25.650]
@@ -3622,7 +3626,7 @@ Bernasconi, C., A.-G. 📞 46.511 Kunststeinfabrik, Terrazzowerke, Edelputz «Gr
 – Edoardo, Maler, Wylerfeldstrasse 71
 – Emma, Ladentochter, Genfergasse 5
 – Ernst, Mosaiker, Gesellschaftsstrasse 71
-– Franz, Fahrdienstarbeiter S. ö. B.. Tscharnerstrasse 20
+– Franz, Fahrdienstarbeiter S. ö. B., Tscharnerstrasse 20
 – Gertrud M., Einlegerin, Cäcilienstrasse 21a
 – Giovanni, Schreiner-Parquetier, Effingerstrasse 101
 – Giulio, Maurerpolier, Güterstrasse 46
@@ -3646,11 +3650,11 @@ Bernegger, Ida, Verkäuferin, Oberweg 2
 Berneralpen-Milchgesellschaft, Bollwerk 15 [23 192]
 Berner, Albert, Verwalter d. Unionsdrückerei, Monbijoustrasse 61 [23.441]
 – Alice N., Schneiderin, Monbijoustrasse 20
-– Christian G.. Hotelier, in Fa. Nietlispach, Berner & Cie., Alpeneckstr 10 [24.483]
+– Christian G., Hotelier, in Fa. Nietlispach, Berner & Cie., Alpeneckstr 10 [24.483]
 – Edgar, stud jur., Schwarzenburgstr. 16
 – Ernst, Elektromonteur, Tscharnerstr. 15
 – Ernst, Grubenarbeiter, Kehrg. 35, Bümpliz
-– Friedrich, pens. Fräser der Waffenfabrik, . Standstrasse 17
+– Friedrich, pens. Fräser der Waffenfabrik, Standstrasse 17
 – Friedr. E., Mech., Murtenstr. 340, Bümpliz
 – Georg, Ingenieur b. eidg. Amt für Wasserwirtschaft. Brunnadernstrasse 87 [27.384]
 – Guido, techn. Experte d. Oberzolldirektion, Dählhölzliweg 13 [36.398]
@@ -3696,7 +3700,7 @@ Bernet, Anton, Angestellter, Sulgenrain 8 [32.493]
 – Peter, Beamter, Zähringerstr. 35 [29.787]
 Bernev, Louis A., Uhrenhdlg. u. Bijouterie (Effingerstr. 41), Hirschengraben 8 [27.426]
 Bernhard und Bernhardt
-– Ad.. Korrespondent Humboldtstr. 53
+– Ad., Korrespondent Humboldtstr. 53
 – Alfred, Käser, Gerechtigkeitsgasse 13
 Bernhard und Bernhardt
 – Alois, Privatier, Mattenhofstrasse 17
@@ -3732,7 +3736,7 @@ Bernhardsgrütter, A. J. A., Elektrotechniker, Greyerzstrasse 52 [24.991]
 – Anna. Greyerzstrasse 52
 Bernheim, Alfr., Ing., Aufzüge Schlieren und Isolierungen, Optingenstrasse 27 [24.679]
 – Edm. (Vögeli), Maschinen u. Werkzeuge f.
-Hoch-, Tief- u. Brückenbau, techn. Bureau, Kornhausstrasse 10 . [21.805]
+Hoch-, Tief- u. Brückenbau, techn. Bureau, Kornhausstrasse 10 [21.805]
 – Edm. L., Nouveautes, Chemiserie (Humboldtstrasse 25), Theaterplatz 4 [23.839]
 – Emil, Wein- u. Likörhdlg., Import franz.
 Weine (Kornhausstrasse 4), Breitenrainstrasse 17 [33.257]
@@ -3785,7 +3789,7 @@ Bersinger, Aug., Blumenbinder, Stauffacherstrasse 8
 Bertallo, Claude M., Wylerstrasse 14
 – Emilien, Architekturbureau, Wylerstr. 14 [21.619]
 Berteletti, Natale, Maurer, Lorrainestrasse 26
-Berthele-Fevrier, B,, Frau, Thunstrasse 42 [34.994]
+Berthele-Fevrier, B., Frau, Thunstrasse 42 [34.994]
 Berthoud, Aimee Marie, Tanzlehrerin, Schauplatzgasse 39
 – Elise, Frau, Erlachstrasse 30
 – Frieda, Gutenbergstrasse 6
@@ -3858,13 +3862,12 @@ Bertschmann, Karl, kaufm. Angest., Optingenstrasse 46
 Berufsberatung und Lehrlingsfürsorge, Zentralstelle (Abtlg. f. Knaben: Münch, Eug. Alb.; Abtlg. für Mädchen: Rosa Neuenschwander), Predigergasse 8 [27.761]
 Besangon, Charles, Vertreter, Hallerstr. 12
 Besitz A.-G., Immobilien- und Wertschriftenverwaltung, Fährstrasse 40 [23.098]
-Besozzi. L C. A . Maurer. Kasernenstrasse 41
+Besozzi, L. C. A., Maurer, Kasernenstrasse 41
 Besse, Henri Luden, Koch, Engehaldenstr. 93
 – Marcel E., Werkzeugdreher, Wiesenstr. 78
 Bessmer u. Besnier
 – Friedr. Wilh., Schreiner, Breitfeldstr.il
-Besso, Michel A., Ing., wiss. Experte b. eidg.
-Amt f. geist. Eigentum, Muristr. 31 [36.233]
+Besso, Michel A., Ing., wiss. Experte b. eidg. Amt f. geist. Eigentum, Muristr. 31 [36.233]
 Besson, Const. H., eidg. Beamter, Predigergasse 4
 – Frank Louis, Ingenieur, Wyttenbachstr. 22
 – M. Rosa, pens. Gehilfin d. S. B. B., Waldheimstrasse 33
@@ -3942,11 +3945,11 @@ Beutler, s auch Bütler
 – Fritz, Einleger, Zähringerstrasse 47
 – Göttfr., Münzarbeiter, Gruiberstrasse 20
 – Hans (Wildbolz), Buchhändler, Kyburgstrasse 7
-– Hans, Bureauangestellt.. Blumensteinstr. 7
+– Hans, Bureauangestellt., Blumensteinstr. 7
 – Hans, Notar (Hochfeldstrasse 103), Schauplatzgasse 39 [22.851]
 – Hans, Tramangestellter, Chutzenstr. 15
 – Joh., Handlanger, Felshaldenweg 19
-– Joh. Arnold, Bureauangest.. Herzogstr.il
+– Joh. Arnold, Bureauangest., Herzogstr.il
 – Joh., Karrer, Laubeckstrasse 60
 – Joh. Jak., Karrer, Zähringerstrasse 47
 – Johanna, Ladentochter, Herzogstrasse 11
@@ -3993,7 +3996,7 @@ Beyeler und Beieler
 – Ernst, Maler, Brunnmattstrasse 61
 – Ernst, Möbelhändler (Bollwerk 21), Neubrückstrasse 15 [27.758]
 – Ernst (Binggeli), Schriftsetzer, Aegertenstrasse 52
-– Erwin Emil, Hilfsarbeiter. Mühleplatz 6
+– Erwin Emil, Hilfsarbeiter, Mühleplatz 6
 – Friedr., pens. Postkond., Scheibenstr. 19
 – Friedr. Hans, Hilfsarbeiter, Breitenrainstrasse 25
 – Friedr., Schlosser, Stockerenweg 16
@@ -4005,7 +4008,7 @@ Beyeler und Beieler
 – Gottfr., Tapezierer, Steppdeckenfabr., Waisenhausplatz 18 [22.732]
 – Gottfr., Handlanger, Elisabethenstrasse 45
 – Gottfr., Schriftsetzer, Elisabethenstrasse 13
-– Gottl.. Postbeamter. Moserstr. 46
+– Gottl., Postbeamter, Moserstr. 46
 – G. (Schlosser), Ausläufer d. eidg. Steuerverwaltung, Hallerstrasse 51
 – Hans, Steindrucker, Federweg 29b
 – Joh., Abwart S. B. B., Stöckackerstr. 83a, Bümpliz
@@ -4089,7 +4092,7 @@ Bichsei, Abr., Magaziner, Könizstrasse 9
 – Emil. Schreiner. Maulbeerstrasse 11
 – Emma und Bertha, Modes und Robes (Schifflaube 30), Kramgasse 83 [32.898]
 – Ernst, Angestellter, Freiburgstrasse 145
-– Ernst, Bankbeamter. Belpstrasse 16
+– Ernst, Bankbeamter, Belpstrasse 16
 – Ernst E., kaufm. Angest., Altenbergstr. 84
 – Ernst, kaufm. Angest., Breitenrainplatz 28
 – Ernst Fr., Goldschmied, Wylerstrasse 45
@@ -4140,7 +4143,7 @@ Bichsei, Joh., Hilfsarbeiter, Wangenstr. 132, Bümpliz
 – Rud., Bahnarbeiter S. B. B., Amselweg 25
 – Sam., Schreiner, Keltenstr. 108, Bümpliz
 – Traug., Bauamtarbeiter, Elisabethenstr. 35
-– Walter, Fabrikarbeiter. Rossfeldstrasse 29
+– Walter, Fabrikarbeiter, Rossfeldstrasse 29
 – Walter, Gärtner, Brunnhofweg 21
 – Walter, Kaufmann, Wylerstrasse 16
 – Walter, Schneider, Niederriedweg 48, Oberbottigen
@@ -4168,7 +4171,7 @@ Bieder, Daniel, Maschinensetzer, Brunnmattstrasse 61
 – Marie, Schneiderin, Tavelweg 20
 Biedermann, Adolf (Störi), gew. Postbureauchef, Jungfraustrasse 4 [21.854]
 – Eduard Max, Kaufmann, in Fa. Kindler & Cie., Donnerbühlweg 14 [21.603]
-– Emil Alfr. Heinr.. Bankangest., Emanuel-Friedlistrasse 21
+– Emil Alfr. Heinr., Bankangest., Emanuel-Friedlistrasse 21
 – E. M., Lehrerin, Schwarztorstr. 3 [36.413]
 – Emil (Sydler), gew. eidg. Beamter, Freiestrasse 53
 – Ernst Ad., Koch, Pavillonweg 9
@@ -4217,10 +4220,10 @@ Bienz, siehe auch Binz
 – Otto, Landwirt, Bernstrasse 77, Bümpliz
 – Rosa, Pension Montana, Gartenstrasse 1 [33.739]
 – Rud., Masch.-Techniker, Zedernstrasse 8, Bümpliz
-Bierhübeli. Gesellschaftshaus, Restaur.. Neubrückstrasse 43 [29.292]
+Bierhübeli. Gesellschaftshaus, Restaur., Neubrückstrasse 43 [29.292]
 Bieri, Adolf, Chauffeur, Allmendstrasse 44
 – Albrecht, kaufm. Angest., Haldenstr. 13, Gurtenbühl
-– Alfred, Dr. phil.. Gymnasiallehrer, Finkenhubelweg 26 [22.177]
+– Alfred, Dr. phil., Gymnasiallehrer, Finkenhubelweg 26 [22.177]
 – Alfred, Schneidermeister, Steigerweg 17
 – Alfred, Wirt z. Wyleregg, Wylerstr. 109 [23.577]
 – Alfr., Magaziner, Brünnenstr. 96, Bümpliz
@@ -4290,11 +4293,11 @@ Zeichnungen, Muristrasse 75 [24.379]
 – Jakob (Stucki), Chauffeur, Brunnadernstrasse 28
 – Jakob. Chauffeur, Rütlistrasse 12
 – Jakob. Hilfsarbeiter, Breitenrainstr. 23
-– Jakob. Angestellter. Militärstrasse 53
+– Jakob. Angestellter, Militärstrasse 53
 – Jak. W., Maurer, Freiburgstr. 378, Bümpliz
 – Jakob, Schmied, Worblaufenstrasse 11
 – -Jakob. Spengler, Zähringerstrasse 51
-– Joh., Bauarb,, Freiburgstr. 511, Bümpliz
+– Joh., Bauarb., Freiburgstr. 511, Bümpliz
 – Joh., Automechaniker, Lenzweg 12
 – Joh. Friedr., Beamter S. B. B., Weissenbühlweg 6
 – Joh., Hilfsarbeiter, Jurastrasse 77
@@ -4305,9 +4308,9 @@ Zeichnungen, Muristrasse 75 [24.379]
 – Klara Elisab., Bureaulistin, Steinauweg 18
 # Date: 1935-12-15 Page: 26020350/47
 Bieri, Klara (Bieri), Stahlen 32
-– Leo Fr.. Gasarbeiter. Berchtoldstr 23
+– Leo Fr., Gasarbeiter, Berchtoldstr 23
 – Lilly B., Bureaulistin, Jubiläumsstrasse 56
-– Maria, .Prokuristin, Schwarztorsitrasse 21 [31.380]
+– Maria, Prokuristin, Schwarztorsitrasse 21 [31.380]
 – Maria (Wüthrich). Wwe., Schanzenstr. 6
 – Marie (Hofer), Wwe., Schneiderin, Brunnhofweg 27
 – Marie (Messerli). Privat., Erlachstr. 80 [34.570]
@@ -4326,16 +4329,16 @@ Bieri, Klara (Bieri), Stahlen 32
 – Rob. Bernh., Chauffeur-Mechaniker, Holzikofenweg 5
 – Rosa A., Ladentochter, Freiburgstrasse 438, Bümpliz
 – Rosa, Hebamme, Erlachstrasse 8 [31.108]
-– Rosa (Reber), Wwe.. Gerechtigkeitsg. 46
+– Rosa (Reber), Wwe., Gerechtigkeitsg. 46
 – Rosette (Zaugg), Wwe., Wachtelweg 23
-– Rudolf E.. Karrer, Sulgenbarhstrasse 12
+– Rudolf E., Karrer, Sulgenbarhstrasse 12
 – Rud., in Fa. Gebr. Bieri, Muesmattstr. 33
 – Sophie (Geissbühler), Wwe., Länggassstrasse 104
 – Werner, Elektromonteur, Wangenstr. 132a, Bümpliz
 – Werner O., Hilfsarbeiter, Schifflaube 28
 – Werner. Hilfsmonteur. Freiburgstrasse 182, Bümpliz
 – Willy E., Mechaniker, Weberstrasse 27
-– Gebr .. Sanitäre Anlagen. Warm Wasserversorgungen, Muesmattstrasse 33 [24.181]
+– Gebr., Sanitäre Anlagen. Warm Wasserversorgungen, Muesmattstrasse 33 [24.181]
 Bietenhard, Ernst, Postbeamter, Zielweg 29 [20.983]
 Bietenharder, Adolf. Kaufmann, Heinr.-Wildstrasse 14 [38.599]
 – Ernst, techn Beamter der städt. Baudirektion, Mattenhofstrasse 33
@@ -4343,19 +4346,19 @@ Bietenharder, Adolf. Kaufmann, Heinr.-Wildstrasse 14 [38.599]
 – Joh. (Adam), Magaziner. Bümplizstr 83b
 – Johanna Ida, Aushilfe, Bümplizstr. 83b
 – Klara. Filialleiterin, Effingerstrasse 41d
-– Marianna (Sieber). Wwe.. Seidenweg 31
+– Marianna (Sieber). Wwe., Seidenweg 31
 Bietry, Alice Marguerite, Freiburgstrasse 18
 – Jos. Ernest, Handlanger, Brünnenstr. 76, Bümpliz
 Biffi, Avg., Schreiner. Schillingstrasse 28
 – Lina, Modistin, Schillingstrasse 28
-Bigard, B.. Wwe, Gutenbergstr. 15 [35.892]
+Bigard, B., Wwe, Gutenbergstr. 15 [35.892]
 Bifller, Adolf, Postangestellter, Zeigerweg J.0
 – Ad., Portier, Zeughausgasse 39
-– Alb.. Beamter O. T. D.. Myrtenweg 7. Bümpliz [46.105]
+– Alb., Beamter O. T. D., Myrtenweg 7. Bümpliz [46.105]
 – Alb., Hilfsarbeiter, Freiburgstrasse 45
-Bigler, Albert, Landwirt, Niodorriedweg 112,, Bümpliz
+Bigler, Albert, Landwirt, Niodorriedweg 112., Bümpliz
 – Alex., pens. Schafter der Waffenfabrik., Waffenweg 10
-– Alfr.. Handlanger, Bümplizstrasse 62a
+– Alfr., Handlanger, Bümplizstrasse 62a
 – Alice, Ladentochter, Weissensteinstr. 112
 – Alice Rosa, Lehrerin, Jennerweg 7
 – Anna, Bureaulistin, Wylerstrasse 43
@@ -4368,12 +4371,12 @@ Bigler, Albert, Landwirt, Niodorriedweg 112,, Bümpliz
 – Charlotte u. Emma Luise. Weiss- u Runtstickerei, Amthausgasse 8 [36.723]
 – Chr., Ausläufer, Brünnenstr. 38, Bümpliz
 – Chr., Schlossermeistev (Kasthoferstr. 34), Thunstrasse 111/113 [33,375]
-– Christ.. Handlanger, Bümplizstrasse 62a
+– Christ., Handlanger, Bümplizstrasse 62a
 – E. C. (Seitz), Wwe., Ob. Dufourstrasse 23 [35.252]
 – Egon Noch. H., Koch, Herrengasse 25
 – Ella, Ladentochter, Steckweg 17
 – - Elsa Martha, Lingere, Kasthoferstrasse 34
-– Emil. Fabrikarbeiter. Sodweg 13
+– Emil. Fabrikarbeiter, Sodweg 13
 – Emil, Bäckermeister, Eman.-Friedlistr. 4 [35.204]
 – Emma. Fabrikarbeiterin. Zieglerstr 66
 – Erich Willy, Schriftsetzer, Tscharnerstr. 13
@@ -4391,23 +4394,23 @@ Bigler, Albert, Landwirt, Niodorriedweg 112,, Bümpliz
 – Ernst, Postbeamter, Effingerstrasse 25
 – Fr., Monteur, Dietlerstrasse 14
 – Fr., pens. Monteur. Breitfeldstrasse 44
-– Fr. Karl, Spezereihandlung, Karl-Staufferstrasse 2? [28.720]
+– Fr. Karl, Spezereihandlung, Karl-Staufferstrasse 22 [28.720]
 – Fritz, Schriftsetzer, Steckweg 17
 – Franz Friedr. (Häberli). Tscharnerstr. 12
 – Franz. Abwart. Bollwerk 25
 – Franz Hermann, Coiffeurgeschäft (Kramgasse 42), Metzgergasse 26
 – Franz. Hilfsarb., Unt. Villettenmattstr. 7
-– Franz Rud.. Chauffeur. Scbeibenstr. 22a
+– Franz Rud., Chauffeur. Scbeibenstr. 22a
 – Frieda, Coiffeuse, Metzgergasse 37
 – Frieda, Hilfsarbeiterin, Zieglerstrasse 66
 – Friedr., Ausläufer, Reichenbachstrasse 3
-– Friedr., .iun., Automech.. Murtenstr. 21a
-– Friedr.. Chauffeur, Murtenstr. 21a [32.733]
-– —Friedr. (Walther), Chauffeur, Kesslerg. 7
+– Friedr., iun., Automech., Murtenstr. 21a
+– Friedr., Chauffeur, Murtenstr. 21a [32.733]
+– Friedr. (Walther), Chauffeur, Kesslerg. 7
 – Friedr. W., Feinmechaniker, Dalmaziw. 65
-– Friedr,, Hausierer. Brunngasshalde 47
+– Friedr., Hausierer. Brunngasshalde 47
 – Friedr., Maler, Brünnenstr. 38, Bümpliz
-– Friedr.. Hauswart, Seilerstrasse 2
+– Friedr., Hauswart, Seilerstrasse 2
 # Date: 1935-12-15 Page: 26020351/48
 Bigler, Friedr., Hilfsarbeiter, Genossenweg 21
 – Friedr., Festangestellter, Gurnigelstr. 10
@@ -4424,10 +4427,10 @@ Bigler, Friedr., Hilfsarbeiter, Genossenweg 21
 – Gottfr., Bechnungsführer b. G. R. D., Beundenfeldstrasse 50 [36.689]
 – Gottfr., Güterarbeiter S. B. B., Rütlistr. 22
 – Gottfr., Lehrer an der Brunnmattschule, Jennerweg 7 [34.112]
-– Gottfr.. Ghauff., Bethlehemstr. 21, Bümpliz
+– Gottfr., Ghauff., Bethlehemstr. 21, Bümpliz
 – Gottfr., Sohn, Landwirt, Niederriedweg 112, Bümpliz
 Bigler, G. [24.331] Sanitäre Installationen, Spenglerei, Zentral- und Etagenheizungen, Gasheizungen, vollautomatisch, Luisenstrasse 16a
-– Gottfr.. Pächter. Melchenbühlweg 56
+– Gottfr., Pächter, Melchenbühlweg 56
 – Gottl., Billetteur S S. B., Brunnmattstr. 53a
 – Gottl., Chauffeur. Weissensleinstrasse 104
 – Hans, kaufm. Angestellter, Tscharnerstr. 13
@@ -4440,7 +4443,7 @@ Bigler, G. [24.331] Sanitäre Installationen, Spenglerei, Zentral- und Etagenhei
 – Hans. Sattlermeister, in Fa. Hans Bigler & Paul Gerber, Dalmaziweg 49 [28.448]
 – Hans, Woll- u. Baumwollgarne, Strumpfwaren, gestrickte Damen- u. Kinder-Artikel (Weissensteinetrasse 98). Neueng. 14 [34.337]
 – Hans, Pferdewärter, Wiesenstrasse 61
-– Hans Alb.. Postangestellter, Effmgerstr.41a
+– Hans Alb., Postangestellter, Effmgerstr.41a
 – Hans Ernst, Ausläufer, Kramgasse 42
 – Hans Otto, Schreiner, Römerweg 26
 – Hans (Schütz), Wagenführer der S. S. B., Alleeweg 3
@@ -4458,9 +4461,9 @@ Bigler, Ida Elsa, Polisseuse, Dalmaziweg 65
 – Joh., Chauffeur, Rossfeldstrasse 25
 – Joh., Maler, Stauffacherstrasse 3
 – Joh., Masch-Techniker, Luisenstrasse 16a
-– Joh., Pferdewärter. Stationsweg 42
+– Joh., Pferdewärter, Stationsweg 42
 – Joh., Schreiner, Bühlstrasse 49
-– Joh.. Schreiner. Schwalbenweg 14
+– Joh., Schreiner. Schwalbenweg 14
 – Johanna, Verkäuferin. Effingerstrasse 25
 – Karl, Pferdewärter, Wiesenstrasse 78
 – Karl, Tapezierer, Aarstrasse 106
@@ -4476,7 +4479,7 @@ Bigler, Ida Elsa, Polisseuse, Dalmaziweg 65
 – Marie Rosa, Fabrikarbeiterin, Morillonstrasse 30
 – Marie (Moser), Wwe., Wildhainweg 12
 – Martha, Verkäuferin, Effingerstrasse 25
-– Martha (Gerber). Wwe.. Wyttenbachstr. 25 [34.254]
+– Martha (Gerber). Wwe., Wyttenbachstr. 25 [34.254]
 – Martha Elise (Moser). Wwe., Militärstr. 61
 – Max, kaufm. Angestellter, Tscharnerstr. 13
 – Otto, Karrer, Landhausweg 6
@@ -4494,8 +4497,7 @@ Bigler, Ida Elsa, Polisseuse, Dalmaziweg 65
 – Rudolf, Schmied, Breitfeldstrasse 35
 – Sophie Frieda, Bureaulistin, Bühlstrasse 49
 – W., Stereotypeur. Römerweg 26
-– Walter Alex. (Bandlin), Mechaniker der
-0. T. D., Kasernenstrasse 40
+– Walter Alex. (Bandlin), Mechaniker der O. T. D., Kasernenstrasse 40
 – Walter E. Fr., Mechaniker, Waffenweg 10
 – Walter, Mechaniker, Simplonweg 15
 – Walter A. (Bieri). Schriftsetzer, Eggimannstrasse 28
@@ -4507,9 +4509,6 @@ Bigler, Ida Elsa, Polisseuse, Dalmaziweg 65
 – Willy Walter, Schlosser, Kirchackerweg 1, Bümpliz
 Biland, Marcel, Milchträg., Bethlehemstr. 114, Bümpliz
 – R. (Wettler), Wwe., Gutenbergstrasse 19 [29.808]
-EISENBETONPLKNE
-H. & F. Pulfer, Ingenieure
-Kapellenstr. 22 - Tel. 22.756
 # Date: 1935-12-15 Page: 26020352/49
 Biland, Rosa, Bureaulistin, Gutenbergstr. 19
 Bilger, Theodor, Malergeschäft, Tapeten- und Papeteriehandlung (Junkerngasse 46), Gerechtigkeitsgasse 42 [36.381]
@@ -4530,7 +4529,7 @@ Bill, Adolf, Handlanger, Jurastrasse 77
 – Frieda, Schneiderin, Elisabethenstrasse 44
 – Friedr., pens. Beamter SBB, Heimstr. 18, Bümpliz
 – Friedr., Vertreter, Moserstr. 18 [28.774]
-– Friedr., Hilfsarbeiter. Ulmenweg 5
+– Friedr., Hilfsarbeiter, Ulmenweg 5
 – Friedr., Hauswart, Bundeshaus-Ost [61.706]
 – Gottl., Schwarztorstrasse 55
 – Gottl., Mechaniker, Wittigkofenweg 1
@@ -4549,9 +4548,9 @@ Bill, Adolf, Handlanger, Jurastrasse 77
 – Rosa, Lingere, Brunnhofweg 30
 – Rud. Ed., Kommis, Kramgasse 76
 – Rud., Polizist, Bümplizstrasse 153
-– Rud., Postangestellter. Seidenweg 64
+– Rud., Postangestellter, Seidenweg 64
 – Walter A., Chemigraph, Wittigkofenweg 1
-– Werner, Beamter. Maulbeerstrasse 17
+– Werner, Beamter, Maulbeerstrasse 17
 – Werner Jak., Zimmermann, Wagnerstr. 26
 Billeter, Hans Alex., Musiker, Waffenweg 21
 – Hedwig Emma, Ladentochter, Bundesbahnweg 13
@@ -4563,7 +4562,7 @@ Billwiller, Alb. Ad. Wilh., Hotelsekretär, Karl-Schenkstrasse 3
 – E. E. J., Modiste, Karl-Sclienkstrasse 3
 – Wilh. Ad. Alb., Musiker, Karl-Schenkstr. 3
 Binaghi, Enrico Fabio, Maurer, Seidenweg 27
-Binder, Alb. Ferd.. Techniker, Morillonstr. 7
+Binder, Alb. Ferd., Techniker, Morillonstr. 7
 – Alb., pens. Schlosser, Morillonstrasse 7
 – Alice Hedw., Postbeamtin, Falkenplatz 5
 – Bertha Elisab., Sek.-Lehrerin, Bühlstr. 53b
@@ -4625,7 +4624,7 @@ Binggeli, Hans, Elektromechaniker, Lorbeerstrasse 2, Bümpliz
 – Joh., Beamter, Lorbeerstrasse 2, Bümpliz [46.624]
 – Karl, Bäcker, Sulgeneckstrasse 36
 – Karl, kaufm. Angest., Karl-Schenkstr. 11 [23.599]
-– Karl, Spenglermeister, in Fa. K. Binggeli & Co.. Hohgantweg 14
+– Karl, Spenglermeister, in Fa. K. Binggeli & Co., Hohgantweg 14
 – K., Wwe., Kasernenstrasse 21a
 – Lina, Ladentochter, Wyttenbachstr. 29
 – Lydia, Hebamme, Schanzenstrasse 23
@@ -4637,7 +4636,7 @@ Binggeli, Hans, Elektromechaniker, Lorbeerstrasse 2, Bümpliz
 – Rud., Bauamtarbeiter, Standstrasse 64
 – Rud., Heizungsmonteur, Nydeckhof 19
 – Rud., Vertreter, Maulbeerstrasse 7
-– Werner, Hilfsarbeiter. Wyttenbachstr. 29
+– Werner, Hilfsarbeiter, Wyttenbachstr. 29
 – Wilh. Friedr., Schriftsetzer, Oberweg 2
 – & Co., K., Spenglerei u. Installationsgesch., Waldheimstrasse 46 [31.253]
 Binkert, Anna, Beamtin S. B. B., Muldenstr. 17
@@ -4689,12 +4688,12 @@ Birrer, Elisabetha, Stickerin, Flurstrasse 29
 Birsfelder, K. F., Buchbinder der S. B. B., Hopfenweg 14
 Bischhausen, Anna (Pauli), Schneiderin, Parkstrasse 40
 – Dora. Klavierunterr., Marktg. 55 [34.720]
-– El. Bertha. Jubiläumsstrasse 19
+– El. Bertha, Jubiläumsstrasse 19
 – Ernst, Photo- und Kino-Börse (Fischerweg 14), Kramgasse 6 [21.857]
 – Fritz P., Sägerei u. Etuisfabrik (Alter Aargauerstalden 5 [34.028]), Wasserwerkg. 10 [31.447]
 – Hs. Fritz, Elektrotechniker, Liebeggweg 11 [35.655]
 – Ida Martha, Angestellte S. B. B., Liebeggweg 11 [35.655]
-– Karl Alfr.. Tapezierer. Parkstrasse 40
+– Karl Alfr., Tapezierer. Parkstrasse 40
 – Louis (Pfründer), Optiker, Marktgasse 53 [21.625]
 – Louis Rud. (Weibel), dipl. Optiker in Fa.
 Gebr. Bischhausen A.-G., Bernastrasse 60
@@ -4702,21 +4701,21 @@ Gebr. Bischhausen A.-G., Bernastrasse 60
 – Rosa, Gryphenhiiheliweg 55 [34.132]
 – Rud. Paul, Elektrotechn., Schwarztorstr. 18
 – Rudolf, Optiker, kant. Insp. f. Mass u. Gewicht, Liebeggweg 14b [32.440]
-– W. W.. Goldschmied, Liebeggweg 11 [35.655]
-– Gebr.. A -G., Optiker und Mechaniker Photographische Artikel, Marktg. 53 [21.625]
-– & Cie.. Avsphaltgeschäft, Liebeggweg 14b [32.440]
+– W. W., Goldschmied, Liebeggweg 11 [35.655]
+– Gebr., A -G., Optiker und Mechaniker Photographische Artikel, Marktg. 53 [21.625]
+– & Cie., Avsphaltgeschäft, Liebeggweg 14b [32.440]
 Bischof, Alb., Chauffeur, Bridelstrasse 24
 – Alfred, Buchbinder, Seftigenstrasse 97
 # Date: 1935-12-15 Page: 26020354/51
 Bischof, Eduard Erich, Schneider, Gerechtigkeitsgasse 29
 – Ernst Joh., Masch.-Meister, Felsenaustr. 12
-– Franz Otto, eidg. Beamter. Luternauw. 6 [38.187]
+– Franz Otto, eidg. Beamter, Luternauw. 6 [38.187]
 – Heinrich, Angestellter, Landoltstrasse 28
 – Josef Maschinist, Freiburgstrasse 56
 – Karl, Kunstmaler, Hallerstr. 54 [26.210]
 – Klara. Kassierin, Lerchenweg 35
-– Marcel H.. Zahntechniker, Landoltstr. 28
-– Waldburga, Ladentochter. Freiburgstr 56
+– Marcel H., Zahntechniker, Landoltstr. 28
+– Waldburga, Ladentochter, Freiburgstr 56
 – Willi Alfr., Postangest., Karl-Schenkstr. 7
 Bischoff, Ernst, Ausläufer, Jolimontstrasse 16
 – F. Wilh., Postangest., Militärstrasse 52
@@ -4741,14 +4740,14 @@ Bitterli, Aug., Buchdrucker. Kyburgstrasse 6
 – Joh., Postbeamter, Schwarztorstrasse 23 [29.737]
 – Joh. Bapt., pens. Zugführer, Fischerw. 16
 – Ruth M., Buchhändlerin, Eman.-Friedlistrasse 12
-– S., Beamter S. B. B., Weissenbühlweg 29 .
+– S., Beamter S. B. B., Weissenbühlweg 29
 – Theodor, Kaufm., Emanuel Friedlistr 12 [22.576]
 Bitterlin, Anna E., Bureaulistin, Spitalackerstrasse 62
 – Emil, Jurastrasse 36
 – Emil, Reisender, Dammweg 41
 — Fritz, Chauffeur, Belpstrasse 59
 – Gustav, Schneider, Wiesenstrasse 31
-– Otto, Amtsrichter. Engestrasse 3
+– Otto, Amtsrichter, Engestrasse 3
 – Rosa Bertha, Ladentochter, Gerechtigkeitsgasse 3
 – Walter Sam., Kanzlist, Gerechtigkeitsg. 3
 Bittier, Marie (Huber), Möbelhandlung. Falkenplatz 22 [32.417]
@@ -4781,7 +4780,7 @@ Blanc, Alice, Verkäuferin, Freiestrasse 42
 – Jeanne, Bureaulistin, Seftigenstrasse 99
 – Louise (Demierre), Wwe., Sulgenrain 8 [33.006]
 – Marg. H., Bureaulistin, Liebeggweg 6a
-– Paul Henri, Oberpostbeamter. Liebeggw. 6a [29.629]
+– Paul Henri, Oberpostbeamter, Liebeggw. 6a [29.629]
 – Rob. Leon, Angestellter, Effingerstr. 4a
 – Rose M. EL, Bureaulistin, Liebeggweg 6a
 – & Paiche. Automobil-Magazine Chrysler.
@@ -4793,7 +4792,7 @@ Blanchard, Alexis, Heilsarmeeoffizier, Steigerweg 22 [34.069]
 Blanche, Albertine, Modiste, Blumenbergstrasse 49
 Blanchong, Gges (Hehr), Küchenchef, Flurstrasse 13
 Blandenier, Eva Emilie, Krankenpflegerin, Schlösslistrasse 11
-Blank, Alfr. G.. Sattler u. Tapezierer, Schosshaldenstrasse 44
+Blank, Alfr. G., Sattler u. Tapezierer, Schosshaldenstrasse 44
 – Alfr., Parkettleger, Bubenbergstrasse 34 [32.989]
 – Bertha, Greyerzstrasse 77
 – Christ., Elilfsarbeiter, Metzgergasse 58
@@ -4886,16 +4885,16 @@ Blaser, Christ. Friedr., Schlosser, Mühleplatz 4
 – Ferdinand, Melker, Niederriedw. 46, Oberbottigen
 – Franz, Stationsvorstand d. S. Z. B., Engerain 16
 – Frieda Erika, Aegertenstrasse 6 [35.796]
-– Friedr., Fabrikarbeiter. Felsenaustr. 45
+– Friedr., Fabrikarbeiter, Felsenaustr. 45
 – Friedr., Angestellter, Brunnhofweg 22
 – Friedr., Hilfsarbeiter, Gerbergasse 7
 – Friedr., Schweisser d. S. S. B., Rodtmattstrasse 97
-– Friedr.. Wärter, Breitfeldstrasse 30
+– Friedr., Wärter, Breitfeldstrasse 30
 – Fritz, Kürschner, Kollerweg 7
 – Fritz Kaufmann, Dapplesweg 2
 – Gertrud, Empfangsfräulein, Bümplizstr. 11
 – Gottfr., Pferdewärter, Kasernenstr. 11a
-– Gottfr. Ad.. Tramangestellter. Muristr 97
+– Gottfr. Ad., Tramangestellter, Muristr 97
 – Gottfr., Schreiner, Gerechtigkeitsgasse 74
 – Gottl., Zügler, Brunngasse 19
 – Hans (Dasen), eidg. Beamter, Stauffacherstrasse 1
@@ -4954,7 +4953,7 @@ Blaser, Hans, Handlanger, Freiburgstr. 393, Bümpliz
 – Paul, Angestellter, Unt. Villettenmattstr. 7
 – Paul Werner. Kaufmann. Dählhölzliweg 16
 – Paula, Bureauangestellte, Seilerstrasse 24
-– Rob., Beamter S. B. B.. Hochfeldstrasse 11
+– Rob., Beamter S. B. B., Hochfeldstrasse 11
 – Rob., Giesser, Länggassstrasse 63
 – Rosa Marie, Weissnäherin, Zeigerweg 5
 Blaser, Rud., gew. Lehrer an der Lorraine-, schule, Jubiläumsstrasse 40 [36.067]
@@ -4986,14 +4985,14 @@ Bläsi, August, Kaufmann, Freiestrasse 31 [36.560]
 – Siegfried, Kaufmann, in Fa. S. u. G. Bläsi & Cie., Eisenhandlung, Bern, Riedweg 3 [20.916]
 – S. u. G., & Co., A.-G., Lötzinn, Eisen- und Metallhandlung, Güterstrasse 46 [28.755]
 Blasimann, V., Beamter O. T. D., Freiburgstrasse 125a [25.810]
-– Jost, Walter, Postangestellter. Gewerbestrasse 23
+– Jost, Walter, Postangestellter, Gewerbestrasse 23
 Blatter, Ad., Postangestellter, Zeitglocken 5
 – Alb. (Heiniger), Kaufmann, Ensingerstr. 16 [20.588]
 – August (König), in Fa. Dr. Schauwecker, Blatter & Cie., Baustoffe Bern K.-A.-G., Mayweg 16 [22.291]
 – Bertha M., Bureaulistin, Brunnadernstr. 30
 – Friedr., alt Inspektor d. Gen.-Dir. P. T. T., Brunnadernstrasse 30 [34.018]
 – Fritz, Dr. med. dent., Zahnarzt (Müslinweg 26 [31.665]), Amthausgasse 1 [24.976]
-– Fritz, Lebensmittelhdlg.. Scheibenstr. 43 [31.159]
+– Fritz, Lebensmittelhdlg., Scheibenstr. 43 [31.159]
 – Fritz, Molkereiarbeiter, Aarbergergasse 12
 – Fritz, Postbeamter, Jubiläumsstrasse 52 [36.647]
 – Gottfr., Bauarbeiter, Kramgasse 34
@@ -5006,7 +5005,7 @@ Probeheft vom Verlag Hallwag, Bern
 # Date: 1935-12-15 Page: 26020357/54
 Blatter, M. Heinr., Kaufmann, Dählhölzliw. 12 [28.395]
 – Martha A. (Schumann), Wwe., Mittelstr. 18
-– Math., Bäckermeister. Gerecbtigkeitsg 10 [21.607]
+– Math., Bäckermeister, Gerecbtigkeitsg 10 [21.607]
 – Rosa Lina, Ladentochter, Fischerweg 17
 – Thomas, Coiffeur, Balmweg 35
 – Werner, Gärtner, Bottigenstr. 47, Bümpliz
@@ -5060,12 +5059,12 @@ Bleuer, Arm. Al., Elektriker, Thunstrasse 25
 – Cocile Bertha, Buchliandlungsamgestellte, Bundesgasse 1
 – Hans, Kond. S. B. B., Engehaldenstr. 197
 – Olga, Ladentochter, Thunstrasse 35
-– Peter. Hausmeister, Bundeshaus-West [61.345]
+– Peter, Hausmeister, Bundeshaus-West [61.345]
 Bleuler, Adolf, Kaufmann, in Fa. Steinmann & Co., Kirchackerweg 5, Bümpliz [46.507]
 – Ernst, Tapezierer, Bubenbergstrasse 6
 – Eleonore (Rohr), Privatiore, Jubiläumsstrasse 79
 – Georges. Handlanger, Mattenenge 13
-– Heinr., Wagenführer S S. B.. Rütlistr. 11
+– Heinr., Wagenführer S S. B., Rütlistr. 11
 – Karl, Gipser, Stöckackerstr. 65, Bümpliz
 – Lydia, Ladentochter, Kirchackerweg 5, Bümpliz
 – Rosalie. Damenscbneiderin. Rütlistr. 14
@@ -5080,7 +5079,7 @@ Laden: Schauplatzgasse 33 [31.357]
 Bloch, Alph., Kaufmann, Spitalackerstr 59 [32.502]
 – Alice. Verkäuferin. Luisenetrasse 13
 – Arthur, Viehhändler, Monbijoustrasse 34 [24.060]
-– Bert., Kaufm.. in Fa. Bloch & Co.. Monbijoustrasse 12 [24.664]
+– Bert., Kaufm., in Fa. Bloch & Co., Monbijoustrasse 12 [24.664]
 – Camille, Kaufmann, Jägerweg 16 [23.157]
 – Charles (Bollag), Privat., Jägerweg 16 [33.564]
 – Emma, Damenschneiderin, Frohbergweg 6
@@ -5094,15 +5093,15 @@ Bloch, Alph., Kaufmann, Spitalackerstr 59 [32.502]
 # Date: 1935-12-15 Page: 26020358/55
 Bloch, Rob., Manufakturw., GesellschaftssIr. 45
 – Rob Max. Kaufmann, Monbijoustrasse 12
-– Susanna (Bühler), Wwe,, Elisabethenstr. 29
+– Susanna (Bühler), Wwe., Elisabethenstr. 29
 – Walter, Dr. jur., Fürsprech (Schulweg 1 [21.407]), Waaghausgasse 1/Ecke Marktgasse [24.243]
 – Willi, Handel in Nouveautes u. Mercerie (Gotthelfstrasse 18 [25.324]), Kornhausplatz 3 [20.910]
 – & Co., Brennerei, Likör- u. Sirupfabrik, Import u. Export v. Spirituosen, Schulweg la—c [22.332]
 Blocher, Alb., Küferei u. Weinhandlung, Gerechtigkeitsgasse 36 [35.960]
 – Jakob M., Hilfsarbeiter, Schmiedweg 7
-– Louise Kath,, Lehrerin, Spitalackerstr. 5 [20.987]
+– Louise Kath., Lehrerin, Spitalackerstr. 5 [20.987]
 – Marie, Spitalackerstrasse 5 [20.987]
-Block, Karl Jul.. Steindrucker. Bubenbergstrasse 12b
+Block, Karl Jul., Steindrucker. Bubenbergstrasse 12b
 Biohorn, Rosalie, Fabrikarbeiterin, Kramg. 60de Blonay, Richard Henri Sigism., Instruktionsoffizier, Laubeckstrasse 56 [35.360]
 Blora, Luigi, Maurer, Engehaldestrasse 22
 Blösch, Ad. (Stöcker), Violinlehrerin, Bonstettenstrasse 16 [32.794]
@@ -5139,7 +5138,7 @@ Blunschy
 Blum, Hermann, Beamter der SBB, Beundonfeldstrasse 16
 – Joh., Viehhändler, Pestalozzistrasse 13
 – Jos. A., Maschinenzeichner, Sonneggring 6
-– Josef, Vertreter. Forsthausweg 12
+– Josef, Vertreter, Forsthausweg 12
 – Joseph, Portier, Bümplizstrasse 38
 – Karl Theodor, Kaufmann, Monbijoustr. 22 [28.282]
 – Lucien Jac., Kaufmann, Belpstrasse 16
@@ -5172,7 +5171,7 @@ Nationalbank, Beaumontweg 16 [36.747]
 – S. (Heiniger), Dr. phil., Lehrer, Myrtenweg 12, Bümpliz [46.234]
 – Walter, Ingenieur, topogr. Bureau, Alpenstrasse 13 [35.217]
 – Willy, Schlosser-Chauffeur, Kasernenstr.41
-Blunier, Alfr., Fabrikarbeiter. Bierhübeliw.31
+Blunier, Alfr., Fabrikarbeiter, Bierhübeliw.31
 – Ed. Rudolf, Hilfsarbeiter, Bahnstrasse 61
 – Ernst Arth., Cavist, Scheuermattweg 6
 – Ernst. Hilfsarbeiter, Bahnstrasse 61
@@ -5186,8 +5185,6 @@ Blunier, Alfr., Fabrikarbeiter. Bierhübeliw.31
 – Walter, Vertreter, Scheibenstrasse 22 [22.655]
 – Werner Göttlieb. Landwirt, Bümplizstr. 95
 Blunschy, Leonz, Weinhändler, Eigerplatz 10 [32.069], Keller: Gerechtigkeitsgasse 29 [26.015]
-Gasöl
-Prompte Bedienung Sciineider&Rindlisbacherzu Konkurrenzpreisen christoffelgasse 4 - Tel. 21 .191
 # Date: 1935-12-15 Page: 26020359/56
 Bluntschli, Georg, Oberst, Sektionschef E.M.D., Jungfraustrasse 30 [20.085]
 – Hans, Dr. med., Professor für Anatomie, Aebistrasse 9 [20.280]
@@ -5195,7 +5192,7 @@ Bluntschli, Georg, Oberst, Sektionschef E.M.D., Jungfraustrasse 30 [20.085]
 Boas, Arne Holst, dipl. Ingenieur, Ostring 38 [33.867]
 Bobaing, Ceeile H. E., Sprachlehrerin, Oberweg 2
 – J. Helene (Graf), Wwe., Oberweg 2
-Bobillier, Hel. Martha, Ladentochter. Beundenfeldstrasse 3
+Bobillier, Hel. Martha, Ladentochter, Beundenfeldstrasse 3
 – Marg. Hedwig, Verkäuferin, Beundenfeldstrasse 3
 – Martha, Damenschneiderin, Beundenfeldstrasse 3 [34.639]
 Bobst, Benj. (Brügger), Kanzleisekretär imeidg. Kav.-Remontendepot, Thunstrasse 89 [21.995]
@@ -5210,7 +5207,7 @@ Bocchetti, Elsa Anita, Ladentochter, Lorrainestrasse 2a
 Boch, Martha Lydia, Bureaulistin, Zeughausgasse 9
 Bocherens, J. Susanne, Angestellte, Effingerstrasse 12
 Bochsler, Alfr. Edw., Kaufmann, Emanuel-Friedlistrasse 25
-– Emanuela Emma. Ladentochter. Bühlstr. 37
+– Emanuela Emma. Ladentochter, Bühlstr. 37
 – Frieda, vormals C. Abys, Herrenmode, Damenneuheiten, Kinderkonfektion (Bühlstrasse 37), Spitalgasse 38 [33.510]
 – Otto, Beamter beim Generalstabsbureau, Bitziusstrasse 3 [35.609]
 – Paul, Import, Kommission, Export, Emanuel-Friedlistrasse 25 [33.689]
@@ -5228,7 +5225,7 @@ Bodenehr, Adele Johanna. Bureauangestellte, Seftigenstrasse 10a
 Bodenmann, Armand, Laborant, Brunnmattstrasse 67
 – Hans, kaufm. Angestellter, Tiefmattstr. 15
 – — Herm., Dr., eidg. Beamter, Fischerweg 18 [29.930]
-Bodini, Anna, Wwe.. Konradweg 1
+Bodini, Anna, Wwe., Konradweg 1
 Bodinoli, Elvezio, Früchte u. Gemüse (Stadtbachstrasse 26), Murtenstrasse 1
 Bodmer, Alb., Metzger, Gerbergasse 7
 – Alb. Jakob, Schmied, Murtenstrasse 26
@@ -5254,10 +5251,10 @@ Bögli, Albert Ernst, Polizist, Attinghausenstrasse 21
 – Ernst, Fabrikarbeiter, Tunnelweg 8
 – Ernst Jakob. Kaufmann, Neufeldstr. 127
 – Ernst, Pferdewärter, Breitfeldstrasse 28
-– Ernst, städt. Beamter. Gewerbestrasse 31
+– Ernst, städt. Beamter, Gewerbestrasse 31
 – Flora Henriette, Bureaulistin, Gutenbergstrasse 10 [26.382]
 – Frieda Kl. (Gammeter), Wwe., Verkäuferin, Neufeldstrasse 5
-– Friedr.. Postangestellter, Freiburgstr. 117a
+– Friedr., Postangestellter, Freiburgstr. 117a
 – Friedrich (Juillerat), alt Seminar-Lehrer, Monbijoustrasse 9 [36.477]
 – Fritz, Spediteur, Kramgasse 3
 – Gottfr., Maurer, Tunnelweg 8
@@ -5308,8 +5305,8 @@ Böhlen, Bertha, Ladentochter, Murtenstr. 39
 – Gottfr. (Kramer), Käser, Engehaldenstr. 55
 – Gottlieb. Fabrikarbeiter, Winterholzstr. 45, Bümpliz
 – Hans Otto, eidg. Angest., Melchthalstr.il
-– Herm.. Monteur, Bundesrain 12
-– Joh. Rob.. Elektrotechn., Länggassstr. 27
+– Herm., Monteur, Bundesrain 12
+– Joh. Rob., Elektrotechn., Länggassstr. 27
 – Joh. G., Hilfsarbeiter, Jurastrasse 35
 – Joh., Polizist, Murtenstr. 217, Bümpliz
 – Marie, Bureaulistin, Schwarzenburgstr. 4
@@ -5363,7 +5360,7 @@ Bohnert, Josef Ant., Automaler, Spitalackerstrasse 24
 – Rudolf, Ausläufer, Spitalackerstrasse 24
 Bohni, Henri A., Angestellter, Malerweg 15
 Böhr, Otto (Linggi), elektromech. Werkstätte (Waldblickstrasse 4, Wabern [34.079]), Mattenenge 9 [34.448]
-Bohren, Alb., Postangestellter. Birkenweg 44
+Bohren, Alb., Postangestellter, Birkenweg 44
 – Alfr., Telephonmonteur, Berchtoldstr. 23
 – Cath. Luise, pens. Aufseherin, Gruberstrasse 4
 – Christ., Restaurant Obstberg, Bantigerstrasse 18
@@ -5372,7 +5369,7 @@ Bohren, Alb., Postangestellter. Birkenweg 44
 – Ernst, Magaziner, Genfergasse 8
 – Frieda, Bureaulist., Morgenstr. 6, Bümpliz
 – Friedr., Bankangestellter, Sulgenbachstr.10
-– Friedr.. Buchbinder, Allmendstrasse 33
+– Friedr., Buchbinder, Allmendstrasse 33
 – Fritz, Milchbändler, Rodtmattstrasse 106 [31.012]
 – Gottfr., Kinoangest., Gerechtigkeitsg. 22
 # Date: 1935-12-15 Page: 26020361/58
@@ -5385,7 +5382,7 @@ Bohren, Hs., Postbeamter, G.esellschaftsstr. 37
 – Marie. Glätterin, Bollwerk 31
 – Martha, Vertreterin, Ferd.-Hodlerstr. 18
 – Rosa, Gruberstr. 4
-– Rosa (Scholl), Wwe.. Ferd.-Hodlerstr. 18
+– Rosa (Scholl), Wwe., Ferd.-Hodlerstr. 18
 – Rudolf, Schreiner, Scheibenstrasse 19a
 – Verena Elisabeth (Pulver), Wwe., Allmendstrasse 33
 – Werner. Ausläufer. Postgasse 32
@@ -5406,7 +5403,7 @@ Boillat, Cecile (Quartier), « Paris-Modes » (Mittelstrasse 61), Neubrückstras
 – Roland R., Bankangest., Rainmattstr. 18
 Boinay, Emil P. (Hubacher), Bankbeamter, Länggassstrasse 59
 Bois-Fleury, Pension, Riedweg 17 [23.970]
-Boisard, Louis E. (Mühlethaler), pens. Bereiter. Stauffacherstrasse 8
+Boisard, Louis E. (Mühlethaler), pens. Bereiter, Stauffacherstrasse 8
 Boivin, Chs., Kaufmann, Thunstrasse 13
 – Friedr., in Fa. Boivin, Kilchenmann & Co., Viktoriarain 17 [27.799]
 – Kilchenmann & Co., Buchdruckerei u. Lithographie, Spitalackerstrasse 51a [25.670]
@@ -5416,10 +5413,10 @@ Boll, Ernst Emil, pens. Beamter, Greyerzstrasse 40
 – Hulda Maria, Telephonistin, Greyerzstr. 40
 Bolla, Gabr., Früchtehandlung, Seidenweg 20
 Bollag, J., Verwaltungsrat der Textil-A.-G., Sulgenauweg 8 [23.070]
-Bolle, Leon Ernst, Postbeamter. Weissensteinstrasse 32
+Bolle, Leon Ernst, Postbeamter, Weissensteinstrasse 32
 – Marie (König), Privatiere. Bubenbergpl. 4
 Boiler, Anna, Stellenvermittlungsbur. Exactus, Schauplatzgasse 11
-– Franz G., Hilfsarbeiter. Mattenhofstr. 35
+– Franz G., Hilfsarbeiter, Mattenhofstr. 35
 – Julius Friedr., Kalkulator, Dietlerstr. 14
 – Robert, Spengler, Gerechtigkeitsgasse 15
 – Robert, Ernst, Goldschmied. Gerechtigkeitsgasse 15
@@ -5503,8 +5500,8 @@ Bongard, Georges Ed. (Leonhard), Maler, Polygonweg 25
 Bongni, Luise, Krankenpflegerin, Stauffacherstrasse 29
 Bonhßte, Eric (Durand), Adjunkt, Lerherstrasse 22 [28.329]
 Böni, Jakob. Kalkulator. Waffenweg 4
-– Joh.. kaufm. Angest., Breitfeldstrasse 44
-– Joh.. Kontrolleur. Breitfeldstrasse 44
+– Joh., kaufm. Angest., Breitfeldstrasse 44
+– Joh., Kontrolleur. Breitfeldstrasse 44
 – Joh. Ulrich, Schlosser, Kramgasse 19a
 – Maria, Bureaulistin, Waffenweg 4
 Bonjour, Ernest, Beamter O. P. D., Finkenhubelweg 30 [36.965]
@@ -5512,13 +5509,14 @@ Bonjour, Ernest, Beamter O. P. D., Finkenhubelweg 30 [36.965]
 – Johanna (Stalder), Wwe., Jubiläumsstr. 68
 – Marie (Schüler), Wwe., Wabernstrasse 20 [35.709]
 – William L., Wagenmaler, Belpstrasse 14
-Bon Marche, Au, A -G.. Nouveautes. Mercerie, Lingerie, Spitalgasse 3 [27 511]
+Bon Marche, Au, A -G., Nouveautes. Mercerie, Lingerie, Spitalgasse 3 [27 511]
 Bonna, Pierre Ghs. Ls., Minister, Brügglerweg 9 [20.872]
 Bonnet, Alfred, Redaktor, Riedweg 19
 – Anna L., Brückfeldstrasse 38
 – Klara (Krapf), Wwe., Jungfraristrasse 2 [31.118]
 – Louise A., Bureaulistin, Brückfeldstr. 38
-Bonny, Jules August, Postbeamter, Armandweg 5v. Bonstetten, A. W Charles, Prokurist, Oranienburgstrasse l [23.508]
+Bonny, Jules August, Postbeamter, Armandweg 5
+v. Bonstetten, A. W Charles, Prokurist, Oranienburgstrasse l [23.508]
 – Albert, Ing. E. T. H., Direktor der städt. Strassenbahnen (Eigerplatz 3 [27.788]), Eigerplatz 3 [23.121]
 – Walter M., Dr. jur., Feldeggweg 6 [24.294]
 Bonzanigo, Riccardo, Abteilungssekretär beimeidg. Amt für geistiges Eigentum, Florastrasse 6
@@ -5530,7 +5528,8 @@ Bonzon, Alexis (Mössinger), kaufm. Angest., Stauffacherstrasse 27
 – Gust. Ad., Postbeamter, Lorrainestrasse 48de Boor, Helmut. Dr. phil., Professor, Asterweg 7 [25.041]
 Bopp, Bertha, Bureaulistin, Aarbergerg. 32
 – Joh., Postangesteliter, Jurastrasse 17
-Borbely, Jean. Coiffeur, Speichergasse 35v. Borck, Marie (Mayer), Wwe., Länggassstrasse 27
+Borbely, Jean. Coiffeur, Speichergasse 35
+v. Borck, Marie (Mayer), Wwe., Länggassstrasse 27
 Bordoli, Alfredo Emesto, Coiffeur, Marktgasse 69 [35.954]
 – G. (Messmer), Marktgasse 69
 Bordoni. Angelo, Maler, Waldheimstrasse 25
@@ -5601,7 +5600,7 @@ Handelsbank, Länggassstrasse 28 [35.231]
 – Martha F., Verkäuferin, Gesellschaftsstr. 73
 – Paul (Hartmann), Plattenleger, Marzilistrasse 28
 – Rosa (Rothen), Wwe., Seftigenstrasse 23
-– Wilhelm, Beamter. Sulgenrain 6
+– Wilhelm, Beamter, Sulgenrain 6
 Bornand, Alfr., Chauffeur, Murtenstrasse 131
 – Berta (Lattmann), Arbeitslehrerin, Luternauweg 5
 – Charlotte (Savoie), Sek.-Lehrerin, Haspelweg 38
@@ -5649,7 +5648,7 @@ Böschenstein, Ed., Bureauangest., Wyttenbachstrasse 33
 # Date: 1935-12-15 Page: 26020364/61
 Boschetti, J. G. A. (Rohner), Zollbeamter, Dalmaziweg 65
 Böschung, Alois (Charmartin), Bremser der S. B. B., Güterstrasse 36
-Böse, Willi W.. Schneider, Schönauweg 10
+Böse, Willi W., Schneider, Schönauweg 10
 Bösiger, Alice Bertha, Ladentochter, Schlossstrasse 119
 – Bertha (Ammonn), Militärstrasse 61
 – Charles (Kunkler), Schlossstrasse 119
@@ -5661,7 +5660,7 @@ Bösiger, Alice Bertha, Ladentochter, Schlossstrasse 119
 – Gottfr., Postbeamter, Viktoriastrasse 65
 – Gottl., Schneidermeister, Marktgasse 47 [35.605]
 – H. (Solenthaler), städt. Beamter, Greyerzstrasse 31 [36.706]
-– Jakob, Hausmeister der S. B. B.. Hochschulstrasse 6
+– Jakob, Hausmeister der S. B. B., Hochschulstrasse 6
 – Joh. J., Postbeamter, Hochfeldstr. 93 [21.009]
 – Johanna Christina, Melchenbühlweg 56
 – Johannes, Chauffeur, Standstrasse 8
@@ -5726,7 +5725,7 @@ Bossard, s. auch Bossart u. Bosshard
 – Hans, Elektromechan., Altenbergstrasse 40
 – Hans (Gruber), Angestellter O. T. D., Lorrainestrasse 74
 Bossart, Hans, Geometer, Bitziusstrasse 5
-– & Co.. A.-G., Teppiche, Linoleum, Artikelf. Innendekoration, Effingerstrasse 1 und Monbijoustrasse 6 [28.546]
+– & Co., A.-G., Teppiche, Linoleum, Artikelf. Innendekoration, Effingerstrasse 1 und Monbijoustrasse 6 [28.546]
 Bossel, Marcel, Kondukteur S. B. B., Brunnmattstrasse 46
 Bossert, Jak. Alfr., Typogr., Freiestrasse 46
 – Walter, Monteur, Gesellschaftsstrasse 77
@@ -5751,7 +5750,7 @@ Bosshard u. Bosshardt, s. auch Bossard und Bossart
 – Joh. Alfr., kaufm. Angest., Könizstrasse 45
 – Jul., Beamter d. S. B. B., Neubrückstr. 55a [36.511]
 – Julius Edmund, Kaufmann, Balderstr. 31 [34.637]
-– Karl Jos.. Coiffeur. Turnweg 21
+– Karl Jos., Coiffeur. Turnweg 21
 – Marg. (Böhrscli), Wwe., Kapellenstrasse 22
 – Martha, Bureaulistin der S. B. B., Falkenweg 11
 – Martha, Sekretärin, Kanonenweg 14
@@ -5774,7 +5773,7 @@ Botta, Giovanni, Beamter des eidg. Militärdepartements, Wyttenbachstrasse 18
 Bottani, Nello G., Bauingenieur, Bärenplatz 7
 Bottelini, C. G., Maurer, Brunngasse 14
 Botteron, Arthur Robert, Techniker, Viktoriarain 12
-– R. (Zahnd), Wwe.. Monbijoustrasse 20
+– R. (Zahnd), Wwe., Monbijoustrasse 20
 Bottinelii, Francesco Rocco, Maler, Kramg. 50
 – G. Battista, Skulpt., in Fa. Gianni & Co., Murtenstrasse 64
 – Stefano, Bildhauer, Murten9trasse 64
@@ -5807,7 +5806,7 @@ Bourquin, Charles E. (Juleni), Schreiner, Federweg 39
 – Marie, pens. Beamtin, Altenbergstrasse 53 [29.099]
 – Pierre Ferd., Postbeamter, Engeriedweg 9
 – Rene J. V., Postbeamter, Kapeilenstr. 7
-– Roger Ami. eidg. Beamter. Steigerweg 17
+– Roger Ami. eidg. Beamter, Steigerweg 17
 Bous, Georg Wilh., Buchhändler, Heimstr. 22, Bümpiiz
 Bova-Scoppa, Renato, I. Sekretär der kgl. italienischen Gesandtschaft, Elfenstrasse 14
 Bovard, Fritz (Brönnimann), Ing. in Fa. Bovard & Cie., Kornhausstrasse 12 [28.109]
@@ -5816,8 +5815,7 @@ Bovay, Berthe, Beamtin S. B. B., Sulgeneckstrasse 36
 – Jules (Perrottet), Magaz., Holzikofenweg 7
 – Marcel J. E. G., Dr. jur., eidg. Beamter, Luisenstrasse 43
 Bovet, Andree A., Klavierlehrerin, Oh. Dufourstrasse 29 [25.279]
-– Fel. (Matthey), Geschäftsführer d. Schweiz.
-Agentur des Blauen Kreuzes, Lindenrain 5 [29.857]
+– Fel. (Matthey), Geschäftsführer d. Schweiz. Agentur des Blauen Kreuzes, Lindenrain 5 [29.857]
 – Madeleine Fr., Bureaulistin, Ob. Dufourstrasse 29
 – Georges (Blonay), Dr. jur., Bundeskanzler, Obere Dufourstrasse 29 [25.279]
 – Rieh. (Grisel), Fürsprecher, Publizist, Marienstrasse 35 [22.445]
@@ -5894,7 +5892,7 @@ Brand, s. auch Brandt
 – C. F., Schriftsetzer, Viktoriastrasse 91
 – Christ., Tscharnerstrasse 11
 – Emil, eidg. Beamter, Graffenriedweg 12
-– Emil, Malermeister. Aarbergergasse 48
+– Emil, Malermeister, Aarbergergasse 48
 – Emil, Maschinist. Stockerenweg 5
 – Emil Hugo, Fürsprecher, Willadingweg 26
 – Emma, Bureaulistin, Bümplizstrasse 146
@@ -5926,13 +5924,13 @@ Brand, s. auch Brandt
 – Karl (Wyler), Gasarbeiter, Martiweg 15
 – Klara, Bureaulistin, Eggimannstrasse 25
 – Klara, Stockerenweg 5
-– Lina M.. Leiterin, Zähringerstrasse 24
+– Lina M., Leiterin, Zähringerstrasse 24
 – Lina (Brand), Wwe., Wyttenbachstr. 37
 – Martha, Modistin, Bundesrain 14
 – Martha (Stucki), Wwe., Willadingweg 26 [32.023]
 – Max, Fürsprecher, Büro Wetli (Neufeldstrasse 105), Spitalgasse 35 [21.894]
 – Max. Gärtner, Jurastrasse 25a
-– Max H.. Bankprokurist, Muristrasse 48
+– Max H., Bankprokurist, Muristrasse 48
 # Date: 1935-12-15 Page: 26020367/64
 Brand, s. auch Brandt
 – Max O., Beamter, Parkstrasse 48
@@ -5963,7 +5961,7 @@ Brandenberg, Albert, Vertreter der Firma O. Steimle, Sperrholzlager, Moserstrass
 – F. X. J., pens. Tramangestellter, Schwarztorstrasse 53a
 – Franz Xaver, Kaufmann, Schwarzenburgstrasse 20
 – Franz Xaver, Spengler, Schwarzenburgstrasse 20
-Brandenberger, Alfr. Arth., Kaufmann. Pilgerweg 5 . [27.975]
+Brandenberger, Alfr. Arth., Kaufmann. Pilgerweg 5 [27.975]
 – Ernst, Beamter der S. S. B., Pestalozzistrasse 1 [27.358]
 – Ernst, pens. Telephonmonteur, Könizstr. 79
 – Fritz, Mechaniker, Könizstrasse 77
@@ -6044,7 +6042,7 @@ Braun, Alfred, Hilfsarbeiter, Brünnenstr. 110, Bümpliz
 – Felix Henri, Journalist, Jubiläumsstr. 54
 – Friedr., Karrer, Zaunweg 23
 – Friedr. A., kaufm. Angest., Kyburgstr. 3
-– Friedr. Georg, Postbeamter. Kyburgstr. 3
+– Friedr. Georg, Postbeamter, Kyburgstr. 3
 – Hedwig, Ladentochter, Schifflaube 16
 – Hermann, Coiffeur, Ladenwandstrasse 45
 – Hermann Friedr., Badgasse 35
@@ -6129,7 +6127,7 @@ Brechbühl, Otto, Architekt, in Fa. Salvisberg & Brechbühl, Muristrasse 8d [23.
 – Paul Alb., Handlanger, Pestalozzistr. 40
 – Paul Otto, Milchträger. Brückfeldstr. 20
 —Rud. Ulr., Schneidermeister, Polygonw. 19
-– Walter Arnold. Bureauangestellter. Moserstrasse 25 [27.658]
+– Walter Arnold. Bureauangestellter, Moserstrasse 25 [27.658]
 – Walter Otto, Kaufmann, Freiestrasse 30
 – Walter, Mech., Stöckackerstr. 107, Bümpliz
 – Walter, Möbelschreiner, Quartierhof 8a
@@ -6186,7 +6184,7 @@ Brendel, O. A., Schneider, Brückenstrasse 12
 – O. A. P., Schriftgiesser, Flurstrasse 20
 Brendlin, Alfr., Hufschmied, Militärstrasse 46
 Brendow, Augusta Louisa, Verkäuferin, Schwarztorstrasse 59
-– J.. Schriftsetzer. Schwarztorstrasse 59
+– J., Schriftsetzer. Schwarztorstrasse 59
 Brenn, Ed., Schausteller, Militärstrasse 36
 Brennecke, E. Walter, Dr., Zahnarzt (Wabern- Bellevuestrasse 112a [45.509]), Bärenplatz 9 [21.465]
 Brenneisen, Max, Elektromonteur, Südbahnhofstrasse 4
@@ -6200,7 +6198,7 @@ Breny, Eugenia E., Näherin, Freiburgstr. 52
 – J. G. F., I. Sektionschef der eidg. Versicherungskasse, Sonnenbergrain 39 [32.812]
 Brenzikofer, Anna, Haushälterin, Elfenauw.il
 – Chr. (Blatter), Schlosser, Schöneggweg 22
-– Ernst. Wärter. Waldau
+– Ernst. Wärter, Waldau
 – Hans, Chauffeur, Grüner Weg 9
 – Hermine. Bureaulistin. Schöneggweg 22
 – Joh. Friedr., Schuhmachermeister, Flurstrasse 1
@@ -6246,7 +6244,7 @@ Bristol, Hotel (Hunziker, R.), Spitalgasse 21 u. Schauplatzg. 10 [20.101] (Café
 Britische Gesandtschaft, Kanzlei, Thunstr. 48 [21.913]
 Britisches Konsulat, Bundesplatz 2 [24.108]
 Britschgi, Peter, Hilfsarbeiter, Postgasse 50
-Britt. Jean. Bankangestellter. Trachselweg 27
+Britt. Jean. Bankangestellter, Trachselweg 27
 Brockenhaus und Bücherantiquariat des Vereins zur Unterstützung durch Arbeit, Gerechtigkeitsgasse 60 [29.830]
 Bröckelmann, Hermann, Graphiker, Gesellschaftsstrasse 4
 Brodbeck, Anna (Grimm), Wwe., Gotthardweg 13
@@ -6349,7 +6347,7 @@ Brönnimann, Friedr., Lokomotivführer, Dübystrasse 24
 – Ida (Meyer), Wwe., Polygonweg 11
 — Joh. Alfr., Karosserieschmied, Spitalg. 37
 – Joh., Fabrikarbeiter, Rossfeldstrasse 19
-– Joh. Friedr.. Maurer, Buchweg 7. Riedbach
+– Joh. Friedr., Maurer, Buchweg 7. Riedbach
 – Joh. Karl, Kaminfegermstr., Gesellschaftsstrasse 72 [36.572]
 – Joh. Rudolf, Handlanger, Lerchenweg 28
 – Joh., Postillon, Belpstr 43
@@ -6382,7 +6380,7 @@ Brönnimann, Paul Arthur (Wahrenberger), kant. Beamter, Steigerweg 14
 – Walter, Hilfsarbeiter, Gerbergasse 34
 – Walter, Bankangestellter, Burgunderstr. 29, Bümpliz
 – Werner, Wirt, Neuengasse 25 [27.765]
-– Werner Friedrich, städt. Beamter. Karl-Staufferstrasse 20 [24.722]
+– Werner Friedrich, städt. Beamter, Karl-Staufferstrasse 20 [24.722]
 – Wilh., Verbandssekretär, Morgenstrasse 62, Bümpliz [46.214]
 Brosi, s. auch Brosy
 – B. (Schmid), Wwe., Muesmattstrasse 26
@@ -6406,7 +6404,7 @@ Bronarski, Alphonse, Pressebeirat der poln.
 Gesandtschaft, Marktgasse 11
 Brouty, Barth., Bibliothekar, Herzogstrasse 3 [36.641]
 Brown, Boveri & Cie., A.-G., techn. Bureau, Spitalgasse 9 [24.362]
-Brüchsei, E.. pens. Beamter d. S.B.B., Moserstrasse 34
+Brüchsei, E., pens. Beamter d. S.B.B., Moserstrasse 34
 – Ernst, Bankangestellter, Moserstrasse 34
 Bruck, Jakob, Privatier, Beundenfeldstr. 18 [27.298]
 – Z., Dr rer. pol., in Fa. J. Kaufmann & Co., Helvetiastrasse 50 [24.569] j
@@ -6522,7 +6520,7 @@ Brüllmann, Adolf (Häfele), Hotelangestellter, Murifeldweg 26
 Brumann, Franz A. J., Dr. med., Spezialarzt für innere Krankheiten (Villettengässchen 41 [42.497]), Marktgasse 24 [28.784]
 – Jakob. Autopiechaniker, Bümplizstrasse 12
 Brun, Alfred, Uhrmacher, Neufeldstrasse 125
-– Alphons. Konzertmeister. Direktor d. Konservatoriums für Musik, Steinerstrasse 33 [23.570]
+– Alphons. Konzertmeister, Direktor d. Konservatoriums für Musik, Steinerstrasse 33 [23.570]
 – Blanche A. Elisabeth, Musiklehrerin, Steinerstrasse 33
 – Fanny (Spyri), Privatiere, Steinerstr. 33
 – Fritz, Dr. phil., Musikdirektor, Elfenauweg 41 [32.126]
@@ -6551,7 +6549,7 @@ Brunner, Adolf, Zigarrier, Neubrückstr. 74
 – Alfred, pens. Kassier des Metallarbeiterverbandes, Länggassstrasse 34
 – Alfred, Konditor, Thunstrasse 18
 – Alfred (Schlienger), Schriftsetzer, Dietlerstrasse 14
-– Alice, Ladentochter. Freiburgstr. 352, Bümpliz
+– Alice, Ladentochter, Freiburgstr. 352, Bümpliz
 Brunner, Alma, Verkäuferin, Seilerstrassc 22
 – Anna Elise. Weissnäherin, Fischerweg 4
 – Anton, Beamter S. B. B., Zähringerstr. 48
@@ -6562,10 +6560,9 @@ Brunner, Alma, Verkäuferin, Seilerstrassc 22
 – Bertha, Ladentochter, Herrengasse 12
 – Cecile (Marti), Wwe., Glätterin, Birkenweg 22
 – Edm. Luk., Telegr., Neubrückstrasse 74
-– Eduard Karl Emil, Dr. jur., eidg. Beamter.
-Aegertenstrasse 65 [35.863]
+– Eduard Karl Emil, Dr. jur., eidg. Beamter. Aegertenstrasse 65 [35.863]
 – Elisabeth Marg., Fabrikarbeiterin, Seidenweg 29
-– Elise (Dardel), Wwe.. Steinauweg 5
+– Elise (Dardel), Wwe., Steinauweg 5
 – Emil, Bankbeamter, Effingerstrasse 37
 – Emil Arn (Gurtner), Hilfsarbeiter, Polygonweg 25
 – Emil, Schriftsetzer, Freiburgstrasse 352, Bümpliz
@@ -6580,25 +6577,25 @@ Aegertenstrasse 65 [35.863]
 – Ernst, Verwaltungsbeamter S. B. B., Neufeldstrasse 111
 – Ernst, Wagenmaler, Martiweg 15
 – Erwin, Schriftsetzer, Freiburgstrasse 352, Bümpliz
-– F. Herm.. Chauffeur. Seidenweg 3
+– F. Herm., Chauffeur. Seidenweg 3
 – Fr Adolf (Anderegg), gew. Landwirt
 Länggassstrasse 102
 – Franz A., Angestellter, Zieglerstrasse 33
 – Frieda, Giletnäherin. Martiweg 15
-– Frieda (Bauer). Wwe.. Hopfenweg 17
+– Frieda (Bauer). Wwe., Hopfenweg 17
 – Frieda (Schmid), Wwe., Steinauweg 18
 – Friedrich, Angestellter d. Generaldirektionder Schweiz Volksbank. Marktgasse 50
 – Friedr., Angestellter, Rodtmattstrasse 99
-– Friedr.. Beamter, Länggassstrasse 14 [29.598]
+– Friedr., Beamter, Länggassstrasse 14 [29.598]
 – Friedr., pens. Schulabwart, Rodtmattstr. 54
 – Fritz, Beamter der B. K. W., Bonstettenstrasse 3
 – Fritz (Schiatter), Kassier der Schweizer.
 Volksbank, Marzilistrasse 24
-– Fritz. Telegr.-Angestellter. Hopfenweg 17
+– Fritz. Telegr.-Angestellter, Hopfenweg 17
 – Gebhard, Schriftsetzer. Bümplizstrasse 122
 – Georg E. M., Reisender, Spitalackerstr. 23 [29.208]
 – Gottfr., Magaziner, Federweg 39
-– Gottfr., Metzgermstr.. Bühlstr. 35 [21 045]
+– Gottfr., Metzgermstr., Bühlstr. 35 [21 045]
 – Hanna, Lehrerin, Lorbeerstr. 5, Bümpliz
 – Hans Max, Bankangestellter, Schwarztorstrasse 11
 – Hans Rud., Elektrotechniker, Eichmattw. 7
@@ -6617,7 +6614,7 @@ Brunner, Hans Xaver, Mech., Murtenstr. 153c
 – Ida (Ryser), Privatiere, Greyerzstrasse 23
 – Jakob (Schmid), kant. Beamter, Gotthelfstrasse 14 [25.849]
 – Jakob, Beamter B. L. S., Bümplizstrasse 14
-– Joh., Hilfsarbeiter. Jurastrasse 91
+– Joh., Hilfsarbeiter, Jurastrasse 91
 – Joh., Tanzlehrer, Falkenplatz 24 [29.832]
 – Joh., Tramangestellter, Martiweg 15
 – Joh. Andreas, Zollbeamter, Gartenstr. 1
@@ -6647,8 +6644,8 @@ Brunner, Hans Xaver, Mech., Murtenstr. 153c
 – Raget O., Musikpädagoge, Obere Dufourstrasse 45 [33.229]
 – Rosette (Spichiger), Wwe., Eichmattweg 7
 – Sophie, Schneiderin, Vereinsweg 1
-– Th., Dr jur.. Fürspr. u Notar, Advokaturu. Notariatsbureau (Neuengasse 26), Laupenstrasse 7 [24.633]
-– Theoph.. Gepäckarbeiter d. S. B. B., Sennweg 13
+– Th., Dr jur., Fürspr. u Notar, Advokaturu. Notariatsbureau (Neuengasse 26), Laupenstrasse 7 [24.633]
+– Theoph., Gepäckarbeiter d. S. B. B., Sennweg 13
 – Walter Erw., Techniker, Mühlemattstr. 14
 – Werner, Tarifbeamter der S. B. B., Neufeldstrasse 99
 Brunner, Werner (Thalmann), Dr. ing., Hochfeldstrasse 102
@@ -6813,7 +6810,7 @@ Herrengasse 19 [26.376]
 – Fritz, Buchdrucker, Marienstr. 3 [27.733]
 – Gertrud Marie, Beundenfeldstrasse 11
 – G., & Cie., Schuhhdlg. und Massgeschäft, Kramgasse 71 [23.449]
-– Gottfr., in Fa. G. Büchler & Cie.. Weststrasse 17 [33.753]
+– Gottfr., in Fa. G. Büchler & Cie., Weststrasse 17 [33.753]
 – Gottfr. Joh., Schuhhandlung (Weststr. 17 [33.753]), Marktgasse 13 [21.141]
 – Gottfr., Maurer, Wasserwerkgasse 14
 – Hans, Dr. med., Arzt, Sulgeneckstrasse 27 [28.860]
@@ -6849,7 +6846,7 @@ Buchs, Alfons Marcel, Beamter, Gantrischstrasse 22 [27.236]
 Buchsbaum, Helene S. (Iseli), Wwe., Kosmetikinstitut, Schauplatzgasse 39 [31.106]
 Buchschacher, Adolf Ulrich, in Fa. O. U. Buchschacher & Sohn, Terrassenweg 10
 – Elise, pens. Filialleiterin, Sulgeneckstr. 36 [28.878]
-– Karl Friedr.. in Fa. K. Buchschacher & Cie., Neubrückstrasse 89 [21.621]
+– Karl Friedr., in Fa. K. Buchschacher & Cie., Neubrückstrasse 89 [21.621]
 – K., & Cie., Installationsgeschäft für sanitäre Anlagen, Entstaubungsanlagen und Zentralheizungen, Werkstatt: Effingerstrasse 6a, Bureau: Neubrückstrasse 87 [21.621]
 – Otto U., Unternehmer, in Fa. O. U. Buchschacher & Sohn, Terrassenw. 10 [32.411]
 – O. U. & Sohn, Installationsgeschäft für sanitäre Anl., Grabenpromenade 5 [29.569]
@@ -6903,7 +6900,7 @@ Bühler, s. auch Bueler
 – Anna (Nyffenegger), Wwe., Hallerstr. 24
 – Anna (Baumann). Wwe. des Oberpostkontrolleurs, Hallerstrasse 56
 – Anton, pens. Schneider, Grundweg 14
-– Aug. A. E.. Hilfsarbeiter, Ivasernenstr. 19
+– Aug. A. E., Hilfsarbeiter, Ivasernenstr. 19
 – Berta, Beamtin, Museumstr. 12 [36.489]
 – Chr. W., Tapezierer, Junkerngasse 16
 – Christ. Gottfr., Molkereiangestellter, Pestalozzi strasse 25
@@ -6911,7 +6908,7 @@ Bühler, s. auch Bueler
 – E. (Bütikofer). Bankangest., Pappelweg 5
 – E. (Waller), Wwe., Spitalgasse 30 [27.009]
 – E Fritz, Schlosser, Freiburgstrasse 117a
-– El Frieda B.. Beamtin, Könizstrasse 63
+– El Frieda B., Beamtin, Könizstrasse 63
 – Ernst (Studer), Magaziner, Tscharnerstrasse 21
 – Ernst, Telegr.-Beamter der G.-D. P. T. T., Brünnenstrasse 97, Bümpliz
 – Ernst. Büchsenmacher, Steigerweg 13
@@ -6977,12 +6974,12 @@ Bühlmann, Adolf, Metzger, Schwarzenburgstrasse 25
 # Date: 1935-12-15 Page: 26020378/75
 Bühlmann, Alfred E., Lokomotivführer, Falkenweg 19
 – Alois. Sattler, Giiterstrasse 34
-– Anton Jos.. Postbeamter, Brückfeldstr. 37
+– Anton Jos., Postbeamter, Brückfeldstr. 37
 – Aug. (Conrad), Frau, Monbijoustrasse 28 [34.250]
 – Bertha (Moser), Wwe., Moserstrasse 12
 – Bertha (Wenger), Wwo., Hochfeldstr. 110 [33.470]
 – Christ., Ausläufer b. Volkswirtschafts-Departement. Aarstrasse 108
-– Ed.. Hilfsarbeiter, Freiburgstr. 378, Bümpliz
+– Ed., Hilfsarbeiter, Freiburgstr. 378, Bümpliz
 – El. Madl., Telephonistin, Sulgenbachstr. 45
 – Ella Frieda, Bureauiistin, Forsthausweg 3
 – Elise (Stöcker), Wwe., Gerbergasse 27
@@ -7011,7 +7008,7 @@ Bühlmann, E., & Co.  📞 21.810 Buchdruckerei und Verlag, Verlag des Amtsblatt
 – H Schlossermeister (Kapellenstr. 2), Monbijoustrasse 17
 – Hans, Buchdrucker, Aegertenstrasse 13
 – Hans, kautm. Angest., Hochfeldstrasse 110
-– Hans R.. Schriftsetzer. Niesenweg 10
+– Hans R., Schriftsetzer. Niesenweg 10
 – Hans Rud., Schreiner, Aarstrasse 108
 – Hedwig, Bureauiistin, Rütlistrasse 4
 – Hedwig, Telephonistin, Hochfeldstr. 110
@@ -7019,7 +7016,7 @@ Bühlmann, E., & Co.  📞 21.810 Buchdruckerei und Verlag, Verlag des Amtsblatt
 – Hermann Walter, Automechaniker. Monhijoustrasse 28
 – Hermann (Gindrat), Techn., Soidenweg 12
 – Ida Elsbeth, Lehrerin, Höheweg 11 [36.732]
-– J. Friedr.. Notar, Bcrchtoldstr. 44 [28.861]
+– J. Friedr., Notar, Bcrchtoldstr. 44 [28.861]
 – Jakob. Mech-Werkfiihror. Freiestrasse 40
 – Jakob (Streit), Schlosser, Muesmattstr. 15a
 – Joh. Christian, Metzger, Metzgergasse 24
@@ -7055,7 +7052,7 @@ Bühlmann, Jos. Ant., Gipser- u. Malermeister, Gartenstrasso 6 [33.775]
 – Yvonne H., Bureauiistin, Moserstrasse 12
 – & Cie., Schweisserei-Materiahen u. Farben, Münzrain 1 (Fabrik: Aegerten bei Brügg)
 Buholzer, Emma (Binggeli), Pens., Schwarztorstrasse 5 [27.199]
-– Marie J., Ladentochter. Weststrasse 17
+– Marie J., Ladentochter, Weststrasse 17
 Bührer, Anna Marie, Schneiderin, Allmendstrasse 35
 – Friedr., Kaufm., Habsburgstr. 9 [36.580]
 – Jonatb E., kaufm. Angest., Hopfenweg 22
@@ -7127,7 +7124,8 @@ v. Büren, Anna (v. Salis), Wwe., Sulgeneckstrasse 19, Blumenrain [21.589]
 – Günther, Dr., Assistent am botan. Institut, Rainmattstrusse 3 [35.254]
 – Meta (v. Bondeli), Wwe., Wabernstr. 49 [31.698]
 – Walter, in Fa. C. Aug. Egli & Cie., Zürich, Kirchenfeldstrasse 37 [36.218]
-– Wilhelm, Elektriker, Thunstrasse 25v. Burg, Adolf, Maler, Landoltstrasse 53
+– Wilhelm, Elektriker, Thunstrasse 25
+v. Burg, Adolf, Maler, Landoltstrasse 53
 – Edwin, Mechaniker, Weissenbühlweg 4
 – Hans (Lenzinger), Sekretär im eidg. Justizund Polizeidepartement, Kalcheggweg 4 [21.206]
 – Viktor. Zimmermann. Kirchbergerstr. 2
@@ -7178,7 +7176,7 @@ Burger, Emma, Falkenhöheweg 14
 – Walter, Elektromechan., Gewerbestr. 29
 – Walter Edw., Piqueur, Allmendstrasse 44
 – Werner August, Beamter S. B. B., Gesellschaftsstrasse 75
-– Werner A.. Handlanger, Krippenstr. 16
+– Werner A., Handlanger, Krippenstr. 16
 – Wilh. A., Monteur, Zähringerstrasse 52
 Bürgerhaus, Neuengasse 20/22 [24.631]
 Burgerkanzlei, Bundesgasse 4 [24.305]
@@ -7190,7 +7188,7 @@ Bürgerliches Forsthaus, Bremgartenwald, Revier II, Murtenstrasse 94 [31.061]
 Bürgerliches Forsthaus. Schermenwald. Revier III Papiermühlestrasse 120 [32.289]
 Bürgermeister, August (Pfenniger), Revisorder O. T. D., Monbijoustrasse 45
 – Elise (Leuenberger), Wwe., Lmsenstr.il
-– K., Sattler, in Fa. Rüfenacht & Bürgermeister. Bottigenstrasse 23, Bümpliz
+– K., Sattler, in Fa. Rüfenacht & Bürgermeister, Bottigenstrasse 23, Bümpliz
 – Ruth A., Bureaulistin, Monbijoustrasse 45
 Bürger-Partei der Stadt Bern, Sekretariat, Bürgerhaus, Neuengasse 20 [23.957]
 Burger-Spital, Bubenbergplatz 4, Verwaltung [23.301], Einzieher [31.305], Filialen: Bogenschützenstrasse 6 [29.110], Dapplesweg 16 [35.618], Laupenstrasse 27 [22.262], Schwanengasse 7 [25.934]
@@ -7201,7 +7199,7 @@ Burghold, Karl, Heizer S. B. B., Wattenwylweg 27
 Bürgi, Ad., gew. Departementssekretär des Schweiz. Justiz- und Polizeidepartements, Beundenfeldstrasse 19
 – Alfred (Scherler), Sekretär d. eidg. Steuerverwaltung, Landhausweg 32
 – Alfred E., Postbeamter, Kniislihuhelweg 23
-– Dora E.. Kochlehrerin, Gutenbergstr. 15
+– Dora E., Kochlehrerin, Gutenbergstr. 15
 – E., Expedient, Finkenrain 6
 – Emil, Prof Dr. med., Direkt, d. med.-chem.und pharrnak. Inst., Inselspital, Kalcheggweg 24 [22.744]
 – Emil (Moser), Handlanger, Jurastrasse 24
@@ -7286,7 +7284,7 @@ Buri, s. auch Burri
 – Emiiie Agathe (Blum), in Fa. Wwe. Buri & Cie., Vereinsweg 14 [27.362]
 – Ernst, Vorsteher der Konsummolkerei, Konsumstrasse 20
 – Franz, Handlanger, Ladenwandstr. 27
-– Friedrich, Hilfsarbeiter. Wachtelweg 17
+– Friedrich, Hilfsarbeiter, Wachtelweg 17
 – Fritz, Kaufmann, Beaulieustr. 15 [28.079]
 – Hans B., Malermeister, Gerechtigkeitsg. 41
 – Heinr., Arch., Waldheimstr. 29 [23.184]
@@ -7312,7 +7310,7 @@ Burkard u. Burkart, siehe auch Burckhardt, Burkhard und Burkhardt
 – Josephine, Lehrerin, Sonnenbergrain 43
 – Olga Bertha, Angestellte, Wyttenbachstr 15
 – Otto Alb., Versicherungsbeamter, Wylerstrasse 81
-– Paul Ed., Angestellter. Wyttenbachstr. 15
+– Paul Ed., Angestellter, Wyttenbachstr. 15
 – Peter, Postangestellter, Sonnenbergrain 43
 Burkhaiter, Adelheid Lse., Bureaulistin, Weissenbühlweg 12
 – Anna, Fürsorgerin, Neufeldstrasse 114
@@ -7335,7 +7333,7 @@ Burkhaiter, Adelheid Lse., Bureaulistin, Weissenbühlweg 12
 – Friedr. (Pärli), Gipser- u. Malermeister, Trechselstrasse 2 [35.805]
 – Friedr., Schmied, Sodweg 3
 – Fr., Stempel- und Graviergeschäft, Aarbergergasse 42 [35.487]
-– Friedr.. Tyoograph, Mühlemattstrassp 68
+– Friedr., Tyoograph, Mühlemattstrassp 68
 – Fritz P. (Balmer), Kaufmann, Schilling– Fritz. Schlosser. Schifflaube 16
 – G., Coiffeurgeschäft, Neuengasse 36
 – Gottl. (Gammeter), Coiffeurgeschäft, Thunstrasse 105 [36.395]
@@ -7345,35 +7343,35 @@ Burkhaiter, Adelheid Lse., Bureaulistin, Weissenbühlweg 12
 – Hulda Martha, Ladentochter, Breitfeldstrasse 48
 # Date: 1935-12-15 Page: 26020382/79
 Burkhalter, Ida, Beamtin, Breitfeldstrasse 48
-– Ida (Rüfenacht). Wwe.. Breitfeldstr. 48
+– Ida (Rüfenacht). Wwe., Breitfeldstr. 48
 – Jakob, March -Tailleur, Rainmattstr. 15
-– Jb Ed., pens. Beamter. Flurstrasse 32
+– Jb Ed., pens. Beamter, Flurstrasse 32
 – Joh., Chauffeur, Gerechtigkeitsgasse 3
 – Joh., Reisender, Effingerstrasse 88
 – Joh., gew. Fabrikarbeiter, Felsenaustr. 28
-– Joh.. Fabrikarbeiter. Tunnelwes 10
+– Joh., Fabrikarbeiter, Tunnelwes 10
 – Joh., Kaufmann, Gryplienhüheliweg 21 [27.624]
 – Joh., Maler u. Prokurist, Mühlemattstr. 66
 – Johann Werner, Maler, Veilchenweg 9, Bümpliz
 – Joh., Privatier. Weissensteinstrasse 60
 – Joh., Hilfsarbeiter, Mühlemattstrasse 66
-– Joh. Jak.. Pferdewärter, Breitfeldstr. 49
-– Joh.. Sohn. Pferdewärter. Wiesenstr. 66
-– Lina (Steiner), Wwe.. Schreibmaschinenzubehör (Weissenbühlweg 12), Spitale 27 [33.066]
+– Joh. Jak., Pferdewärter, Breitfeldstr. 49
+– Joh., Sohn. Pferdewärter, Wiesenstr. 66
+– Lina (Steiner), Wwe., Schreibmaschinenzubehör (Weissenbühlweg 12), Spitale 27 [33.066]
 – Lina. Frl., Ladentochter, Beaumontweg 38
 – Margarithe, Zuschneiderin, Obere Villettenmattstrasse 8
-– Marie, Ladentochter. Breitfeldstrasse 48
+– Marie, Ladentochter, Breitfeldstrasse 48
 – Max Sam., Maschinenmeister, Zähringerstrasse 54
 – Nelly, Reklamezeichnerin, Stalden 32
 – Rosa, Bureaulistin. Optingenstrasse 5
-– Rosette (Steiner). Wwe.. Blumensteinstr. 8
+– Rosette (Steiner). Wwe., Blumensteinstr. 8
 – Rud Bend., pens Eisenbahner. Alleeweg 8
-– Rud., Hilfsarbeiter. Scheibenstrasse 38
+– Rud., Hilfsarbeiter, Scheibenstrasse 38
 – Rud. Friedr., Monteur, Kyburgstrasse 7
-– Walter. Monteur Seidenweg 14
+– Walter, Monteur Seidenweg 14
 – Werner P., Bäcker. Sonneggring 15
-– Werner. Hilfsarbeiter. Talweg 9
-– Wilh. Fr. Hrch.. Hilfsarb . Schifflaube 22
+– Werner. Hilfsarbeiter, Talweg 9
+– Wilh. Fr. Hrch., Hilfsarb., Schifflaube 22
 – Willy. Optiker, Neuengasse 36 [34.683]
 Burkhard, s. auch Burckhardt, Burkart und Burkhardt
 – Adolf Eugen, Maschinentechniker, Rabbentalstrasse 65
@@ -7382,8 +7380,8 @@ Burkhard, s. auch Burckhardt, Burkart und Burkhardt
 – Arnold Em Lehrer. Höheweg 34
 – Arnold (Wild), Reisender, Papiermühlostrasse 1 ia
 – Arth. Osk., Zollbeamter, Seilerstrasse 27
-– Bertha. Speichergasse 13
-– C., Frl.. Damen- und Herrenhutgeschäft (Thunstrasse 19 [33.698]), Aarbergerg. 63 [31.344]
+– Bertha, Speichergasse 13
+– C., Frl., Damen- und Herrenhutgeschäft (Thunstrasse 19 [33.698]), Aarbergerg. 63 [31.344]
 – Elisabeth (Ritter). Wwe., Thunstrasse 19
 – Elis. Rosina, Frau, Federweg 21
 – Ernst, Bankangestellter, Thunstrasse 19
@@ -7393,24 +7391,24 @@ Burkhard, s. auch Burckhardt, Burkart und Burkhardt
 – Eugen, Spengler, Erikaweg 8 [26.101]
 – Fr. E., gew. Stationsvorstand, Bernstr. 94, Bümpliz
 – Flora, Postbeamtin, Thunstrasse 19
-– Frieda Bertha. Münsterplatz 6
+– Frieda Bertha, Münsterplatz 6
 – Frieda, Schneiderin, Thunstrasse 19
-– Friedr.. Buchhalter u Prok.. Seidenweg 66
+– Friedr., Buchhalter u Prok., Seidenweg 66
 – Friedr., Buchhalter, Terrassenweg 4
 – Friedr., Säger, Murtenstr. 390, Bümpliz I
 Burkhard, s. auch Burckhardt, Burkart und Burkhardt
 – Fritz. Bureaulist. Schöneggweg 21
 – Fritz (Sterchi), Lehrer, Neubrückstr. 114 [35.683]
 – Fritz, Schneider, Bahnhöhew. 32, Bümpliz
-– Gottl.. Bautechniker, Höheweg 34
+– Gottl., Bautechniker, Höheweg 34
 – Gust. Alph., Elektrotechniker. Könizstr. 59
 – Hans W., Giessereiarbeiter, Jurastr. 65
 – Hans Jakob, Postbeamter, Federweg 21
 – Hedwig, Bureaulistin, Bernstr. 94, Bümpliz
 – Hedwig, Ladentochter, Schwarztorstr. 59
-– Hugo Walter. Buchbinder. Militärstr. 39
+– Hugo Walter, Buchbinder. Militärstr. 39
 – Hulda E., Kürschnerin, Brunngasse 12
-– Ida (Graf). Wwe.. Schöneggweg 21
+– Ida (Graf). Wwe., Schöneggweg 21
 – Jakob. Spenglermeister, in Fa. J. Burkhardt & Söhne, Schmiedweg 6
 – Jak. Erw., Spengler, Schmiedweg 6
 – Joh. Friedr., Wirt z. Linde, Murtenstr. 21 [21.724]
@@ -7463,7 +7461,7 @@ Burkhardt, s. auch Burckhardt, Burkart und Burkhard
 – Mina Rosa, Ladentochter, Vereinsweg 6
 – Otto (Schütz), Buchdruckerei (Steinerstrasse 12 [32.143]). Postgasse 44 [34.864]
 – Paul Alfr., Buchbinder, Breitenrainpl. 40b
-– Walter Joh.. Buchhalter, Sennweg 17
+– Walter Joh., Buchhalter, Sennweg 17
 – Werner, Postangestellter, Gerbergasse 24
 Burkhardt & Cie. 21.955mechan. Holzscheiterei, Holz- und Kohlenhandlung, Seftigenstrasse 35
 — & Häberli, Schreinerei u. Aussteuergesch., Turnweg 33 [32.680]
@@ -7473,22 +7471,22 @@ Bürki, Ad., Ausläufer, Kramgasse 7
 – Adolf, Angest. G. W. B., Dammweg 7
 – Adolf. Kartograph b. d. eidg. Landestopographie, Bernastrasse 46 [29.186]
 – Albert, Monteur, Länggassstrasse 57
-– Albert, Hilfsarbeiter. Scheibenstrasse 25a
+– Albert, Hilfsarbeiter, Scheibenstrasse 25a
 – Albert, kaufm. Angest., Schwarztorstr. 3
 – Alex., Handlanger, Wasserwerkgasse 4
 — Alfr. O., Schlosser, Altenbergstrasse 13
-– Alfred, Landwirt, Freiburgstr. 385, Büm- .pliz
+– Alfred, Landwirt, Freiburgstr. 385, Bümpliz
 – Alfred, Güterarbeiter, Altenbergstr. 13i—Alfred, Buchhalter, Gesellschaftsstr. 17a [25.905]
 – Anna Bertha, Frl., Sulgenbachstrasse 59 [22.125]
 – Anna (Weber), Freie Strasse 60
 – Arthur, Lokomotivführer, Freiestrasse 60
-– Aug.. Installateur, Gerechtigkeitsgasse 71
+– Aug., Installateur, Gerechtigkeitsgasse 71
 – Bertha (Huber), Arbeitslehrerin, Moserstrasse 38
 — Bruno, Versieh.-Angest., Blumensteinstr. 17
 – Ed., Maler, Breitfeldstrasse 36
 – Ed. Gottl., Lok.-Führer, Drosselweg 5
 – Eduard, Waffenweg 25
-– Elisabeth (Ruchti). Wwe.. Brunngasse 28
+– Elisabeth (Ruchti). Wwe., Brunngasse 28
 – Elisabeth, Bureaulistin, Blumensteinstr. 17
 – Emil, Architekt, Wyttenbachstr.il
 – Emil, Glaserei, Schönburgstr. 46 [27.971]
@@ -7496,7 +7494,7 @@ Bürki, Ad., Ausläufer, Kramgasse 7
 – Emma (Schär), Wwe., Alpenstrasse 5
 – Emma, Marktgasse 37 [24.931]
 – Ernst, Ausläufer, Steckweg 3
-— Ernst, Bereiter. Herzogstrasse 9
+— Ernst, Bereiter, Herzogstrasse 9
 – Ernst, Gärtner, Murifeldweg 1
 Bürki, Ernst Arth., Kartograph, Blumensteinstrasse 15
 – Ernst Eduard, Metalldreher, Wylerfeldstrasse 35
@@ -7509,7 +7507,7 @@ Bürki, Ernst Arth., Kartograph, Blumensteinstrasse 15
 – Fr. (Glauser), Magaziner, Bersetweg 12
 – Frieda M., Bureaulistin, Scheuermattweg 6
 – Friedr., Einleger, Bümplizstrasse 75
-– Friedr.. Holz- und Kohlenhändler, Abendstrasse 54. Bümpliz
+– Friedr., Holz- und Kohlenhändler, Abendstrasse 54. Bümpliz
 – Friedr. (Brügger), Kaufm., Murtenstr. 137
 – Friedr., Postchauffeur, Beaulieustrasse 43
 – Fr. Rud., Elektromonteur, Lorrainestr. 62
@@ -7523,7 +7521,7 @@ Bürki, Ernst Arth., Kartograph, Blumensteinstrasse 15
 – Gertrud, Pelznäherin. Kramgasse 27
 – Gertrud, Rotkreuzpflegerin, Freiburgstr. 18
 – Gottfr., Hilfsarbeiter, Rodtmattstrasse 73
-– Gottfr.. Lampist. Sulgenbachstrasse 28
+– Gottfr., Lampist. Sulgenbachstrasse 28
 – Gottfr. (Willener), Maurerpolier, Lorrainestrasse 63
 – Gottfr., Schneidermeister, Herren- u. Damengarderobe, Viktoriarain 6 [34.210]
 – Gottfr., Telegr., Kasernenstr. 43 [20.855]
@@ -7532,7 +7530,7 @@ Bürki, Ernst Arth., Kartograph, Blumensteinstrasse 15
 – Hanna, Packerin, Stationsweg 38
 – Hanna Marg., Damenschneiderin, Scheibenstrasse 53
 – Hans W., Buchbinder, Mindstrasse 8
-– Hans, Hilfsbereiter. Papiermühlestrasse 13
+– Hans, Hilfsbereiter, Papiermühlestrasse 13
 – Hans (Tüscher), Hochbautechn., Belpstr. 14
 – Hans, Wirt, Cafe Fischermätteli, Holligenstrasse 70 [22.089]
 – Hans (Adolf), Schreiner, Graffenriedw. 14
@@ -7557,7 +7555,7 @@ Bürki, Hermine Gl. (Blaser), Wwe., Bureaulistin, Dalmazirain 36
 – Joh., Landwirt. Bümplizstr. 156 [46.261]
 – Johanna, Mittelstrasse 58
 – Karl, Polierer, Gerechtigkeitsgasse 6
-– Karl Konr.. Schreinermeister, Gerechtigkeitsgasse 6
+– Karl Konr., Schreinermeister, Gerechtigkeitsgasse 6
 – Karl Ludw., Lehrer, Kursaalstrasse 11
 – Karl Robert, Coiffeur, Aarbergergasse 20
 – Erwin E., Bautechniker, Schönburgstr. 46
@@ -7565,7 +7563,7 @@ Bürki, Hermine Gl. (Blaser), Wwe., Bureaulistin, Dalmazirain 36
 – M. (Scheibli), Wwe., Steinerstr. 41 [33.976]
 – Magdalena, Stenodactylographin, Sennw. 9
 – Marg. S., Wwe., Telegraphistin, Bantigerstrasse 26
-– Margar.. Ladentochter, Beundenfeldstr. 37
+– Margar., Ladentochter, Beundenfeldstr. 37
 – Marie, Damenschneiderin, Länggassstr. 57
 – Marie Frieda, Näherin, Belpstrasse 30
 – Marie, Heilsarmee-Offiz., Hochfeldstr. 95
@@ -7597,11 +7595,11 @@ Kinderkrankheiten F. M. H. (Belpstr. 14 [24.941]), Seilerstr. 3, Suvahaus [25.69
 – Walter Hans, Kaufmann, Friedheimweg 21 [23.412]
 – Walter Hans, Kaminfegermeister, Herrengasse 18 [33.958]
 – Walter, Kaufm., Friedheimweg 21 [23.412]
-– Walter, Kaufmann in Fa.. Bürki & Cie., Seftigenstrasse 6 [36.019]
+– Walter, Kaufmann in Fa., Bürki & Cie., Seftigenstrasse 6 [36.019]
 – Walter, Monteur, Frohbergweg 6
 – Werner, Bauschreiner, Altenbergstr. 57
 – Werner, Bureauangestellter, Hallerstr. 50
-– Werner, Chauff.. Sägehofweg 19, Bümpliz
+– Werner, Chauff., Sägehofweg 19, Bümpliz
 – Werner Paul, Kässalzer, Könizstr. 39a
 – Wilh. Hch., Maler, Mattenhofstrasse 23
 Bürki & Cie., Käsehandlung en gros, Sulgenbachstrasse 49 [22.105]
@@ -7617,14 +7615,13 @@ Burn, Anna Mina Luise, Ladentochter, Marktgasse 25, Eingang Amthausgässchen 3
 – Gertr. Frieda, Ladentochter, Gesellschaftsstrasse 75
 – Gottfr. Heinr., Angest., Berchtoldstr. 43 [29.740]
 – Hans Rob., Lehrer, Berchtoldstrasse 43
-– Hans, Tapezierermeister. Breitenrainstr. 79
+– Hans, Tapezierermeister, Breitenrainstr. 79
 – Joh. (Berger), pens. Lehrer, Berchtoldstrasse 43
 – Joh., Hilfsarbeiter, Scheibenstrasse 19
 – Paul Arth., Reise-Kino, Waisenhauspl. 27 [24.236]
 – Rob., Schuhmachermeister, Wylerfeldstr.40
 – Walter, Drogist. Breitenrainstrasse 79
-Burnens, Julien (Golay), Conseiller pres la
-Legation du Japon, Effingerstr. 40 [21.389]
+Burnens, Julien (Golay), Conseiller pres la Legation du Japon, Effingerstr. 40 [21.389]
 Burnier, Emile (Derron), Lokomotivheizer der S. B. B., Gesellschaftsstrasse 70
 – Louis Oskar, Berchtoldstrasse 54
 – Margr. Lina, Verkäuferin, Gerechtigkeitsgasse 64
@@ -7646,7 +7643,7 @@ Burren, Alfr., Privatier, Niederbottigenw. 86, Bümpliz
 – Ernst, Monteur, Seftigenstrasse 97
 – Friedr., Handlanger, Morgenstr. 6. Bümpliz
 – Fritz, Geschäftsleiter, Maulbeerstrasse 14
-– Gottl.. Installateur, Sandrainstrasse 74
+– Gottl., Installateur, Sandrainstrasse 74
 – Hans, Angestellter, Sandrainstrasse 74
 – Hans Herm., Packer, Scheuerrain 6
 – Ida, Hebamme, Schanzenstrasse 23
@@ -7673,7 +7670,7 @@ Bealabteilung des städt. Gymnasiums, Brunnadernstrasse 5 [32.758]
 – Albertina H., Coiffeuse, Stauwehrrain 8
 – Albr., Schneidermstr., Gesellschaftsstr. 18a
 – Aiex., Bahnarbeiter, Turnweg 27b
-– Alfr., Fabrikarbeiter. Felsenaustrasse 54
+– Alfr., Fabrikarbeiter, Felsenaustrasse 54
 – Alfr., Sattler, Freieckweg 6, Bümpliz
 – Alice Margr., Hilfsarbeiterin, Wylerringstrasse 47
 – Anna Verena, Kassierin, Hochbühlweg 3
@@ -7681,7 +7678,7 @@ Bealabteilung des städt. Gymnasiums, Brunnadernstrasse 5 [32.758]
 – Anna El. (Hirsclii), Wwe., Altenbergstr. 20
 – Armand, Masch.-Schloss., Wylerringstr. 41
 – Arthur, Bauschlosser, Fichtenweg 3
-– A.. Frau, Koloniahvarenhandlung, Hopfenweg 40
+– A., Frau, Koloniahvarenhandlung, Hopfenweg 40
 – Berta, Assistentin der städt. Schulzahnklinik, Effingerstrasse 69
 – Bertha A. M., Haushälterin, Hallerstr. 39
 – Gajus, Linosetzer, Moserstrasse 33
@@ -7723,7 +7720,7 @@ Burri, s. auch Buri
 – Ernst, Versieh.-Vertreter, Jolimontstr. 12
 – Erwin Fr., Autospengler, Breitenrainstr. 19
 – Franz, Gärtner, Neuengasse 5
-– Frieda Gertr . Bureaulistin. Allmendstr. 39
+– Frieda Gertr., Bureaulistin. Allmendstr. 39
 – Friedr. (Gosteli), Angest., Wylerringstr. 45
 – Friedr., Chauffeur, Hopfenweg 40
 – Friedr., Coiffeur, Kesslergasse 16
@@ -7760,13 +7757,13 @@ Burri, s. auch Buri
 – Herm. W., Schreiner, Allmendstrasse 42a
 – Ida. Damenschneiderin, Morgenstrasse 13, Bümpliz
 – J. Rud. (Müller), Magaziner, Schwarzenburgstrasse 9
-– Jakob, Hilfsarbeiter. Flurstrasse 5
+– Jakob, Hilfsarbeiter, Flurstrasse 5
 – Jakob, Metzgermeister, Marzilistrasse 7 [32.468]
 – Joh., Reichenbachstrasse 76
 – Joh., Automechaniker, Gutenbergstrasse 7
 – Joh., Karrer, Aarbergergasse 48
 – Joh. Alfr., Notar, Militärstrasse 56
-– Joh.. Sattler, Bümplizstrasse 52
+– Joh., Sattler, Bümplizstrasse 52
 – Joh., Schuhmachermeister, Cäcilienstr. 48
 – Joh., Schuhmachermeister, Herzogstr. 18
 – Joh. Otto, Progymnasiallehrer, Hochfeldstrasse 96 [29.268]
@@ -7789,26 +7786,26 @@ Burri, s. auch Buri
 – Oskar, Ausläufer, Turnweg 27b
 – Paul Alex., Bahnangestellter, Turnweg 27b
 – Paul Ant., Kanzlist, Zielweg 9
-– Paul, Bahnangestellter. Blumensteinstr. 5
+– Paul, Bahnangestellter, Blumensteinstr. 5
 – Paul, Schlosser, Weissenbühlweg 23
-– Rob.. Gasarbeiter, Badgasse 47
+– Rob., Gasarbeiter, Badgasse 47
 – Rob Jos., Prof. Dr. phil., Vorstand dermilchwirtschaftl. Anstalt Liebefeld. Manuelstrasse 93 [34.565]
 – Rob., Hilfsarbeiter, Standstrasse 28
-– Rob. Christ.. Maschinist, Zeughausgasse 1
-– Rosa Th.. Spezereihandlung. Jurastr. 19
+– Rob. Christ., Maschinist, Zeughausgasse 1
+– Rosa Th., Spezereihandlung. Jurastr. 19
 – Rosa, Frau, Schneiderin, Kramgasse 53
-– Rosa (Ruchti), Wwe.. Wylerringstr 41
+– Rosa (Ruchti), Wwe., Wylerringstr 41
 – Rosa (Zimmermann). Wwe., Breitenrainstrasse 19
 – Rosette (Hofer), Privatiere, Brünnenstr. 96, Bümpliz
 – Rud. Herm., Lehrer, Zähringerstrasse 29 [29.665]
 – Rud., Bäcker, Metzgergasse 76
 – Rud., Bahnwärt., Wangenstr. 125, Bümpliz
-– Rud., Bauarbeiter. Lenzweg 9
+– Rud., Bauarbeiter, Lenzweg 9
 – Rud., Maurer, Sägehofweg 9, Bümpliz
-– Rud.. Privatier. Aebistrasse 2
+– Rud., Privatier. Aebistrasse 2
 – Ursula Kath., Pflegerin, Waisenhauspl. 25
 Burri, s. auch Buri
-– Walter. Bäcker, Lentulusstrasse 46
+– Walter, Bäcker, Lentulusstrasse 46
 – Walter (Dänzer), Bereiter, Murifeldweg 29
 – Walter, Spengler, Postgasse 58
 – W. F. K., Schriftsetzer, Wagnerstrasse 11
@@ -7822,7 +7819,7 @@ Burtscher, Franz Hugo, Dr. med., Arzt, Kapellenstrasse 8 [31.448]
 Burzio, Maria, pens. Fabrikarbeiterin, Tunnelweg 3
 Busag, A.-G., Klischeefabrik, Monbijoustr. 49 [22.883]
 Busam, Joseph, Coiffeur, Postgasse 6b
-– J.. & Svhild, E.. Coiffeurgeschäft, Kesslergasse 29
+– J., & Svhild, E., Coiffeurgeschäft, Kesslergasse 29
 Büsch, Ernst, Postbeamter, Lombachweg 28 [35.576]
 – Fl. Fortunat. Bankangest., Helvetiastr. 35
 – Katharina (Gnipper), Wwe., Helvetiastr. 35
@@ -7831,14 +7828,14 @@ Büschi, Alfred, Eisenarbeiter, Graffenriedw. 10
 – Dora Gertrud. Telephonistin, Martiweg 12
 – Emil. Schlosser. Martiweg 12
 – Eug. Emil, Kaufmann, Raineggweg 3
-– Gottl.. Handlanger, Altenbergstrasse 30
+– Gottl., Handlanger, Altenbergstrasse 30
 – Lydia. Verkäuferin, Graffenriedweg 10
 – Robert, Dekorateur, Graffenriedweg 10
 – Robert, Postbeamter, Effingerstrasse 41
 Buschke, Wilhelm. Dr. med., Assistenzarzt, Lorystrasse 16 [24.507]
-Buser, A A.. Beamter der Güterexpedition, Stadtbachstrasse 42
+Buser, A A., Beamter der Güterexpedition, Stadtbachstrasse 42
 – Albin Aug., Bautechn., Seftigenstrasse 20 [29.207]
-– Alfred, Postbeamter. Jubiläumsstrasse 61
+– Alfred, Postbeamter, Jubiläumsstrasse 61
 – Alice, Schönheitspflege, Gurtengasse 6 [25.099]
 – Anna Elisäb. (Trachsel), Wwe., Zieglerstrasse 35 [23.613]
 – Arnold, dipl. Landwirt, Giessereiweg 9 [27.939]
@@ -7846,7 +7843,7 @@ Buser, A A.. Beamter der Güterexpedition, Stadtbachstrasse 42
 – Ernst, Revisor S. B. B., Hochfeldstr. 107 [26.147]
 – Ernst Fr., Tapezierer, Badgasse 51
 – Ernst Theophil. Mechaniker Alleeweg 11a
-– Fr.. Werkmeister. Wasserwerkgasse 1
+– Fr., Werkmeister, Wasserwerkgasse 1
 – Frieda, Fabrikarbeiterin, Gerbergasse 7a
 – Frieda (Blau). Wwe. des eidg. Oberpferdearztes, Zeughausgasse 39
 – Fritz. Mechaniker. Wasserwerkgasse 1
@@ -7882,7 +7879,7 @@ Busslinger, Isidor, Genfergasse 7
 Busson, Jules Josef, Kaufmann, Spitalackerstrasse 64
 Busti, Gertrud, Modiste, Bridelstrasse 31
 – J. G., Maurer, Bridelstrasse 31
-– Marg.. Bureauangestellte, Bridelstrasse 31
+– Marg., Bureauangestellte, Bridelstrasse 31
 Butacon A.-G., Verwertung von Erfindungen, Patenten usw., Marktgasse 17
 Bütikofer, Albrecht, Kaminfeger, Seidenw. 33
 – Alex., Handlanger, Gesellschaftsstr. 32
@@ -7928,7 +7925,7 @@ Bahnhof-Reklamen, Kanonenweg 14 [36.009]
 – Othmar, Instruktionsoffizier, Alter Aargauerstalden 9 [28.841]
 – Otto Ed., Lehrer, Bernstr. 86, Bümpliz
 – Rob., Ingenieur, Kornhausstr. 4 [32.641]
-– Rud.. Hausierer. Metzgergasse 78
+– Rud., Hausierer. Metzgergasse 78
 – Walter, Bahnarbeiter, Ralligweg 14
 – Walter W., Fabrikarbeiter, Metzgergasse 49
 – Werner, kaufm. Angestellter, Mittelstr. 54
@@ -8002,7 +7999,7 @@ Buzzi, Arturo, Maurer, Sägehof weg 9, Bümpliz
 – Mario L., Maurer, Stapfenackerstrasse 40, Bümpliz
 – Theresia (Benecchi), Wwe., Muldenstr. 48
 Buzzini, Elsa, Bureaulistin, Weissenbühlw. 8
-Byland, Lucie (Diacon). Wwe.. Schänzlistr. 19
+Byland, Lucie (Diacon). Wwe., Schänzlistr. 19
 – Rudolf J. (Giger),. Kellner, Kramgasse 44c.
 — (Vergl. auch Buchstabe K.)
 Cabalzar, Joh. F., Elektriker, Simplonweg 13
@@ -8014,7 +8011,7 @@ Cadisch, Padrutt (Trog), Fürspr., Erlachstrasse 22 [35.732]
 Caduff, J. G., Handlanger, Alleeweg 34
 – Wilhelm. Hotelangestellter, Spitalgasse 36
 Caflisch, Christoffel, Maurer, Brünnenstr. 75, Bümpliz
-– R. F., Schreinervorarbeiter. Sulgenbachstrasse 12
+– R. F., Schreinervorarbeiter, Sulgenbachstrasse 12
 – Rieh. (Büchi), Weststrasse 28 [32.648]
 – Rosa Margr., Bureaulistin. Sulgenbachstrasse 12
 – Willi Ernst, Maurer, Weststrasse 28
@@ -8060,10 +8057,10 @@ Cantieni, Domenic, Postbeamter, Wylerstr. 40
 – Orlando, Sek.-Lehrer, Schiösslistrasse 23
 Cantine, Kaserne (F. Lüthi), Papiermühlestrasse 15 [23.321]
 Canton, Jos. Clotilde. Modes (Viktoriastr. 49), Marktgasse 23 [35.763]
-C. A. P., Hilf- u. Rochtsschutzgesellschaft für Strassenbenützer A.-G.. Oeneralagenten P. Koenig & Grimmer, Hotelg. 1 [24.828]
+C. A. P., Hilf- u. Rochtsschutzgesellschaft für Strassenbenützer A.-G., Oeneralagenten P. Koenig & Grimmer, Hotelg. 1 [24.828]
 Capelli, Guido Giacomo, Maler, Metzgerg. 75
 Capeilo, Giulio, Kaufmann, Friedheimweg 51 [28.005]
-Capitol A.-G,, Schauplatzgasse 35
+Capitol A.-G., Schauplatzgasse 35
 Capitol-Cinema-Variete, Kramg. 72 [22.424]
 Cappelloza, Sam., Handlanger, Lorrainestr. 46
 Cappis, Oskar Bernhard, Dr. phil., Redaktor, Beaulieustrasse 21 [25.025]
@@ -8183,7 +8180,7 @@ Cerutti, PL (Hciinsch), Gipser- u. Malermstr. (Schänzlistr. 72 [32.484]), Zentr
 – V. (Bauer), Direktor Ryff & Co., A.-G., Pavillonweg 14 [33.827]
 Cesar, Pierre Jos., Fürspr., Advokaturbureau (Waldblickstrasse 31, Wabern [35.639]), Effingerstrasse 2 [28.234]
 CH Touring [28.222] «Die Schweiz», Führer für Automobilfahrer, Redaktion und Verlag, Breitenrainstrasse 97
-Chabus, Augustin L., Lehrmeister. Kyburgstrasse 9
+Chabus, Augustin L., Lehrmeister, Kyburgstrasse 9
 – Charles M., Küchenchef, Viktoriastr. 45
 – Georges, Werkzeugmacher, Viktoriastr. 45
 – Marcelle J., Bureaulistin, Viktoriastr. 45
@@ -8206,7 +8203,7 @@ Chapuis und Chappuis
 – Alphonse, Musiker, Pestalozzistrasse 34
 – Celine Octavie (Didierjean), Wwe. d. Oberrichters, Sulgenheimweg 9 [27.403]
 – Charles E., Postbeamter, Simonstrasse 21
-– Charles Rob.. Schriftsetzer. Länggassstr. 65
+– Charles Rob., Schriftsetzer. Länggassstr. 65
 – Eugene Osk., Beamter, Viktoriarain 17
 – Frieda, Frl., Privatiere, Südbahnhofstr. 15
 – Gaston, Verw. d. Apotheke Brändli, Effingerstrasse 50
@@ -8235,7 +8232,7 @@ Chardon, Francois H., Postbeamter, Cäcilienstrasse 27
 — Franz, Pianist, Wattenwylweg 3 [23.806]
 – Josephine (Burger), Wwe., Wattenwylw. 3
 Chariton, Sroul, Kaufmann, Monbijoustr. 51 [29.345]
-Charles, Arthur Francois, Dipl. Ing.. Tillierstrasse 50 [29.231]
+Charles, Arthur Francois, Dipl. Ing., Tillierstrasse 50 [29.231]
 – Henri Arthur, eidg. Beamter, Sulgenrain 4 [21.048]
 – Maurice A., Bankangestellter, Könizstr. 35
 Charlef, Alexis A. (Tzaut), pens. Postbeamter, Zähringerstrasse 28 [33.347]
@@ -8258,7 +8255,7 @@ Pochon-Jent, A,-G., Verlag des « Bund », Friedheimweg 22 [31.348]
 – Margr, Marie, Arbeitslehrerin, Mauerrain 1
 – Mina Marg., Verkäuferin, Cäcilienstr. 22
 – Otto, Glaser, Gäcilienstrasse 22
-– Walter. Tiefbauzeichner, Gäcilienstrasse 22
+– Walter, Tiefbauzeichner, Gäcilienstrasse 22
 Chavannes, Achille G. Chs., Versich.-Beamter, Brunnmattstrasse 68
 – Henri Edgar, Pfarrer, Kollerw. 9 [22.982]
 – Jean Charles Andre, Bankbeamter, Brunnadernstrasse 12a [24.210]
@@ -8280,7 +8277,7 @@ Cherpillod, Anna Marie (Ritter), Wwe., Egelgasse 55 [20.980]
 – Jules, Handlanger, Mattenenge 9
 Chervet, Daniel Rod., Dr. ing., Willadingw. 50 [31.620]
 – Ernst W., Hilfsarbeiter, Krippenstrasse 44
-– J. E.. Schreiner, Krippenstrasse 44
+– J. E., Schreiner, Krippenstrasse 44
 – Jean Jules, Magaziner, Krippenstrasse 44
 – Marie Pauline, Coiffeuse, Krippenstr. 44
 Chessex, Albert, Reisender, Hopfenrain 16 [32.669]
@@ -8294,7 +8291,7 @@ Chevalley, Alfr., Chauffeur, Weissensteinstr.68
 Chevre, Eduard, Kaminfeger, Kramgasse 49
 « Chez-moi », Heim für berufstätige Töchter, Steigerweg 7 [24.925]
 Chiesa, Luigia, eidg. Beamte, Depotstrasse 52
-– Natale, gew. Hafnermeister. Vennerweg 12
+– Natale, gew. Hafnermeister, Vennerweg 12
 Chilenische Handelskammer für die Schweiz:angeschlossen der Zentral-Handelskammerfür Latein-Amerika, Bubenbergplatz 8 [25.666]
 Chinesische Gesandtschaft, Willadingweg 23 [33.310]
 Chitro, Salmann, Reisender, Monbijoustr. 71
@@ -8406,7 +8403,7 @@ Christen, Ernst (Widmer), Metzgermeister (Steinauweg 28), Effingerstr. 4a [34.19
 – Hugo, Magaziner, Nydeckhof 45
 – Jeannette, Bureaulistin, Fabrikstrasse 3
 – Joh., Packer, Armandweg 9
-– Joh. Fritz, Bankbeamter. Gottl.-Kuhnweg 8
+– Joh. Fritz, Bankbeamter, Gottl.-Kuhnweg 8
 # Date: 1935-12-15 Page: 26020393/90
 Christen, Joh., gew. Beamter S. B. B., Hallerßtrasse 54 [31.405]
 – Joh., gew. Metzgermeister, Cäcilienstr. 19
@@ -8540,7 +8537,7 @@ Claus, Karl Friedrich, Bundesbahnbeamter, Stockerenweg 32
 Clausen, Augustin, Dienstmann, Belpstr. 49
 – J. D., Fabrikarbeiter, Felsenaustrasse 28
 – Otto, Massatelier u. Tuchhandlung (Aarbergergasse 7), Neuengasse 7 [23.778]
-Clauzel, Bertrand, Graf, französischer Botschafter. Sulgeneckstrasse 44
+Clauzel, Bertrand, Graf, französischer Botschafter, Sulgeneckstrasse 44
 Clavadätscher, Lina, Masseuse und Pedicure, Amthausgasse 22 [31.791]
 Clavadetscher, Paul, Vertrieb der Staubsaugapparate Vampir 35, chem.-techn. Produkte (Rosenweg 9b), Maulbeerstrasse 14, Sommerleisthaus [29.245]
 – Thomas, Wirt z. Innern Enge, Engestr. 54 [21.442]
@@ -8549,11 +8546,11 @@ Clemengon, Arthur Ch., Maler, Moserstr. 18
 – Henri M. (Jossi), kaufm. Angestellter, Schwarzenburgstrasse 4
 – Rene J., Postangestellter, Hallerstrasse 60
 Clement, Marie P. (Heimo), Wwe., Weingartstrasse 57
-Clenin. Joh. Ed.. Hilfsarbeiter. Seftigenstr. 47
+Clenin. Joh. Ed., Hilfsarbeiter, Seftigenstr. 47
 Clerc, Fritz Ed., Dr. med., Arzt, Sektionschefdes Bahnärztlichen Dienstes S. B. B., Neufeldstrasse 128
 – Julia, Bureaulistin, Kapellenstrasse 6
 – Julia A. (Longchamp), Wwe., Gotthelfstrasse 16
-– Louis Elie, Fürspr., eidg. Beamter. Gotthelfstrasse 16 [28.436]
+– Louis Elie, Fürspr., eidg. Beamter, Gotthelfstrasse 16 [28.436]
 Clerico, Guido A., Maler, Metzgergasse 18
 Clivio, Elis. P. (Spahni), Wwe., Peterweg 4, Bümpliz [46.053]
 Cloetta, Willy, Ingenieur, Dorngasse 6
@@ -8575,12 +8572,12 @@ Coenen, Maria Christ., Reisende, Balmweg 35
 Colla, Giovanni, Maurer, Länggassstrasse 29
 – Serafino, Koch, Läuggassstrasse 29
 Collaud, L. V., Dr., Adjunkt des Oberpferdearztes, Viktoriastrasse 82 [27.886]
-Colle, L.. Holzbildhauer u. Antiquar, Mattenhofstrasse 22
+Colle, L., Holzbildhauer u. Antiquar, Mattenhofstrasse 22
 Collin, Luise. Frl., Helvetiastrasse 9 [34.777]
 – Marguerite, Choisystrasse 21
 Collioud, Louis Ernst, in Fa. E. Collioud & Co., Weissensteinstrasse 87 [31.598]
 – & Co., E., photo-kartogr. Werkstätte, Weissensteinstrasse 87 [31.598]
-Collomb. Aug.. Sekuritaswächter. Seidenw. 43
+Collomb. Aug., Sekuritaswächter, Seidenw. 43
 – Ed., Sekuritaswächter, Berchtoldstrasse 48
 – Henri Roger, Zeichner. Mühlemattstrasse 37
 – Paul Jules, kaufm. Angestellter, Zähringerstrasse 31
@@ -8597,8 +8594,7 @@ Colombo, Alceo, Ausläufer, Metzgergasse 57
 – Pietro, Früchtehändler, Wagnerstrasse 27
 – Pietro, Monteur. Stöckackerstr. 79, Bümpliz
 – Rialdo, Maler, Rohrweg 8
-Coloprint A.-G. 22.413
-Photos und Kino, Spitalgasse 4
+Coloprint A.-G. 📞 22.413 Photos und Kino, Spitalgasse 4
 Columbische Gesandtschaft. Balmweg 22
 Columbisches Konsulat, Zeitglockenlaube 2 [24.044]
 Combe, Ida, Frh, gew. Lehrerin, Weissenbühlweg 29 [23.679]
@@ -8606,7 +8602,7 @@ Combe, Ida, Frh, gew. Lehrerin, Weissenbühlweg 29 [23.679]
 Gaswerkes, Weissenbühlweg 29 [23.679]
 – Math., Frl., Beamtin, Weissenbühlweg 29 [23.679]
 – Pierre Jean, Zeichner, Hallwylstrasse 38
-Commarmot, E M.. Kupferschmiedmeister (Schifflaube 16), Postgasse 6b [35.704]
+Commarmot, E M., Kupferschmiedmeister (Schifflaube 16), Postgasse 6b [35.704]
 – Erwin, Coiffeur, Kapellenstrasse 12
 – J. Alphons, Monteur und Badaufseher, Quartiergasse 25
 – Paul Edm., Hilfsmonteur, Quartiergasse 25
@@ -8636,7 +8632,7 @@ Coniungo A.-G., Patentverwertung, Belpstr. 39
 Conod, J. F., Diener, Laupenstrasse 17
 Conrad, s. auch Konrad
 – Anna, Frl., Luisenstrasse 41 [22.697]
-– Peter, Zollbeamter. Monbijoustrasse 22
+– Peter, Zollbeamter, Monbijoustrasse 22
 Conscience, Emelie (Fueg), Wwe., Hallerstr.19
 Constans, Marguerite, Heilsarmeeoffizierin, Viktoriastrasse 47
 Conie, Alessandro, Dr. jur., intern. Beamter, Junkerngasse 37 [34.012]
@@ -8654,13 +8650,12 @@ Conzett, A., Afficheur, Sulgeneckstrasse 60
 Coq d’Argent S. A., Geflügelzucht, Schauplatzgasse 11
 Corbat, Arthur Fr., kaufm. Angestellter, Kapellenstrasse 10
 – Marius Ernest, Sektionschef, Blumenbergstrasse 14 [26.025]
-Corbaz, Alb. Gabriel, Internat. Beamter. Humboldtstrasse 53 [27.557]
+Corbaz, Alb. Gabriel, Internat. Beamter, Humboldtstrasse 53 [27.557]
 – J. L., Spengler, sen., Neufeldstrasse 27f
 – Jules Louis (Schenk), jun., Mechaniker, Güterstrasse 36
 Corbet, Jeanne, Angestellte, Waisenhauspl. 15 [26.391]
 Corboud, Louis Georges M. (Brugger), Vertreter, Neufeldstrasse 128 [20.774]
-Corecco, Carlo Antonio, Beamter d. eidg. stat.
-Amtes, Marktgasse 11
+Corecco, Carlo Antonio, Beamter d. eidg. stat. Amtes, Marktgasse 11
 – Guido, eidg. Beamter, Karl-Schenkstr. 5
 Cornaz, Andre Fr., Lithograph, Ob. Aareggweg 6
 Corneli, Paul, Postbeamter, Erikaweg 12
@@ -8710,8 +8705,7 @@ Courvoisier, Andre, Redakteur, Scheuermattweg 14 [21.772]
 – C. Jean, Schuhmachermeister und Schuhhandlung (Viktoriarain 8), Herreng. 10 [36.717]
 – Georges Ernest, Mechan., Speichergasse 37
 – H. A., Schriftenmaler, Aarbergergasse 24
-Covera AG., Kommerzielle Vertretung aller
-Art, Liegenschaftshandel, Neubrückstr. 127 [33.784]
+Covera AG., Kommerzielle Vertretung aller Art, Liegenschaftshandel, Neubrückstr. 127 [33.784]
 Crastan, Gust., Bankbeamter, Grünerweg 11
 – Notta, Telephonistin, Kyburgstrasse 6
 – Valentina, Telephonistin, Greyerzstrasse 24
@@ -8747,14 +8741,14 @@ Cueni, s. auch Kühne und Kühni
 – Bernh. Jos., Ingenieur, Viktoriastrasse 61
 Cuenin, Arsene, Bautechniker, Kasernenstrasse 11b
 Cuennet, Rob. (Gubler), Mechaniker, Gesellschaftsstrasse 16
-Cuenod-Werke A.-G. (Sitz Genf), Morillonstrasse 4 . [27.857]
+Cuenod-Werke A.-G. (Sitz Genf), Morillonstrasse 4 [27.857]
 Cuerel, Hermann, Postkommis, Bantigerstr. 33
 Cugnolio, Adolf, Maurer, Greyerzstrasse 35
 – Ernst, Elektromonteur, Militärstrasse 63
 – Germinale, Gemüse- und Früchtehandlung (Wabern), Eigerplatz 2 [36.268]
 – Oreste, Meeh.-Chauffeur, Aarbergerg. 50
 Cuhat, Jeanne Marie, Krankenpflegerin, Wildhainweg 16
-da Cunha Mendonça e Menezes (Olhão), D. Jose, Dr. med.. Spezialarzt für innere und Nervenkrankheiten, Junkerng. 57 [28.737]
+da Cunha Mendonça e Menezes (Olhão), D. Jose, Dr. med., Spezialarzt für innere und Nervenkrankheiten, Junkerng. 57 [28.737]
 Cuonz, Elisa U., Ladentochter, Spitalgasse 31
 Cupelin, Lily Sus., Bureaulistin, Wabernstrasse 20
 – Martha (Gribi), Wabernstrasse 20 [21.850]
@@ -8766,7 +8760,7 @@ Curty, Rosa, Schneiderin, Brückfeldstr. 42
 Cuttat, Anna (Müller), Wwe., Glätterin, Kramgasse 32
 – Charles Alb., Attache, Junkerngasse 51 [32.602]
 – Paul, Angestellter, Schärerstrasse 21
-Cviljusac, Karl. Coiffeurmeister. Freiburgstrasse 167 [27.091]
+Cviljusac, Karl. Coiffeurmeister, Freiburgstrasse 167 [27.091]
 Czermak, K., Handarbeiten. Wollwaren, Mercerie (Viktoriarain 7), Viktoriastrasse 82 [34.108]
 Czernicki, Faia, Wwe., Länggassstrasse 57
 D.v. Dach, Alice, Damensalon, Karl - Schenkstrasse 3 [20.834]
@@ -8778,8 +8772,8 @@ D.v. Dach, Alice, Damensalon, Karl - Schenkstrasse 3 [20.834]
 – Melanie, Bureaulistin, Gerechtigkeitsg. 14
 – Paul, Elektriker, Karl-Schenkstrasse 3
 – Paul Fritz, Beamter, Zeigerweg 5 [32.235]
-– Paul, Feinmechaniker, Gerechtigkeitsg. 14v. Dach, Rudolf 22.851
-Notariat, Verwaltungen, Gründungen, Liquidationen, Erb- u. Güterrechtsverträge (Kirchenfeldstrasse 79 [32.134] ), Schauplatzgasse 39
+– Paul, Feinmechaniker, Gerechtigkeitsg. 14
+v. Dach, Rudolf 22.851 Notariat, Verwaltungen, Gründungen, Liquidationen, Erb- u. Güterrechtsverträge (Kirchenfeldstrasse 79 [32.134] ), Schauplatzgasse 39
 Dachselt, Fr., gew. Lehrer an d. Kunstschule, Bühlstrasse 19 [33.286]
 – G., dipl. Arch., Bildhauerei, Grabmalkunst, vormals A. Laurenti (Kalcheggweg 11 [36.135] ), Murtenstr. 66 [31.055], Architekturbureau: Schauplatzgasse 23 [29.496]
 – Natalie Elisabeth, Privatlehrerin, Bühlstrasse 19
@@ -8819,7 +8813,7 @@ Dähler, Fr., Maurer, Jurastrasse 36
 – Karoline (Engel), Wwe., Viktoriastrasse 49
 – Marg., Ladentochter, Keltenstr. 95, Bümpliz
 – Marie (Portner), Wwe., Wagnerstrasse 10
-– Rob., Fabrikarbeiter. Dammweg 19
+– Rob., Fabrikarbeiter, Dammweg 19
 – Rob., Pflästerer, Rosenweg 1
 – Rob., Fritz, Postchauffeur. Jurastrasse 32
 – Walter, Packer, Marzilistrasse 32
@@ -8861,7 +8855,7 @@ Dällenbach, s. auch Dellenbach u. Tellenbach
 – Otto, Telephonmonteur. Freiburgstr. 436, Bümpliz [46.106]
 – Paul Arthur, Hilfsarbeiter, Jurastrasse 44
 – Paul Gottfr., Maler, Quartiergasse 5
-– Walter Otto, Hilfsarbeiter. Steckweg 9
+– Walter Otto, Hilfsarbeiter, Steckweg 9
 – Walter, Autosattler, Monbijoustrasse 120
 – Werner Alb., Handlanger, Wylerfeldstr. 44
 – Werner, Karrer, Güterstrasse 40
@@ -8877,7 +8871,7 @@ Dängeli, Friedr., pens. Postangest., Turnw. 29
 – Marie, Bureaulistin, Turnweg 29
 – Marie. Ladentochter, Thunstrasse 14
 Daniel, Anna Kl., Kassierin, Belpstrasse 67
-– Jos.. Korrektor, Allmendstrasse 39
+– Jos., Korrektor, Allmendstrasse 39
 Däniker, Armin H. O., Dr. jur., eidg. Beamter, Nydeckgasse 17
 Dänische Gesandtschaft, Kanzlei, Luisenstr. 38 [22.940]
 Dänisches Konsulat, Melchenbühlweg 4 [23.589]
@@ -8932,7 +8926,7 @@ Däppen, Ad., Schuhmachermstr., Kirchbergerstrasse 3 [45.078]
 – Margrit (Bigler), Wwe., Freiestrasse 37
 – Rosa Hedwig, Kunststopferin, Mattenhofstrasse 29
 – Rud. Rieh., Schuhmacher, Wylerstr. 28
-– Samuel, Bauamtarbeiter. Mühleplatz 8
+– Samuel, Bauamtarbeiter, Mühleplatz 8
 – Walter, Ausläufer, Schärerstrasse 19
 Dapples, Luise, Frl., Ensingerstr. 3 [20.789]
 D’Apuzzo, Gerardo, Früchte- und Gemüsehandlung (Aarbergergasse 13), Spitalg. 36
@@ -8949,13 +8943,13 @@ Gesandtschaft, Kornhausstrasse 6 [27.533]
 Daschinger, Mathilde, Beamtin, Brückfeldstrasse 18
 Dasecke, Margrith, Buchbindenn, Burgfeldweg 8
 – Wilh. Ad., Giesser, Burgfeldweg 8
-Dasen, Franz. Beamter. Breitenrainplatz 33
+Dasen, Franz. Beamter, Breitenrainplatz 33
 – Fritz (Linsmayer), Angestellter d. Militärversicherung, Balmweg 35 [36.367]
 – Henri Ls., kaufm. Angest., Balmweg 33
 – Marie Sus., Telephonistin, Balmweg 35
 – Martha, eidg. Beamtin. Moserstrasse 23
 – Mathilde, Jubiläumsstrasse 60 [36.811]
-– Rud. Joh.. Maler, Wylerfeldstrasse 40
+– Rud. Joh., Maler, Wylerfeldstrasse 40
 # Date: 1935-12-15 Page: 26020399/96
 Dassler, Fr. W. E., Missionsarbeiter, Allmendstrasse 36
 Däster, Herm. A., Monteur, Breitenrainstr. 31
@@ -8973,13 +8967,13 @@ Dätwyler, s. auch Dettwyler
 – Guido, Dr. med. dent., Zahnarzt (Rabbentalstrasse 59 [34.468]), Bundespl. 4 [21.117]
 – Herm. (Mathys), Zieglerstr. 26 [24.439]
 – Jean Willy, Zeichner, Beundenfeldstrasse 5
-– Joh., Beamter S. B. B.. Mittelstrasse 59
+– Joh., Beamter S. B. B., Mittelstrasse 59
 – Rösa M., Schneiderin, Länggassstrasse 70
 – Rudolf, Hilfsarbeiter, Chutzenstrasse 17
 – W. Friedr., Kaufmann, Hubelmattstr. 46 [27.485]
 – Willi. Friedr., Chemiker, Hubelmattstr. 46
 Datzmann, Jos. (Bieger), Schneider, Weissensteinstrasse 62
-Daun, Rob. H.. Betriebsleiter, Militärstr. 16
+Daun, Rob. H., Betriebsleiter, Militärstr. 16
 Daut, Fritz, Elektriker, Murtenstr. 46 [25.864]
 – Pauline (Brupbacher), Wwe., Lorrainestrasse 16 [36.491]
 – Rud. (Brand), in Fa. Daut & Cie., Willadingweg 26 [35.934]
@@ -8998,8 +8992,7 @@ Weg 9
 Da Via, Ida, Fabrikarbeiterin, Brückfeldstr. 26
 David, Aug., Tramangest., Spitalackerstr. 51
 – — Const., Bereiter, Breitenrainplatz 36
-– Ernst Paul, Vertrieb v. Textilwaren aller
-Art, Breitenrainplatz 36
+– Ernst Paul, Vertrieb v. Textilwaren aller Art, Breitenrainplatz 36
 – Germaine, Bureaulistin, Breitenrainplatz 36
 – Pierre M. J., kaufm. Angest., Bühlstr. 14
 Dayidoff, Herm., Zigarrenhaus zum Capitol (Effingerstr. 29), Neuengasse 39 [31.069]
@@ -9039,7 +9032,7 @@ Degen. Alb., Schneider, Kasernenstrasse 21b
 – Pauly, Coiffeuse, Damensalon (Muristr. 67), Bollwerk 35
 Degenhardt, Adele, Bureaulistin, Brückfeldstrasse 26
 – Hans, Elektriker, Brückfeldstrasse 26
-Deggelmann, Osk., Schuh- u. Kleiderhandlg.u. mech. Schuhreparaturwerkstatt, Gerechtigkeitsgasse 65—69 . [35.918]
+Deggelmann, Osk., Schuh- u. Kleiderhandlg.u. mech. Schuhreparaturwerkstatt, Gerechtigkeitsgasse 65—69 [35.918]
 Degiacomi, Paul L., Möbelschrein., Jurastr. 59
 Degiorgi, Bruna, Bureaulistin, Marktgasse 5
 – Domenico, Gehilfe, Marktgasse 5
@@ -9067,7 +9060,7 @@ Delb, Ernst, Schneider, Wylerstrasse 43
 Delbanco, H. H., Bankbeamter, Bümplizstr. 177
 Delemont, Germaine (Henzi), Gesanglehrerin, Viktoriastrasse 61
 – R. A. J., eidg. Beamter, Viktoriastrasse 61
-Delessert, Chs. H.. Dr jur.. Schwarztorstr. 71
+Delessert, Chs. H., Dr jur., Schwarztorstr. 71
 – Louis Edm., kant. Angestellter, Rickenw. 31
 Del Fante, Irma Margr., Coifieuse, Spitalackerstrasse 51
 Del Grande, Anna (Habegger), Wwe., Gewerbestrasse 14 [33.455]
@@ -9112,8 +9105,7 @@ De Luca, Jone, Lehrerin, Monbijoustrasse 22
 Delz, Albert, chem.-techn. Artikel, Fahr, und Handel, Moserstrasse 26 [27.808]
 Demarmels, Maria E., Damenschneiderin, Bubenbergpiatz 9
 Demarta, Pierre, Techniker, Fischerweg 17 [22.624]
-Demartin, Alb. Gust., Elektrotechn. O T D .
-Blumenbergstrasse 16 [23.602]
+Demartin, Alb. Gust., Elektrotechn. O T D, Blumenbergstrasse 16 [23.602]
 – Henri Chs., Postbeamter, Monbijoustr. 20 [29.059]
 Demartines, Eugene E., Beamter der S. B. B., Brückfeldstrasse 37
 Demenga, K. Fritz, Monteur b. d. O. T. D., Kasernenstrasse 44
@@ -9142,9 +9134,9 @@ Denner, Elisab. M., Klavierlehrerin, Jägerweg 3
 Dennler, A., Annoncen-Expedition. Sulgenauweg 24 [24.340]
 – Emil Max, Dr., Pferdearzt, Dalmazirain 30 [25.887]
 – Emil, Maler, Frohbergweg 10
-– Ferd.. Bauamtarbeiter. Weingartstr. 45
+– Ferd., Bauamtarbeiter, Weingartstr. 45
 – Ferd., Sattler- u. Tapezierermeister (Kasernenstrasse 31 [33.057]), Mezenerweg 9
-– Max Erw.. Konditor. Stockerenweg. 13
+– Max Erw., Konditor. Stockerenweg. 13
 – O., gew. Bäckermeister, Berchtoldstr. 17 [34.576]
 – Paul E., kaufm. Angest., Wylerringstr. 52a
 – Paul, Postangestellter, Wylerringstr. 52a
@@ -9156,9 +9148,9 @@ Dens A,-G., Zahnärztl. Klinik, Kirchenfeldsttasse 29
 Denz, Friedrich, Konfiseur, Wabernstr. 25
 – Herm., graph. Kunst- und Klischeeanstalt, Tscharnerstrasse 14 [23.954]
 – Stephanie (Herzog), Wwe., Hochfeldstr. 73
-Denzler, Chs Hch., städt. Beamter. Rabbentalstrasse 41 [28.953]
+Denzler, Chs Hch., städt. Beamter, Rabbentalstrasse 41 [28.953]
 ; —Eugen (Havenith), kaufm. Angestellter, Wernerstrasse 8
-– Gottfr.. Beamter der P. T. T., Sulgenbachstrasse 12 [25.263]
+– Gottfr., Beamter der P. T. T., Sulgenbachstrasse 12 [25.263]
 – Hs., Angestellter B. L. S., Moserstrasse 33 [27.992]
 – Heinrich. Gerechtigkeitsgasse 5
 – Jakob, Photogrammeter b. Landestopographie, Burgernzielweg TB [29.514]
@@ -9176,7 +9168,7 @@ Deragisch, A., Postbeamter, Elisabethenstr. 17
 Derendinger und Därendinger
 – Christ (Hofmann), Holligenstrasse 47
 – Helene, Angestellte, Stauffacherstrasse 12
-– J J.. Brems- und Kupplungsmaterialien, Zweiglager Bern, Belpstrasse 16 [25.920]
+– J J., Brems- und Kupplungsmaterialien, Zweiglager Bern, Belpstrasse 16 [25.920]
 – Karl Joh., Konditor. Vluesmattstrasse 35
 – Luise E., Bureaulistin, Murifoldwcg 7
 – - Martha, Bureaulistin, Holligenstrasse 47
@@ -9191,7 +9183,8 @@ Derleth, Thomas. Magaziner. Metzgergasse 58
 Derron, Hubert Jos., Vertreter, Wabernstr. 77
 – Mathilde (Lanz), Wwe., Privatiere, Alpenstrasse 25
 Derungs, Bertha (Graf), Wwe., Jubiläumsplatz 6
-– Wilh. Alb., kaufm. Angest., Jubiläumspl. 6v. Deschwanden, Arnold, Bureaulist, Greyerzstrasse 38
+– Wilh. Alb., kaufm. Angest., Jubiläumspl. 6
+v. Deschwanden, Arnold, Bureaulist, Greyerzstrasse 38
 Descombes, Emil, Faktor, Neufeldstrasse 15 [33.875]
 – Walter E., kaufm. Angest., Neufeldstr. 15
 Desgraz, Paul (Lambert), Beamter d. internal
@@ -9214,10 +9207,10 @@ Dettling, Jos., Prof. Dr. med., Sonnenbergrain 9 [21.821]
 Dettwyler, s. auch Dätwyler
 – Ernst Moritz, Bantigerstrasse 8 [35.646]
 – Emil, Bankangestellter, Schulweg 11
-– Ernst Joh.. Metzger. Storchengässchen 5
+– Ernst Joh., Metzger. Storchengässchen 5
 – Fritz, Coiffeur, Belpstrasse 69 /
 – Gertrud, Arbeitslehrerin, Schlösslistr. 45 [29.774]
-– Karl (Matthey), Beamter B. L. S.. Schlösslistrasse 45 [29.774]
+– Karl (Matthey), Beamter B. L. S., Schlösslistrasse 45 [29.774]
 – Karl, Coiffeurmeister, Belpstr. 69 [27.667]
 – Karl, Reitlehrer, Laubeckstr. 55 [36.597]
 – Rudolf Louis, kaufm. Angest., Lorystr. 16
@@ -9226,8 +9219,6 @@ Dettwyler, s. auch Dätwyler
 Deubelbeiss, Alice, Bureaulistin, Mattenhofstrasse 9
 – Hans (Gloor), Bautechniker, Könizstr. 51
 – Karl (Zgraggen), Beamter P. T. T., Nünenenweg 37 [25.248]
-Entwürfefür alle Gebrauchszwecke Hallwag Bern
-Clichäs aller Art liefert Telephon 28.222
 # Date: 1935-12-15 Page: 26020402/99
 Deubelbeiss, Maria, Bureaulistin, Mattenhofstrasse 9
 – Sam., Schneidermeister, Mattenhofstr. 9
@@ -9263,11 +9254,11 @@ Dick, Ad., Elektromonteur, Freiestrasse 52
 – Alex., Hilfsarbeiter, Muldenstrasse 46
 – Alex., Reisender, Wiesenstrasse 71
 – Arnold. Schmied, Badgasse 29
-– Bertha, Ladentochter. Tillierstrasse 24
+– Bertha, Ladentochter, Tillierstrasse 24
 – Elise R., Lingere, Schauplatzgasse 21
 – Elise (Stauffer), Wwe., Schillingstrasse 8
 – Elise (Wasserfallen), Wwe., Gemüsehdlg., Gerechtigkeitsgasse (24) 18
-– Erika M.. Verkäuferin, Badgasse 49
+– Erika M., Verkäuferin, Badgasse 49
 – Erna. Kindergärtnerin, Altenbergstrasse 9
 – Ernst, Bankangestellter, Diesbachstr. 11
 – Ernst. Gasarbeiter, Brunnmattstrasse 85
@@ -9314,7 +9305,7 @@ Diensten-Spital, Junkerngasse 21 [32.811]
 Dienstmänner-Verein Bern, Lastauto, Leichentransport, Station Bahnhof [33.838]
 Dier, Hermann, Korrektor, Mittelstrasse 13
 Dierauer. Willy, Marchand-Tailleur (Viktoriastrasse 37 [20.070]). Marktgasse 37 [34.422]
-Diesslin, W. H., Angestellter. Morellweg 12
+Diesslin, W. H., Angestellter, Morellweg 12
 # Date: 1935-12-15 Page: 26020403/100
 Dieterich, s. auch Dietrich
 – Hugo (Etzel), Handelsgärtnerei u. Blumenbinderei, Wylerstrasse 36 [32.948], Früchteu. Gemüse: Ecke Wylerstrasse/Steinweg
@@ -9425,7 +9416,7 @@ Direktion d. öffentlichen Bauten u. d. Eisenbahnen, Münsterplatz 3a (Stift) [2
 Diriwächter, Giovanni (Fritschy), Postbeamter, Neubrückstrasse 97
 Dirlewanger, Hans Anton, Dr., Beamter der S. B. B., Brückfeldstrasse 8 [22.874]
 Disch, Jakob (Bill), eidg. Beamter, Greyerzstrasse 19 [36.311]
-Disler, Peter. Buchbinder, Tscharnerstrasse 7
+Disler, Peter, Buchbinder, Tscharnerstrasse 7
 Distel, Erwin, Zollbeamter, Zährmgferstr. 48
 Disteli, Emil, Telegraphist, Berchtoldstr. 43 [24.458]
 Distelzwang, Zunftgeb., Gerechtigkeitsgasse 79
@@ -9479,7 +9470,7 @@ Dolder, Alb., Handlanger, Blumenweg 9
 – Julius. Büchser, Militärstrasse 30
 – Lina, Ladentochter, Spitalgasse 31
 – Lydia, Fabrikarbeiterin, Gerbergasse 19
-– Otto, Bauamtarbeiter, Weissensteinstr. la
+– Otto, Bauamtarbeiter, Weissensteinstr. 1a
 – Paul, Gärtner, Spitalackerstrasse 57
 – Rob., Angestellter S. O. B., Freiburgstr. 378, Bümpliz
 – Samuel, Fabrikarbeiter, Turnweg 22
@@ -9518,9 +9509,9 @@ Dorn, Eugen, eidg. Beamter, Gurnigelweg 12
 Dörrwächter, Fr., Legieranstalt, Stereotypie, Galvanoplastik, Römerweg 26 [32.206]
 Dosch, Elise (Gfeller), Wwe., Liebeggweg 10
 Dospel, Alfr, Buchbinder, Güterstrasse 32
-– Franz, Hilfsarbeiter. Bahnstrasse 77
-– Joh.. Elektromonteur, Bahnstrasse 77
-Dössekker, W., Dr.. Spezialarzt f. Hautkrankheiten, Bubenbergstrasse 9 [34.307]
+– Franz, Hilfsarbeiter, Bahnstrasse 77
+– Joh., Elektromonteur, Bahnstrasse 77
+Dössekker, W., Dr., Spezialarzt f. Hautkrankheiten, Bubenbergstrasse 9 [34.307]
 Doswald, Marc Alfred, Spielleiter, Viktoriastrasse 45
 Dotta, Emilio, Elektrotechn., Effingerstr. 41d
 – Mario, Sekr. d. O. T. D., Falkenhöhew. 16
@@ -9533,7 +9524,7 @@ Drabert, Th. H. Otto, Vertreter, Dietlerstr. 6
 – Walter Otto, kaufm. Angest., Dietlerstr. 6
 Drahtseilbahn Marzili, Aarstrasse 96
 Drasdo, Walter Rieh., Dr. med., Arzt, Sandrainstrasse 58
-Drees, Herm.. Drechsler, Wasserwerkgasse 4
+Drees, Herm., Drechsler, Wasserwerkgasse 4
 Dreher, Hans, Handelslehrer, Moserstrasse 13 [29.309]
 Dreier siehe Dreyer
 Dreifuss und Dreyfuss
@@ -9555,7 +9546,7 @@ Drexhage, Karl, Schneider, Neubrückstr. 71
 Dreyer, s. auch Treier
 – Ad., Beamter d. S. B. B., Schwarzenburgstrasse 79 (Liebefeld)
 – Ad. Hans, Dr. phil., Mathematiker, Schwarzenburgstrasse 79 (Liebefeld)
-– Alex. (Lehmann), Versich.-Beamter. Grüneckweg 8 [34.232]
+– Alex. (Lehmann), Versich.-Beamter, Grüneckweg 8 [34.232]
 – Bertha Dora, Bureaulistin, Zaunweg 22
 – Ed. Sam., Käse- u. Butterhdlg., Bantigerstrasse 41 [23.802]
 – Ed., pens. Gasarbeiter, Murifeldweg 83
@@ -9589,7 +9580,7 @@ Dreyer, s. auch Treier
 – Viktor, Feinmechaniker, Ostermundigenstrasse 22
 – Walter, Kaufmann, Attinghausenstr. 21
 Dreyfuss siehe Dreifuss
-Dritte Baugesellschaft Stauffacherstr.. A.-G., Chutzenstrasse 21
+Dritte Baugesellschaft Stauffacherstr., A.-G., Chutzenstrasse 21
 Drollinger, Friedr., Anschläger, Gruberstr. 2
 – Friedr., Handlanger, Brünnenstrasse 72, Bümpliz
 – Joh., Hilfsarbeiter, Weberstrasse 17
@@ -9618,7 +9609,7 @@ Drude, Hans, Saitenspinner, Länggassstr. 77
 – Hildegard K. E., Angestellte, Länggassstrasse 77
 DRY-Schuhe (Gummi- und Maschinenfabrik Zürich A.-G.), Hirschengraben 2 u. Kramgasse 52 [29.130]
 Dubach, Ad. (Brandenberg), Tiefmattstrasse 4 [31.246]
-– Albr.. Handlanger, Morgenstr. 7. Bümpliz
+– Albr., Handlanger, Morgenstr. 7. Bümpliz
 – Alfred, Kondukteur S. B. B., Dietlerstr. 58
 – Alfred, Handlanger, Steckweg 13
 – Elise, Frl., Seidenweg 49
@@ -9674,7 +9665,7 @@ Dübi, s. auch Düby
 – Gottl., Schreiner, Mattenenge 12
 – Hanna, Bureaulistin, Sulgenbachstr. 43
 – Hanna, Bureaulistin, Böcklinstrasse 19
-– Hans Rud., eidg. Beamter. Friedeckweg 6
+– Hans Rud., eidg. Beamter, Friedeckweg 6
 – Hans. Beamter S. B. B., Wyttenbachstr. 22
 – Heinrich (Ernst), Dr. phil., Rabbentalstrasse 49 [22.724]
 – Johanna Hedw., Bureaulistin, Könizstr. 45
@@ -9782,7 +9773,7 @@ Versich.-Amtes, Feldeggweg 5 [32.651]
 Dumermuth, Maria, Privatlehrerin, Junkerngasse 27
 – Walter, Drogist, Spitalackerstrasse 36
 Dummermuth, Christ., Bauamtarbeiter, Kehrgasse 12, Bümpliz
-– Gottfr.. Milchführer, Hopfenweg 36
+– Gottfr., Milchführer, Hopfenweg 36
 – Klara Lina, Fabrikarbeiterin, Kehrgasse 12, Bümpliz
 – Paul, Spengler, Kehrgasse 12, Bümpliz
 – Rosina (Gugger), Wwe., Zähringerstr. 25
@@ -9823,7 +9814,7 @@ Dürig, Arnold A., Automechaniker, Pestalozzistrasse 24
 – Elise (Staub), Wwe., Felsenaustrasse 60
 – Ernst, Kaufmann, Falkenplatz 7 [34.822]
 – Friedr., Hilfsarbeiter, Sodweg 11
-– Friedr.. Bahnarbeiter, Eggimannstrasse 18
+– Friedr., Bahnarbeiter, Eggimannstrasse 18
 – Fritz, Handlanger, Neuengasse 1
 – Gottfr., Küfer, Falkenplatz 3
 – Hans, Fabrikarbeiter, Felsenaustrasse 85
@@ -9854,7 +9845,7 @@ Dürler, Hanna, Bureaulistin, Effingerstr. 29
 – Klara, Bureaulistin, Effingerstrasse 29
 – Wilh., Kalkulator, Rodtmattstrasse 58
 Dürmüller, s. auch Dürrmüller
-– Alb.. Buchhalter, Brunnadernstrasse 106
+– Alb., Buchhalter, Brunnadernstrasse 106
 – Franz Jos., Polizist, Predigergasse 5 [23.399]
 – Luise (Jakob), Wwe., Pestalozzistrasse 32
 Dürr, s. auch Dür
@@ -9893,7 +9884,7 @@ Durtschi, Elsa, Ladentochter, Scheibenstr. 30
 – R. (Wyss), Wwe., Schwarztorstrasse 55
 Durussel, G. Alb., Bereiter, Rodtmattstr. 39
 – Charles Emil, Elektromonteur, Hallerstr. 30
-Duruz, A. C.. Gipser- u. Malermeister, Beaumontweg 36 [33.910]
+Duruz, A. C., Gipser- u. Malermeister, Beaumontweg 36 [33.910]
 – Arnold B., Gipser u. Maler, Beaumontw. 36
 – Germaine Jeanne, Angestellte, Beaumontweg 36
 – Marg. (Paris), Gesanglehrerin, Knüslihubelweg 13
@@ -9911,11 +9902,11 @@ Duthaler, G. Joh., städt. Beamter, Hopfenrain 21
 – Walter, kaufm. Angest., Schlossstrasse 121
 Dutoit, Fernand J. L., Bankangest., Greyerzstrasse 29
 – J. A. (Gogaz), Sekretärin, Schanzenstr. 1
-Dutoit, Julielte Ida, Coiffeuse, Stauffacherstrasse la
+Dutoit, Julielte Ida, Coiffeuse, Stauffacherstrasse 1a
 – Marc, Bäckerei, Karl-Staufferstrasse 26 [29.282]
-Dütsch, Rud.. eidg. Beamter, Trechselstr. 4
+Dütsch, Rud., eidg. Beamter, Trechselstr. 4
 Dütschler, Hermann, städt. Beamter, Breitenrainstrasse 75
-– Joh.. Zollbeamter, Bürglenstrasse 18
+– Joh., Zollbeamter, Bürglenstrasse 18
 Duvoisin, Louis, Kaufmann, Seftigenstr. 38
 Dvorak, Jan, Monteur, Mattenhotstrasse 12
 Dworschak, Alois, Coiffeurgeschäft (Badg. 45).
@@ -9940,7 +9931,7 @@ Eberhard und Eberhardt, s. auch Aeberhardund AeberhaTdt
 – Jakob, sanitäre Anlagen, Morgenstrasse 9, Bümpliz [46.209]
 – Joh., Genossenweg 1
 – Joh., eidg. Angestellter, Wylerstrasse 53
-– Karl, Wagenreiniger S. B. B. t Reichenbachstrasse la
+– Karl, Wagenreiniger S. B. B. t Reichenbachstrasse 1a
 – Margr. Fr. J. J., Schneiderin, Ahornweg 5
 – Otto (Gerber), Herren- u. Damenfrisiersalon, Bantigerstrasse 45 [24.997]
 – Otto W., kaufm. Angest., Rodtmattstr. 54
@@ -9975,7 +9966,7 @@ Ecabert, Marg. G., Lingere, Weingartstr. 53 [32.418]
 Ecaubert, Martha, Schanzeneckstrasse 25
 Echaud, Ed. Hri., Maschinenmeister, Gerbergasse 9a
 Echenard, Hanny (Kühni), Ensingerstr. 14
-Echle, Raimund, Schuhmachermeister. Kapellenstrasse 7 .
+Echle, Raimund, Schuhmachermeister, Kapellenstrasse 7
 Eckert, Alb. (Egloff), Reisender, Gesellschaftsstrasse 80
 – Aug., Galvanoplastiker, Finkenrain 13
 – Bertha Lse. (Heitz), Wwe., Schwarztorstrasse 17
@@ -9986,7 +9977,7 @@ Eckert, Alb. (Egloff), Reisender, Gesellschaftsstrasse 80
 – Henri Fr. L., Ing. S. B. B., Helvetiastr. 27 [28.071]
 – Heinr. Jak., Coiffeur, Gerechtigkeitsg. 43
 – Julie, Zeitungsträgerin, Viktoriarain 2
-– Marie E.. Herrengasse 17
+– Marie E., Herrengasse 17
 – Martha Hedwig. Bureaulistin d. S. B. B., Schwarztorstrasse 17
 – Max G., Zeichenatelier, Blumensteinstr. 6
 Eckmann, Aron, Dr. ehern., Bersetweg 6 [27.395]
@@ -9995,7 +9986,7 @@ Eckstein, Gustav, Maurer, Turnweg 23
 Ecole de coupe de Paris, Aarbergergasse 61 [33.794]
 Ecuador-Gesandtschaft, Kanzlei, Hotel Bellevue-Palace
 Ecuyer, Francis Roland, Gärtner, Wabernstrasse 40
-Edelmann, A.. «Aux Occasions». Bonneterieu. Merceriegeschäft (Kornhausstrasse 10), Kramgasse 35 [32.875] u. Aarbergerg. 9 [36.170]
+Edelmann, A., «Aux Occasions». Bonneterieu. Merceriegeschäft (Kornhausstrasse 10), Kramgasse 35 [32.875] u. Aarbergerg. 9 [36.170]
 – Israel, Handelsmann, Wyttenbachstrasse 6 [34.315]
 – Johann P., kaufm. Angest., Monbijoustr. 17
 – Jos. N., Prokurist, Wyttenbachstrasse 6 [34.315]
@@ -10011,7 +10002,7 @@ Egeli, Elly (Scheidegger), Damen-Salon, Kornhausplatz 7 [28.387]
 – Josef G. (Scheidegger), Inspektor, Kornhausplatz 7 [28.387]
 Egenter, Gaston, Automechan., Laubeckstr. 57
 – Gertr. Marie, Bureaulistin, Monbijoustr. 36
-– Jos., eidg. Beamter. Dalmaziw. 65 [27.875]
+– Jos., eidg. Beamter, Dalmaziw. 65 [27.875]
 – Marie (Walther), Wwe., Laubeckstr. 57
 Egerter, Ed Ls., Techniker. Tscharnerstr 45
 Egg, Karl Albert, kaufm. Angest., Monbijoustrasse 22
@@ -10043,7 +10034,7 @@ Eggenberg, E., Kaufmann, Sulgenauweg 22 [35.770]
 – Max, Dr. rer. pol., Treuhand- u. Revisionsbureau, Spitalackerstrasse 9 [24.131]
 – Rudolf. Lehrer. Sulgenauweg 22
 Eggenberger, Anna (Kammerstätter), Wwe., Zähringerstrasse 48
-– David, Maseh.-Techn.. Wabernstrasse 6a
+– David, Maseh.-Techn., Wabernstrasse 6a
 – Ernst, kfm. Angestellter, Jubiläumsstr. 88
 – Jakob (Baur), Schneider, Alleeweg 24
 – Hans, Obering. f. Elektrifikation S. B. B., Engeried weg 19 [34.631]
@@ -10085,7 +10076,7 @@ Egger, Adolf, Maler, Spitalackerstrasse 11
 – Hans. Photograph, Spitalgasse 3
 – Hans Ernst, Schlosserei (Bierhübeliw. 35), Mittelstrasse 53 [25.834]
 – Hans E., Filialleiter, Blumenbergstrasse 3
-– Hans W.. Hilfsarbeiter, Federweg 61
+– Hans W., Hilfsarbeiter, Federweg 61
 – Hedwig, Damenschneid., Engehaldenstr. 198
 – Herm., Schreiner, Jurastrasse 99
 – Ida Luise, gew. Telephonistin, Weststr. 9
@@ -10118,7 +10109,7 @@ Egger, Martha, Damenschneiderin, Engehaldenstrasse 198
 – Walter Fr., Kaufmann, Schauplatzg. 33
 – Walter, Dr. jur., Redaktor, Steinerstr. 5 [31.341]
 – Wilhelm, Billetteur der S. S. B., Chutzenstrasse 39
-– Wilh Rob., Hilfsarbeiter, Weissensteinstrasse la
+– Wilh Rob., Hilfsarbeiter, Weissensteinstrasse 1a
 – Willy, Elektrotechn., Brünnenstrasse 111, Bümpliz [46.063]
 Eggimann, s. auch Eggemann und Eggmann
 – Adolf, Bauhilfsarb., Grabenpromenade 1
@@ -10203,7 +10194,7 @@ Egli, Adolf, pens. Briefträger, Pestalozzistrasse 25
 – Alfred, Handelsgärtnerei, Laubeckstr. 27
 – Alfred Friedr., Büchsenmacher. Römerw. 22
 — Anna, Verkäuferin, Lorrainestrasse 27
-– Bertha. Ladentochter. Hallerstrasse 14
+– Bertha, Ladentochter, Hallerstrasse 14
 – Edw., Postkommis, Engerain 18 [34.061]
 – Edw. (Soltermann), eidg. Beamter, Brunnmattstrasse 53 [29.040]
 Egli, Emil, Pächter, Bottigenstr. 389, Riedbach
@@ -10283,14 +10274,14 @@ Jean J. P., Techniker, Gesellschaftsstr. 75
 – Paul, Handlanger, Metzgergasse 24
 – Rob. Otto, Mützenmacher, Bürkiweg 19
 Ehret, Hermann, Beamter beim Elektrizitätswerk. Schläflirain 10
-– Johanna E.. Bureaulistin, Lilienweg 19
+– Johanna E., Bureaulistin, Lilienweg 19
 – Lina (Rüfenacht). Aufseherin, Lilienweg 19
-Ehrhardt, Emma u. Margrit. Frl.. Schwarztorstrasse 9 [23.316]
+Ehrhardt, Emma u. Margrit. Frl., Schwarztorstrasse 9 [23.316]
 – Emma M., Geschäftsangestellte, Sulgenauweg 15 [24.020]
 — Georg. Kaufmann, Sulgenauweg 15 [24.020]f— Geschwister, Blumenhaus. Bubenbergplatz 9 [23.335] u. Monbijoustrasse 17 [20.080]
 – Johann Georg, Sulgenauweg 15 [24.020]
 – Luise Marg., Blumenbinderin, Sulgenauweg 15 [24.020]
-– Rosa, Ladentochter. Gryphenhübeliweg 31
+– Rosa, Ladentochter, Gryphenhübeliweg 31
 Erhärt, Richard, Hilfsmonteur, Seidenweg 9a
 Ehricht, Emma, Gesellschaftsstrasse 40
 Ehrsam, Emil, Direkt, d. Vereinigten Mineralwasserfabriken Bern, A.-G., Weissensteinstrasse 96 [28.303]
@@ -10339,7 +10330,7 @@ Eichenberger Blumenhauseigene Gärtnerei, Spitalgasse 22 32.629
 – Fritz Rud., Schreiner, Forstweg 61
 – Gottfr., Chauffeur, Dapplesweg 1
 – Gottfr., Hilfsarbeiter, Altenbergstrasse 86
-– Gottl.. Müller, Freiburgstrasse 75
+– Gottl., Müller, Freiburgstrasse 75
 – Gottl. (Roth), Maurer. Berchtoldstr. 38
 – H., Kiosk. Breitenrainstrasse 44
 – H. (Urech), Spezereihandlung (Sodweg 1), Gesellschaftsstrasse 26 [24.353]
@@ -10348,17 +10339,17 @@ Eichenberger Blumenhauseigene Gärtnerei, Spitalgasse 22 32.629
 # Date: 1935-12-15 Page: 26020414/111
 Eichenberger, Hans Franz, Mechaniker, Lorrainestrasse 67
 – Hans, Metzgerei, Wursterei, Hopfenweg 38 [22.324]
-– Hedwig, Krankenschwester. Kesslergasse 3
-– Hedw. Gertr.. Prokuristin. Breitfeldstr 56
+– Hedwig, Krankenschwester, Kesslergasse 3
+– Hedw. Gertr., Prokuristin. Breitfeldstr 56
 – Heinrich Emil, Prokurist, Steigerweg 23 [31.575]
 – Heinrich, Ing. b. eidg. Amt f. geist. Eigentum, Brunnadernstrasse 7 [28.527]
-– Hektor. Arch S. 1. A.. in Fa. W. &. H.
+– Hektor. Arch S. 1. A., in Fa. W. &. H.
 Eichenberger, Hch.-Wildstr. 11 [23.758]
 – Helene Rosa, Bureaulistin, Diesbachstr. 7
 – Helene Esther, Laborantin, Bühlplatz 4
 – Jakob, Hilfsarbeiter, Rodtmattstrasse 91
 – Joh., Schlosser, Turnweg 17
-– Joh.. Meister C. R D. Turnweg 11
+– Joh., Meister C. R D. Turnweg 11
 – Johanna, Bureaulistin, Marzilistrasse 7
 – Johanna Klara, Bureauangestellte. Graffenriedweg 10
 – Johanna Marg., Bureauangestellte, Sonneggring 5
@@ -10378,9 +10369,9 @@ Eichenberger, Hch.-Wildstr. 11 [23.758]
 – Max, Fürspr., Lilienweg 16 [29 503]
 – Max. Möbel- u. Bettwarengeschäft, Florastrasse 3 [21.447]
 – Oskar Emil, Maler, Freiburgstrasse 147
-– Otto Ad.. Lehrer. Seilerstrasse 24
+– Otto Ad., Lehrer. Seilerstrasse 24
 – Otto, Typograph, Stauffacherstrasse 5
-– Rene G.. Ingenieurbureau. Schwarztorstrasse 5 [28.280]
+– Rene G., Ingenieurbureau. Schwarztorstrasse 5 [28.280]
 – Rob., Versich.-Beamter, Emanuel-Friedlistrasse 10
 – Rosa. Gehilfin, Elfenauweg 16
 – Rosa, Hilfsarbeiterin, Mittelstrasse 64
@@ -10392,7 +10383,7 @@ Eichenberger, Hch.-Wildstr. 11 [23.758]
 – Werner, Architekt in Fa. W. & H. Eichenberger, Bühlplatz 4 [31.112]
 – Werner Willy, Kaufmann, Steinerstr. 43
 – Werner, Mechaniker, Hochfeldstrasse 20
-– W & H.. Architektur- und Baubureau, Länggassstrasse 48 [22.121]
+– W & H., Architektur- und Baubureau, Länggassstrasse 48 [22.121]
 – freres, S. A., Velos u. Motorvelos, Neuengasse 24 [28.399]
 – & Sohn, Gipser- u. Malergeschäft, Breitfeldstrasse 56 [32.803]
 Eicher, B., Buchdruck., i. Fa. Eicher & Roth, Humboldtstrasse 55 [31.067]
@@ -10409,7 +10400,7 @@ Eicher, B., Buchdruck., i. Fa. Eicher & Roth, Humboldtstrasse 55 [31.067]
 – Fr. (Lehmann), Schriftsetzer, Graffenriedweg 14 [34.453]
 – Frieda, Giletmacherin, Rodtmattstrasse 50
 – Frieda, Pflegerin, Postgasse 46
-– Friedr.. Hilfsarbeiter, Metzgergasse 18
+– Friedr., Hilfsarbeiter, Metzgergasse 18
 – Friedr., pens. Lehrer, Jennerw 5a [28.367]
 – Friedr., Tapezierer, Gerechtigkeitsgasse 35
 – Gottfr., Handlanger, Freieckweg 9, Bümpl.
@@ -10429,7 +10420,7 @@ Eicher, B., Buchdruck., i. Fa. Eicher & Roth, Humboldtstrasse 55 [31.067]
 – & Roth, Buchdruckerei, Speichergasse 33 [22.256]
 Eichholzer, Ed. H. E., Dr., eidg. Beamter, Beaulieustrasse 25 [32.703]
 Eichmann, A., Schreiner, Murifeldweg 3
-– Jakob Karl, Beamter. Luternauweg 5
+– Jakob Karl, Beamter, Luternauweg 5
 – Joh., Heizer, Gerechtigkeitsgasse 34
 – Karl Emil (Feiler), Entkalker, Marktg. 23
 – Otto, Dekorateur, Eichmattweg 7 [24.537]
@@ -10458,7 +10449,7 @@ Eigensatz, Ad., Mechaniker, Bümplizstr. 180
 – David, Weinhändler, Bümplizstrasse 180 [46.019]
 – Elisab. (Wey), Kesslergasse 25
 – Ernst, Hilfsarbeiter, Bümplizstrasse 180
-– Joh.. Bauhandlanger, Fischermätteliw. 11
+– Joh., Bauhandlanger, Fischermätteliw. 11
 – Jos., Küfer, Jurastrasse 5
 «Eika», Einkaufsstelle d. Schutzverbandes d. papierverarbeitenden Industrien d. Schweiz, Effingerstrasse 2 [23.671]
 Eilgut, Cafe-Restaurant, Neubrückstrasse 13 [22.218]
@@ -10500,7 +10491,7 @@ Elektro-Cardinaux  📞 35.751 Installationen jeder Art für Licht, Kraft- u. Sc
 Elektrodienst A.-G., Monbijoustr. 6 [21.214]
 Elektro-Einkaufsvereinigung, Spitalackerstr.
 Nr. 60 [22.821]
-Elektro-Material Zürich A.-G.. Filiale Bern, Effingerstrasse 31 [29.675]
+Elektro-Material Zürich A.-G., Filiale Bern, Effingerstrasse 31 [29.675]
 Elike, Arthur (Würgler), Linieranstalt, Junkerngasse 36 [32.328]
 Elkhadem, Renee, Bureaulistin, Humboldtstrasse 35 [24.893]
 Ellams Duplikator A.-G., Waaghausgasse 1 [28.393]
@@ -10514,7 +10505,7 @@ Ellenberger, Arn. Walter, Güterarbeiter der S. B. B., Federweg 29d
 – Friedr., Maurer, Bottigenstr. 47, Bümpliz
 – Friedr., Fabrikarbeiter, Länggassstr. 23
 – Friedr. G., Magaziner, Gerbergasse 7b
-– Friedr. Oskar, Bureauchef, Lorbeerstr. .7, Bümpliz
+– Friedr. Oskar, Bureauchef, Lorbeerstr. 7, Bümpliz
 – Fritz (Birrer), Angestellter der S. B. B., Greyerzstrasse 40
 – Fritz, Maler, Freiburgstr. 383, Bümpliz
 – Fritz (Dovat), Breitenrain-Molkerei, Moserstrasse 6 [35.224]
@@ -10540,21 +10531,21 @@ Ellenberger, Hermann, Schuhmacher, Freiburgstrasse 486, Bümpliz
 – Gebr., Gipser- und Malergeschäft, Bärengassp 12, Bümpliz [46.168]
 Ellenson, Hans (Schleusener), Sonnenbergrain 45 [32.559]
 Elles, Alb., Kaufmann, Gryphenhübeliweg 39 [36.548]
-Elliker, Hugo Peter, Postbeamter. Neubrückstrasse 75
+Elliker, Hugo Peter, Postbeamter, Neubrückstrasse 75
 – Otto (Oehninger), Beamter, Gartenstr. 12
 Eimer, Arthur, Kaufmann, Viktoriarain 15
 – Alice (Zingg), Konzertsängerin u. Gesanglehrerin, Greyerzstrasse 77 [27.742]
 – Edwin, Dr., Adjunkt der kant. Steuerverwaltung, Greyerzstrasse 77 [27.742]
 – Matth., Beamter S. B. B., Viktoriarain 15
 Elmiger, Gust., Sektionschef O. K. K., Rabbentalstrasse 63 [29.996]
-Elos A.-G,, Erwerb, Vermietung, Verwaltung, Veräusserung v. Liegenschaften, Monbijoustrasse 49
+Elos A.-G., Erwerb, Vermietung, Verwaltung, Veräusserung v. Liegenschaften, Monbijoustrasse 49
 Eirad A.-G., elektrische u. radiotechn. Produkte, Schwarztorstrasse 21 [26.340]
 Elsässer, Anna, Schneiderin, Dahliaweg 3
 – E., pens. Magaziner, Dahliaweg 3
 – Emil Jakob, Peitschen en gros (Niesenweg 10a), Kornhausplatz 14 [31.028]
 – Frieda Rosa, Bureaulistin, Dahliaweg 3
 – Georg (Zimmerli), Fabrikant, Oranienburgstrasse 13 [26.168]
-– Kilian Herm., kaufm. Angest.. Dahliaw. 3
+– Kilian Herm., kaufm. Angest., Dahliaw. 3
 – Otto Kilian, Angestellter, Dahliaweg 3
 – Theodor, Kaufmann, Dahliaweg 3
 – Werner Paul, kaufm. Angestellter, Neufeldstrasse 116 [36.886]
@@ -10604,7 +10595,7 @@ Ender, Anton, Maler, Beundenfeldstrasse 32
 Enderli, A. Max, Kaufm., Brems- u. Kupplungsmaterial für Autos, Waisenhauspl. 18
 – Albert, Schlosser. Weissensteinstrasse 68
 – Hans, Abwart am Progymnasium, Waisenhausplatz 30
-– Heinr.. Monteur, Länggassstrasse 99
+– Heinr., Monteur, Länggassstrasse 99
 – Lina (Blaser), Wwe., Weissensteinstr. 68
 – Silvio. Bankangestellter, Wyttenbachstr. 15
 – Werner, Radiotechniker, Waisenhauspl. 30
@@ -10615,7 +10606,7 @@ Endtner, Robert (Seiler), Ingenieur O. P. D., Ensingerstrasse 11 [23.834]
 Enengl, Gottfr., Coiffeur, Kasernenstrasse 21
 Eng, Frz., Tramführer, Schwarzenburgstr. 20
 – Franz, Reisender, Dietlerstr. 2 [45.162]
-– Joh.. Lokomotivführer. Holligenstrasse 45
+– Joh., Lokomotivführer. Holligenstrasse 45
 – Joh., Reisender, Lorrainestrasse 20
 – Louis, städt. Beamter, Schwarzenburgstr.20 [36.130]
 – Marie, Verkäuferin, Schwarzenburgstr. 20
@@ -10629,15 +10620,15 @@ Engel, Alb., Hilfsarbeiter, Kasernenstr. 44
 – Charles, Hausierer, Waisenliausplatz 22 [23.022]
 – Chr., Kond. B. L. S., Karl-Schenkstr. 1
 – Christ., Giessereiarbeiter, Forstweg 61
-– Ernst, Fabrikarbeiter. Jurastrasse 55
+– Ernst, Fabrikarbeiter, Jurastrasse 55
 – Ernst, Handlanger, Ferd.-Hodlerstr. 16
 – Fanny, Ladentochter, Elisabetlienstr. 40
 – Franz, Zimmermann. Friedeckweg 30
 – Friedr., Maler, Murifeldweg 33
-– Friedr.. Gärtner Waffenweg 25
+– Friedr., Gärtner Waffenweg 25
 – Friedr., Kanzlist, Rodtmattstrasse 48
 – Friedr., Schlosser, Breiteweg 23
-– Gottfr., Bureauangestellter. Rohrweg 8
+– Gottfr., Bureauangestellter, Rohrweg 8
 – Grety (Leuenberger), Klavierlehrerin, Müslinweg 24 [29.091]
 – Hans, Hilfsarbeiter, Fährstrasse 34
 – Hedwig, Bureaulistin, Obstbergweg 10
@@ -10645,7 +10636,7 @@ Engel, Alb., Hilfsarbeiter, Kasernenstr. 44
 – Hermine, Fabrikarbeiterin, Engehaldenstrasse 202
 – Ida Marie, Bureaulistin, Speichergasse 29
 – Ida, Gutenbergstrasse 26 [33.781]
-– Jakob, Billetteur S. S. B.. Obstborgweg 10
+– Jakob, Billetteur S. S. B., Obstborgweg 10
 – Johanna (Krebs), Sek.-Lehrerin, Wabernstrasse 14 [25.606]
 – Klara Emma, Gehilfin O. Z. D., Bernastr. 6
 – Lina, Ladentochter, Landoltstrasse 56
@@ -10653,7 +10644,7 @@ Engel, Alb., Hilfsarbeiter, Kasernenstr. 44
 – Marie, Frau. Elisabethenstrasse 40
 – Marie, Fabrikarbeiterin, Metzgergasse 38
 – Paul, Bankangestellter, Burgunderstr. 35, Bümpliz
-– Peter. Metzgergasse 32
+– Peter, Metzgergasse 32
 – Rob. Paul, Schreiner, Quartiergasse 31
 – Rob., Sekundarlehrer, Muristr 63 [22.378]
 – Rud. Jak., Einzieher beim Gaswerk, Rodtmattstrasse 33
@@ -10664,7 +10655,7 @@ Engeier, K. H., Chauffeur, Graffenriedweg 6
 Engeli, Jean O., Elektrotechniker, Birkenw. 44 [21.463]
 Engelmann, Arth., Steindrucker, Greyerzstr. 35
 – Charles, Ausläufer, Wylerfeldstrasse 69
-– Joh., Hilfsarbeiter. Wylerfeldstrasse 69
+– Joh., Hilfsarbeiter, Wylerfeldstrasse 69
 – Willy Ernst, Vernickler, Wylerfeldstr. 69
 Engeloch, Alfr., Vertretungen in Stoffen und Textilwaren, Dietlerstrasse 10 [27.856]
 – Franz, Dr. med., Spezialarzt für Frauenkrankheiten u. Chirurgie, Moserstrasse 11 [24.542]
@@ -10677,7 +10668,7 @@ Engeloch, Rud., Zahnarzt (Bitziusstrasse 11 [31.632]), Zeitglockenlaube 2 [36.08
 Enger, Georg, Schlosser, Amselweg 15
 Engeried, Klinik, Riedweg 11 [23.721]
 Engerth, Wilh., österr. Gesandter, Humboldtstrasse 33 [21.471]
-Engetschwiller. Emil A.., Hilfsarbeiter. Rodtmattstrasse 97
+Engetschwiller. Emil A.., Hilfsarbeiter, Rodtmattstrasse 97
 Enggist, Berta Sophie, Bureaulistin, Eigerweg 9
 – Ed. (Wagner), Lehrer, Wylerstrasse 83 [34.597]
 – Ernst Fr., Bureaulist. Lorrainestrasse 27
@@ -10687,7 +10678,7 @@ Enpler, Alfred Fr., Kaufmann, Zinggstr. 31
 – Arthur, Schneider, Aebistrasse 10
 – Eduard, Kürschner. Schillingstrasse 28 [20 829]
 – Ed.’s Wwe., «Au Tigre Royal», Pelzwarengeschäft (Dalmazirain 10 [21.868]). Bahnhofplatz 11 [24.819]
-– Friedr Rud.. Fräser, Greyerzstrasse 42
+– Friedr Rud., Fräser, Greyerzstrasse 42
 – Friedr. (Haldimann), Sek.-Lehrer, Manuelstrasse 72 [22.363]
 – Friedrich. Marchand-Tailleur (Rosenw 13 [36.637]), Laupenstrasse 3 [22.274]
 – Hanny. Angestellte. Dalmazirain 10
@@ -10698,7 +10689,7 @@ Enpler, Alfred Fr., Kaufmann, Zinggstr. 31
 Engl. Gesandtschaft, Kanzlei: Thunstrasse 48 [21.913]
 Englisches Konsulat, Bundesplatz 2 [24 108]
 Enkerli, Fritz, Polizist, Stauffacherstrasse 46
-Ensinger. Ant. Jos.. Garagearbeiter, Seftigenstrasse 97
+Ensinger. Ant. Jos., Garagearbeiter, Seftigenstrasse 97
 Ensslin, Friedr., Koch, Brückenstrasse 8
 Enz, Alfred, Beamter b. eidg. Statist. Amt, – Ida (Vassalli), Wwe., Bernastr. 68 [36.008]
 – Klara, dipl. Klavierlehrerin, Bernastr. 68 [36.008]
@@ -10752,7 +10743,7 @@ Erb, Augusta C., Bureaulistin, Mühlemattstrasse 18
 – Klara Fr., Sekretärin, Mühlemattstrasse 18
 – Marie Magdal., Bureauiistin, Mühlemattstrasse 18
 – Max, Dr. med., Augenarzt (Muldenstr. 37), Spitalgasse 20 [35.722]
-– Wilh. Heinr., Beamter S. B. B.. Granatw. 5
+– Wilh. Heinr., Beamter S. B. B., Granatw. 5
 Erdin, Ida, Damenschneiderin (Hofweg 5), Spitalgasse 28 [23.878]
 – Julius. Schneider. Hofweg 5
 Erdmann, Lydie, Bureauiistin, Thunstr. 51
@@ -10767,11 +10758,12 @@ Erismann, Anna Elisab., Frau, Seidenweg 38
 – Helene, Damenschneiderin, Lorrainestr. 68
 – Johanna Bertha, Ladentochter, Freieckweg 12, Bümpliz
 – Marie B. (Bönzli), Wwe., Statthalterstr. 18, Bümpliz
-– Martha Fr.. Ladentochter, Freieckweg 12, Bümpliz
+– Martha Fr., Ladentochter, Freieckweg 12, Bümpliz
 – Paul Albert, kaufm. Angest., Breitfeldstr.33
 – Rud., Schreiner, Drosselweg 25
 – Ulrich. Angestellter, Eigerplatz 8
-Erka A.-G., Christoffelgasse 4v. Erlach, A., Dr. med., prakt. Arzt u. Spez.für Harnorgane (Weststrasse 4), Junkerngasse 51 [25.077]
+Erka A.-G., Christoffelgasse 4
+v. Erlach, A., Dr. med., prakt. Arzt u. Spez.für Harnorgane (Weststrasse 4), Junkerngasse 51 [25.077]
 – Alfred (v. Mülinen), Ingenieur, Schwarztorstrasse 35 [28.434]
 – E. A., Kaufm., Gerechtigkeitsg. 79 [23.537]
 Erlacherhof, Junkerngasse 47 [21.511]
@@ -10795,8 +10787,7 @@ Ernl, s. auch Aerni
 – Fritz, Chauffeur, Effingerstrasse 9
 – Herm., Molkereifachmann, Hrch.-Wildstrasse 9
 – Hermine, Telephonistin. Muesmattstr. 20
-– J. (Benz), pens. Kanzleisekretär b. eidgen.
-Amt f. geist Eigentum, Bernastrasse 34
+– J. (Benz), pens. Kanzleisekretär b. eidgen. Amt f. geist Eigentum, Bernastrasse 34
 – Jakob, Maschinenmeister, Murifeldweg 15
 – Jak. Arth., Typograph, Schanzenbergstr. 7
 – Joh., Inseraten-Akcjuisiteur. Tannenweg 18
@@ -10805,7 +10796,7 @@ Amt f. geist Eigentum, Bernastrasse 34
 – Werner, Hausierer, Mattenenge 8
 Ernst, A., Dr., Fürspr. (Gümligen [42.466]), i. Bur. R. v. Stürler, Bundesg. 6 [21.546]
 – Ad. Wilh., Steinhauer. Tillierstrasse 24
-– Adolf, Beamter der S. B. B.. Bridelstr. 58
+– Adolf, Beamter der S. B. B., Bridelstr. 58
 – Alb. (Wüger), Oberst, gew. Chef d. Rechnungsbureaus d. Oberkriegskommissariats, Drosselweg 17
 – Anna (Fahrni), Wwe., Fischerweg 20 [33.983]
 # Date: 1935-12-15 Page: 26020419/116
@@ -10851,9 +10842,9 @@ Ersparniskasse des Amtsbezirks Bern, Amthausgasse 14 [22.360]
 Erste Baugesellsch. Stauffacherstrasse, A.-G., Chutzenstrasse 21
 Erste Immobiliengesellschaft Friedheim A.-G., Monbijoustrasse 134
 Erziehungsanstalt f. schwachsinnige Kinder, Schwarzenburgstrasse 36 (Weissenheim) [45.045]
-«Esa», Einkaufsgenossenschaft f. d. Schweiz.
-Autogewerbe, Mezenerweg 11 [27.966]
-Esche, Max, Chauffeur, Marktgasse 56v. Escher, Elise M., Beamtin, Bj:ückenstr. 59
+«Esa», Einkaufsgenossenschaft f. d. Schweiz. Autogewerbe, Mezenerweg 11 [27.966]
+Esche, Max, Chauffeur, Marktgasse 56
+v. Escher, Elise M., Beamtin, Bj:ückenstr. 59
 Eschler, Emil, Postangest., Genossenweg 7
 – Elise (Wyssmüller), Wwe., Engerain 44
 – Frieda. Damenschneiderin, Genossenweg 7
@@ -10864,7 +10855,7 @@ Eschler, Emil, Postangest., Genossenweg 7
 Eschler, Ida, Verkäuferin, Genossenweg 7
 – Jakob, Handelsmann, Engerain 44 [32.122]
 – Johanna, Fabrikarbeiterin. Genossenweg 7
-– Louise Clara, Ladentochter. Schützenw. 21
+– Louise Clara, Ladentochter, Schützenw. 21
 – Oskar, Chauffeur, Freie Strasse 37
 – Otto Willy, Schlosser, Wattenwylweg 34
 – Paul Arn., Installateur, Standstrasse 3
@@ -10917,7 +10908,7 @@ Etter, Gottfr., Handlanger, Felsenaustr. 14
 – Ida R. Krankenschwester, Erlachstr. 8
 – Ida EL, Wäscherin, Quartierhof 12
 – Joh., Generaldirektor der S. B. B., Bernastrasse 57 [31.310]
-– Joh.. Tramkondukteur, Sulgenauweg 34
+– Joh., Tramkondukteur, Sulgenauweg 34
 – Karl, Maler, Flurstrasse 1
 – M. El. (Aebersold), Damenschneiderin, Weberstrasse 1
 – Maria, Bureaulistin, Lorrainestrasse 54
@@ -10944,8 +10935,7 @@ Europ. Güter- u. Reisegepäck-Versicherungs-A.-G., Bundesgasse 30 [28.276]
 Evang. Gemeinschaft, Zionskapelle, Nägelig. 4 [31.921]
 Evangelische Gesellschaft, Nägeligasse 9 u. 11 [22.583]
 Evangelische Gewerkschaft, Kreissekret. Bern, Weissensteinstrasse 122 [21.338]
-Evangelisches Lehrerinnen-Seminar (Neue
-Mädchenschule), Nägeligasse 6 [27.981]
+Evangelisches Lehrerinnen-Seminar (Neue Mädchenschule), Nägeligasse 6 [27.981]
 Evang. Lehrerseminar Muristalden, Direktion, Muristrasse 8 [31.473]
 Evard, P. H., Beamter G.-D. P. T. T., Südhahnhofstrasse 10
 Evequoz, Raymond, eidg. Beamter, Schwanengasse 5d’Everstag, Johanna L. (Gaussen), Wwe., Schwarztorstrasse 5 [23.474]
@@ -10961,7 +10951,7 @@ Eyer, Ad. (Eicher), Küfer, Brunnmattstr. 65
 – Fritz, Schneider, Seidenweg 62
 – Joh., Vermessungsgehilfe. Militärstr. 60
 – Willy Joh., Kaufmann, Erlachstrasse 3
-Eymann. Alfr . Milchträger, Bridelstrasse 26
+Eymann. Alfr., Milchträger, Bridelstrasse 26
 – Alex., Schlosser, Schanzenstrasse 4
 – Fritz, Chauffeur-Magaziner, Schläflistr. 4
 – Fritz, Schlosser, Eggimannstrasse 18
@@ -10994,8 +10984,7 @@ Fäh, Lilly Bertha, Diesbachstrasse 6
 Fählimann, Ernst A., Handlanger, Gerbergasse 44
 – Marie R. (Stettier), Wwe., Fabrikarbeiterin, Gerbergasse 44
 Fahrn, Jos. (Valet), Dr. jur., Sektionschef d. S. B. B., Viktoriastrasse 82 [26.291]
-Fähndrich, Ernst (Stössel), Wirt, Rest, zum
-. Hopfenkranz, Neuengasse 1/Waisenhausplatz 8 [23.619]
+Fähndrich, Ernst (Stössel), Wirt, Rest, zum Hopfenkranz, Neuengasse 1/Waisenhausplatz 8 [23.619]
 – Walter, kaufm. Angestellter, Schärerstr. 9
 Fahnenfabrik Hütmacher-Schalch A.-G. Bern, Lorrainestrasse 1 [22.411]
 # Date: 1935-12-15 Page: 26020423/118
@@ -11018,7 +11007,7 @@ Fahrni, Albert, Maler, Bierhübeliweg 35
 – Ernst, Wagner, Bolligenstrasse 117
 – Frieda, Einlegerin, Talweg 12
 – Frieda A., Lehrerin, Brückenstr. 4 [28.951]
-– Friedr., Bauamtarbeiter. Buchenweg 24
+– Friedr., Bauamtarbeiter, Buchenweg 24
 – Friedr., Bauamtarbeiter, Breitfeldstr. 65
 – Friedr., Monteur, Wylerstrasse 57
 — Friedr., Buchbinder. Buchenweg 24
@@ -11026,7 +11015,7 @@ Fahrni, Albert, Maler, Bierhübeliweg 35
 – Fritz, Drogerie (Optingenstrasse 11), Lorrainestrasse 21 [31.195]
 – Fritz, Hilfsmonteur, Jurastrasse 42
 – Fritz Christ., Maschinentechniker, Spitalackerstrasse 11 [32.092]
-– Gottfr., pens. Bahnarbeiter. Quartierhof 13
+– Gottfr., pens. Bahnarbeiter, Quartierhof 13
 – Gottfr., Handlanger. Länggassstrasse 92
 – Gottfr., pens. Kasernenvorarbeiter, Spitalackerstrasse 27
 – Gottfr., Schreiner, Kehrgasse 20, Bümpliz
@@ -11048,16 +11037,16 @@ Fahrni, Albert, Maler, Bierhübeliweg 35
 – Samuel, Hilfsarbeiter, Brunngasse 14
 – Walter, Mechaniker, Bantigerstrasse 26
 Fahrradhaus u. Nähmaschinenhandlung Solidarität Bern, Militärstr. 59 [24.265], Filiale: Freiburgstr. 190, Bümpliz [29.155]
-Faigaux, H. G.. Postbeamter, Seminarstr. 11
+Faigaux, H. G., Postbeamter, Seminarstr. 11
 Failletaz, Marie Amelie Cecile, Pflegerin, Elfenauweg 98
-Faiss, Emil Gottfr.. Bureaulist. Seftigenstr. 53
+Faiss, Emil Gottfr., Bureaulist. Seftigenstr. 53
 Faisst, Anna (Segessemann), Pension, Bubenbergstrasse 19 [34.940]
 Faisst, Arnold (Segessemann), Gipser- u. Malergeschäft, Bubenbergstrasse 19 [34.940]
 Fakler, Jos., Schneidermeister, Gerechtigkeitsgasse 38
 – O., Geschäftsführer u. Verwalt.-Rat bei O.
-Fakler A -G.. Gurtengasse 6 [21.200]
+Fakler A -G., Gurtengasse 6 [21.200]
 – Otto, Akt.-Ges., Benzin, Mineralölprodukteen gros, Gurtengasse 6 [21.200]
-Falb, Albert, eidg. Beamter. Weissensteinstrasse 98 [27.405]
+Falb, Albert, eidg. Beamter, Weissensteinstrasse 98 [27.405]
 – Anna Cecile. Propagandistin, Seidenw. 54 [21.985]
 – Elsa, Verkäuferin, Seidenweg 54 [21.985]
 – Fritz (Zbinden), eidg. Beamter, Weissensteinstrasse 96 [23.998]
@@ -11079,27 +11068,27 @@ Falquet, Louis, pens. Kupferstecher bei der
 Landestopographie, Neufeldstrasse 27b
 Familien-Restaurant Dählhölzli, F. Senn-König, Dalmaziweg 151 [21.894]
 Fänger, Ant. ; Vertreter, Schärerstrasse 21
-Fankhauser, Ad., Malermeister. Weiherg 16 [35.201]
-– Alfred. Dr.. Schriftsteller. Liebeggweg 5
+Fankhauser, Ad., Malermeister, Weiherg 16 [35.201]
+– Alfred. Dr., Schriftsteller. Liebeggweg 5
 – Anna Martha, Ladentochter, Moserstr. 16
 – Arn., Hilfsarbeiter, Bottigenstr. 69, Bümpliz
 – Arn., Postbeamter, Freiburgstr. 501, Bümpliz
 – Bendicht Handlanger. Randweg 11
 – Ed. Christ., Magaziner, Cäcilienstrasse 21b
-– Ed.. Papeterie. Kunst- und Buchhandlung
+– Ed., Papeterie. Kunst- und Buchhandlung
 «Die Neue Zeit» (Dorngasse 4), Laupenstrasse 3
 ;— Elise (Trittibach), Wwe., Kesslergasse 17
 – Elsa Hedwig, Bureauangestellte. Schwarztorstrasse 1 [34.137]
 – Emil, Kaufmann, Hallwylstr. 44 [32.465]
 – Ernst. Dr. med., Arzt. Waldau, Bolligenstrasse 117
 – Ernst, Bäckerei-Konditorei. Mittelstr. 56 [21.046]
-– Ernst, eidg Beamter. Simonstr. 19 [36.136]
+– Ernst, eidg Beamter, Simonstr. 19 [36.136]
 – Ernst, Chauffeur, Frohbergweg 7
 Gebr. Keller, Architekten
 # Date: 1935-12-15 Page: 26020424/119
 Fankhauser, Ernst, Vertretungen und Auto-Reparaturen, Schönburgstrasse 5 [32.929]
 – Ernst, Handlanger, Wylerringstrasse 69
-– Ernst, Maschinenmeister. Murifeldweg 68
+– Ernst, Maschinenmeister, Murifeldweg 68
 – Ernst, Kaufmann, Aarbergergasse 7
 — Erwin, eidg. Beamter, Wallgasse 4
 Fankhauser, Fr. 21.450, Gipser-, Maler-, Tapeziererarbeiten, Bersethweg 16
@@ -11152,8 +11141,7 @@ Kurzwaren, Turnweg 22 [36.501]
 Farinoli, Fred. C., Kaufmann, Erlenweg 20
 – Germaine Therese, Modistin, Kasernenstrasse 45
 – Giov. Luc., Coiffeur, Damensalon (Kasernenstrasse 45), Aebistrasse 2 [27.866]
-Farner, Alfred, Dr. phil., Verw. d. Haaf’schen
-Apotheke u. Drogerie (Optingenstrasse 35), Marktgasse 44 [21.441]
+Farner, Alfred, Dr. phil., Verw. d. Haaf’schen Apotheke u. Drogerie (Optingenstrasse 35), Marktgasse 44 [21.441]
 – Otto, Grenzwächter, Schulweg 9
 Farr, G. E., Direktor der Ryff & Co., A.-G., Lentulusstrasse 33
 Farrer, Aug. Andr., graph. Atelier, Allmendstrasse 36 [25.937]
@@ -11175,7 +11163,7 @@ Fasnacht, Anna Martha, Ladentochter, Junkerngasse 11
 – Franz, Privatier, Bubenbergplatz 4
 – Frieda A. G., Zieglerstrasse 9 [31.143]
 – Gertr., Kanzlistin, Holzikofenw. 18 [27.678]
-– Hans Karl, Autoschmied, Unt. Aareggw. la
+– Hans Karl, Autoschmied, Unt. Aareggw. 1a
 – Helena E., Bureaulistin, Karl-Schenkstr. 7
 – Hermann, Gärtner, Kesslergasse 31
 – Hermann, gew. Metzgermeister, Breitenrainplatz 29 [24.019]
@@ -11185,7 +11173,7 @@ Fasnacht, Anna Martha, Ladentochter, Junkerngasse 11
 Fasola, Dora Anita, Fabrikarbeiterin, Pestalozzistrasse 30
 – Ernesto, Maurerpolier, Ladenwandstr. 96
 – Katharina (Gertsch), Wwe., Pestalozzistrasse 30
-Fässer, Ad Joh.. Lithograph, Kirchbühlw. 48
+Fässer, Ad Joh., Lithograph, Kirchbühlw. 48
 Fassina, Elvira, Telephonistin, Spitalgasse 4
 Fässler, Alb., Beamter der S. B. B., Aegertenstrasse 49
 # Date: 1935-12-15 Page: 26020425/120
@@ -11194,7 +11182,7 @@ Fässler, Albertine, Merceriewarengesch., Herzogstrasse 23 [32.302]
 – Fr. Ad. (Münch), Vertrieb elektr. Aufzüge, Bollwerk 41 [22.514]
 – Frz. Friedr., Kommis, Kasernenstr. 21c
 – J., Coiffeurgeschäft (Effingerstrasse 42), Laupenstrasse 2 [32.360]
-– Maria Olga,, Schneiderin, Moserstrasse 20
+– Maria Olga., Schneiderin, Moserstrasse 20
 – V. A., Vorarbeiter S. S. B., Thunstrasse 107 [34.943]
 – Walter Paul, Monteur, Wylerstrasse 17
 – Willy, Coiffeur, Effingerstrasse 42
@@ -11206,7 +11194,7 @@ Faiio, Jules, Billetteur d. S. S. B., Schwarztorstrasse 93
 – Roger Marc, Reporteurlithograph, Freiburgstrasse 354, Bümpliz
 Fatton, Numa Ed., Beamter S. B. B., Muesmattstrasse 34
 Faucherre, Celine, Spulerin, Wiesenstrasse 79
-Fauconnet, Charles J., Dr. med.. Adjunkt b.eidg. Gesundheitsamt, Kapellenstrasse 30 [26.026]
+Fauconnet, Charles J., Dr. med., Adjunkt b.eidg. Gesundheitsamt, Kapellenstrasse 30 [26.026]
 Fauguel, Edm. G., Postkommis, Mittelstr. 34
 Faulhaber, Adele (Reber), Wwe., Rodtmattstrasse 37 [20.083]
 Fauser, Hans G., kaufm. Angest., Monbijoustrasse 26
@@ -11237,7 +11225,7 @@ Favre, Alb. (Ochsenbein), Sektionschef b. d.eidg. Steuerverwaltung, Bubenbergstr
 Favre, William Fr., Stationsvorst, d. B. L. S., Freiburgstrasse 169
 Fawer, Alfr., Handlanger, Bottigenstrasse 59, Bümpliz
 – Frieda (Bichsei), Knabenschneiderin, Fabrikstrasse 31
-– Friedr., Polizeigefreiter. Oberbottigenw. 40, Oberbottigen
+– Friedr., Polizeigefreiter, Oberbottigenw. 40, Oberbottigen
 – Gertrud, Angestellte, Fabrikstrasse 31
 – Lina Bertha, Glätterin, Aehrenweg 37, Bümpliz
 – Oskar, Hilfsarbeiter, Fabrikstrasse 31
@@ -11249,8 +11237,8 @@ Fechner, Hans, Kürschner, Gesellschaftsstrasse 18a [23.981]
 Fedi, Sabatino, Handlanger, Hofweg 5a
 Fegbli, Arth., Velos, Motos (Scheibenstr. 19a), Rep.-Werkst.: Breitenrainplatz 42 [36.544]
 – Werner, Schneider, Lorrainestrasse 6
-Fehlbaum, Ad.. Schmied, Zähringerstr. 14
-– Bertha. Strickwaren und Bonneterie engros, Sulgenauweg 38a [23.486]
+Fehlbaum, Ad., Schmied, Zähringerstr. 14
+– Bertha, Strickwaren und Bonneterie engros, Sulgenauweg 38a [23.486]
 – B., & Cie. Woil- und Baumwollgarne, Strumpfwaren, gestr. Sportartikel, mech. Strickerei, Kramgasse 33 [23.481]
 – Dora Maria, Verkäuferin, Zähringerstr. 14
 – Elisabeth (Galli), Privatiere, Distelweg 21
@@ -11398,8 +11386,7 @@ Fellmann, s. auch Feldmann
 – Arnold, Coiffeur, Morillonstrasse 8
 – Joh., Schneider, Muristrasse 87
 – Laura Ida (Botteron). Wwe. des Notars, Moserstrasse 42 (ab 1. Mai: Spitalackerstrasse 23) [34.729]
-– Nelly Gertrud, Notar (Moserstrasse 42, ab
-1. Mai: Spitalackerstrasse 23) [34.729]), Neuengasse 39 [29.852] (ab 1. Mai: Schanzenstrasse 1)
+– Nelly Gertrud, Notar (Moserstrasse 42, ab 1. Mai: Spitalackerstrasse 23 [34.729]), Neuengasse 39 [29.852] (ab 1. Mai: Schanzenstrasse 1)
 Felsenau, Bierbrauerei, Fährweg 33 [22.206]
 – Spinnerei, Felsenaustrasse 17 [22:216]
 – Wirtschaft, Fährweg 2 [22.254]
@@ -11464,25 +11451,25 @@ Rettungs- u. Sappeurkompagnie II, Tavelweg21 [32.043]; Arbeitsort: Schweiz. Volk
 – Hauptmann Hans Feuz, Kdt. der Löschkomp. III; Wohn- u. Arbeitsort: Lindenrain 1 [24.533]
 # Date: 1935-12-15 Page: 26020428/123
 Feuerwehr-Oberleutnant Hans Schmid, Wildermettweg 48 [23.640]; Arbeitsort: Grundbuchamt des Amtsbezirks Bern, Ferdinand-Hodlerstrasse 7 [24.034]
-– Oberleutnant Hugo Arber, Bubenbergstrasse 25 [34.198]; Arbeitsort; Zeughausgasse 27 [35.366]
-– Oberleutnant Fr. Kocher, Mittelstrasse 60 [32.006]; Arbeitsort: Elektrizitätswerk [20.221]
-– Leutnant Ernst Brechbühler, Effingerstrasse 59 [28.506]; Arbeitsort: Elektrizitätswerk [20.221]
-– Leutnant Hermann Niederhauser; Arbeits- u. Wohnort: Gesellschaftsstrasse 30a [22.446]
-– Leutnant Karl Schultbess, Landoltstr. 39 [32.041]; Arbeitsort: Elektrizitätswerk [20.221]
-– Arzt Dr. A. Leemann, Jubiläumsstr. 91 [22.516]
-– Arzt Fr. Mauderli, Scbanzenstr. 4 [28.950]
+– -Oberleutnant Hugo Arber, Bubenbergstrasse 25 [34.198]; Arbeitsort; Zeughausgasse 27 [35.366]
+– -Oberleutnant Fr. Kocher, Mittelstrasse 60 [32.006]; Arbeitsort: Elektrizitätswerk [20.221]
+– -Leutnant Ernst Brechbühler, Effingerstrasse 59 [28.506]; Arbeitsort: Elektrizitätswerk [20.221]
+– -Leutnant Hermann Niederhauser; Arbeits- u. Wohnort: Gesellschaftsstrasse 30a [22.446]
+– -Leutnant Karl Schultbess, Landoltstr. 39 [32.041]; Arbeitsort: Elektrizitätswerk [20.221]
+– -Arzt Dr. A. Leemann, Jubiläumsstr. 91 [22.516]
+– -Arzt Fr. Mauderli, Scbanzenstr. 4 [28.950]
 Feuerwehr Bern-Bümpliz; Löschbezirk II.
-– Kommandant Fritz Reist. Heimstrasse 17 [46.189]; Arbeitsort: Sekundarschulhaus (während des Schulunterrichtes) [46.117]
-– Hauptmann Alfred Schwalm. Stellvertret.u. Kdt. d. Löschkp. I Bümpliz, Brünnenstrasse 50 [46 121]; Arbeitsort: Sekundarschulhaus (während d. Schulunterrichtes) [46.117]
-– Hauptmann Gottfr. Wüthrich und Kdt.d. Löschkp. II Bottigen, Riedbach [46.013]
-– Hauptmann Rob. Spahr, Quartiermeisterund Materialoffizier; Wohn- u. Arbeitsort: Brünnenstrasse 119 [46.037]
-– Oberleutnant Rudolf Spillmann, Kdt. der Löschabteilung Bümpliz, Freiburgstr. 372 [46.145]; Arbeitsort: Buchdruck. Benteli [46.191]
-– Leutnant Jakob Eberhard, Löschabteilung Bümpliz; Wohn- und Arbeitsort: Morsrenstrasse 9 [46.209]
-– Oberleutnant Fritz Bigler, Kdt. d. Leiternund Rettungsabteilung. Bümplizstrasse 16 [46.004]; Arbeitsort: Publicitas A.-G., Bern [27.351]
-– Leutnant Fr. Spillmann, Hauswart, Primarschulhaus Bümpliz, Bernstrasse 35 [46.07P]
-– Oberleutnant Ernst Sehori, Kdt. d. Pikettsder Motorspritze, Wohn- und Arbeitsort: BcTtigenstrasse- 37 [46.148]
-– Leutnant Thomet, Albert, Kdt. der Löschabt. Bottigen, N.-Bottigen [Riedbach 13]
-– Arzt: Dr. M. Fankhauser. Keltenstr 108 [46.040]
+– -Kommandant Fritz Reist. Heimstrasse 17 [46.189]; Arbeitsort: Sekundarschulhaus (während des Schulunterrichtes) [46.117]
+– -Hauptmann Alfred Schwalm. Stellvertret.u. Kdt. d. Löschkp. I Bümpliz, Brünnenstrasse 50 [46 121]; Arbeitsort: Sekundarschulhaus (während d. Schulunterrichtes) [46.117]
+– -Hauptmann Gottfr. Wüthrich und Kdt.d. Löschkp. II Bottigen, Riedbach [46.013]
+– -Hauptmann Rob. Spahr, Quartiermeisterund Materialoffizier; Wohn- u. Arbeitsort: Brünnenstrasse 119 [46.037]
+– -Oberleutnant Rudolf Spillmann, Kdt. der Löschabteilung Bümpliz, Freiburgstr. 372 [46.145]; Arbeitsort: Buchdruck. Benteli [46.191]
+– -Leutnant Jakob Eberhard, Löschabteilung Bümpliz; Wohn- und Arbeitsort: Morsrenstrasse 9 [46.209]
+– -Oberleutnant Fritz Bigler, Kdt. d. Leiternund Rettungsabteilung. Bümplizstrasse 16 [46.004]; Arbeitsort: Publicitas A.-G., Bern [27.351]
+– -Leutnant Fr. Spillmann, Hauswart, Primarschulhaus Bümpliz, Bernstrasse 35 [46.07P]
+– -Oberleutnant Ernst Sehori, Kdt. d. Pikettsder Motorspritze, Wohn- und Arbeitsort: BcTtigenstrasse- 37 [46.148]
+– -Leutnant Thomet, Albert, Kdt. der Löschabt. Bottigen, N.-Bottigen [Riedbach 13]
+– -Arzt: Dr. M. Fankhauser. Keltenstr 108 [46.040]
 Feurer, Walter, Buchbindermeister (Junkern– gasse 3), Herrengasse 11 [36.415]
 Feurich, Max E., Optiker, Waagüausgasse 7
 Feusi, A. (Boiler), Dr., Gymn.-Lehrer, Bühlstrasse 17 [24.456]
@@ -11495,15 +11482,15 @@ Feuz, Christ., Chauffeur, Engerain 24
 – Ernst Gottl., Gymn.-Lehrer, Kanonenw. 18 [27.835]
 – Frieda, Vorgängerin, Spitalackerstrasse 16
 – Gottfr. (Kraus), Annoncen und Reklamen, Viktoriarain 21 [29.284]
-– Gottfr., Missionsarbeiter. Allmendstrasse 39
+– Gottfr., Missionsarbeiter, Allmendstrasse 39
 – Gottl., Adjunkt d. kant. Kirchen- u. Armendirektion, Srhillingstrasse 20 [28.894]
 – Gottl., pens. Postangestellter, Turnweg 21
 – Gusiav, kaufm. Angest., Rodtmattstr. 60
-– Hs., Baumeister. Lindenrain 1 [24.533]
+– Hs., Baumeister, Lindenrain 1 [24.533]
 – Hs., Maurer, Lindenrain 1
 – Hans, Angestellter, Lentulusstrasse 49
 – Hans, Maschinenmeister, Länggassstr. 76
-– Hans CJhielert), pens. Tramangestellter, Friedheimweg 12a
+– Hans (Thielert), pens. Tramangestellter, Friedheimweg 12a
 – Herm. (Beiner), Angest. A. T. S., Fellenbergstrasse 5
 – J. (Maurer), gew. Wagnermeister, Steinauwfeg 28
 – Marg. B., Bureaulistin, Altenbergs.tr. 110
@@ -11529,7 +11516,7 @@ Filan, Simon, Bureaulist, Stauffacherstr. 27
 – Vera, Bureaulistin, Stauffacherstrasse 27
 Filippini, Guido, Radiotelegraphist, Gesellschaftsstrasse 29
 Fillettaz, Louis Constant, Maurer, Freiburgstrasse 505d, Bümpliz
-Filleux, Alb., Bankangestellter. Effingerstr. 59 [23.942]
+Filleux, Alb., Bankangestellter, Effingerstr. 59 [23.942]
 – Andre Alb., Coiffeur, Effingerstrasse 59
 – Roger, kaufm. Angest., Effingerstrasse 59
 Filii, Haidy, Laborantin, Mattenhofstrasse 32
@@ -11607,7 +11594,7 @@ Fischbach, Ernst, Pferdewärter, Freiburgstrasse 140
 Fischbacher, Alfr., Elektrotechniker E. W. B., Parkstrasse 52
 – Marg., eidg. Beamtin, Ludwig-Forrerstr. 28
 v. Fischer, Alice, Frl., Laubeckstrasse 40 (Kl. Schönberg) [21.462]
-– B. Friedrich, Fürsprecher, in Fa. Stettier, v. Fischer & Cie (Sulgeneckstrasse 48, Villa Sulgenrain (33.248]), Bubenbergplatz 8 [22.945]
+– B. Friedrich, Fürsprecher, in Fa. Stettier, v. Fischer & Cie (Sulgeneckstrasse 48, Villa Sulgenrain [33.248]), Bubenbergplatz 8 [22.945]
 – Bertha Constance Hilda, Boiligenstrasse 20
 – Ed. (Grüner), Dr. phil., pens. Prof., Kirchenleidstrasse 14 [22.095]
 – El Math. (v. Becker), Wwe., Privatiere, Morgenstrasse 67, Bümpliz [46.287]
@@ -11624,8 +11611,8 @@ Fischer, A., Dr. 📞 23.940 Med. Institut. Spezialarzt für Magen-, Darm-, Herz
 – Achilles, kaufm. Angest., Blumenbergstr. 14
 # Date: 1935-12-15 Page: 26020430/125
 Fischer, Ad., Hotel Metropole-Monopole, Zeughausgasse 28 [25.021]
-– Ad.. Monteur Gerechtigkeitsgasse 16
-– Alb. Jul., Hilfsarbeiter. Kramgasse 39
+– Ad., Monteur Gerechtigkeitsgasse 16
+– Alb. Jul., Hilfsarbeiter, Kramgasse 39
 – Alb., kant. Beamter, Steigerweg 14
 – Albrecbt, Beamter O. T. D. Egghölzliw. 48 [27.918]
 – Alfr., Anschläger, Berchtoldstrasse 9
@@ -11647,7 +11634,7 @@ Fischer, Ad., Hotel Metropole-Monopole, Zeughausgasse 28 [25.021]
 – Edwin (Letsch), Beamter S. B. B., Kirchbergerstrasse 47 [45.646]
 – Edwin, Lehrer, Sägehofweg 18, Bümpliz [46.047]
 – Elisabeth, Krankenpflegerin, Allmendstr. 14
-– Ella Sophie, Bankangest.. Länggassstr 102
+– Ella Sophie, Bankangest., Länggassstr 102
 – Emil, Handel in Automobilen, Rep.-Werkstätte, Brunnadernstrasse 28 [28.576]
 – Emma, Telegraphistin, Schanzeneckstr. 17
 – Ernst, Dr., Betriebsbeamter der B. L. S./
@@ -11673,7 +11660,7 @@ B. N., Humboldtstrasse 19 [27.849]
 – Gottfr., Schuhmacher, Brunnhofweg 27
 – Gustav, Schuhmachermeister, Greyerzstr. 19 [34.488]
 – H. (Milter), Wyttenbachstrasse 15
-– Hans, Beamter S. B. B.. Lorrainestr. 4
+– Hans, Beamter S. B. B., Lorrainestr. 4
 – Hans Alb., Beamter d. S. B. B., Waldheimstrasse 10a
 Fischer, Hans U. (Wassmuth), Graphiker, Kramgasse 14 [25.023]
 – Hs. Wilh., Visiteur der S. B. B., Freiburgstrasse 368, Bümpliz
@@ -11743,10 +11730,10 @@ Fjtze, Jakob, Schlosser, Murifeldweg 40
 Fivian, s. auch Vifian
 – Adolf. Handlanger, Parkstrasse 5
 – Charlotte, Coiffeuse, Polygonweg 10
-– Ernst. Bauamtarbeiter. Schifflaube 18
+– Ernst, Bauamtarbeiter, Schifflaube 18
 – Ernst (Grünig), Depothandwerker, Könizstrasse 49
-– Friedr. Hilfsarbeiter. Stöckackerstrasse 74, Bümpliz
-– Fr.. Bahnarbeiter, Stöckackerstrasse 74, Bümpliz
+– Friedr. Hilfsarbeiter, Stöckackerstrasse 74, Bümpliz
+– Fr., Bahnarbeiter, Stöckackerstrasse 74, Bümpliz
 – Gottl., Fabrikarbeiter, Polygonweg 10
 – Herm., Magaziner, Wabernstrasse 77
 – Ida R., Telephonistin, Brückenstrasse 59
@@ -11759,10 +11746,10 @@ Fivian, s. auch Vifian
 – Rud., Lokomotivheizer. Könizstrasse 55
 – Rud., Stempelsetzer, Stöckackerstrasse 74, Bümpliz
 – Rud., Tramarbeiter, Pestalozzistrasse 15
-– Rud.. Zeughausarbeiter. Laubeckstr. 36
+– Rud., Zeughausarbeiter, Laubeckstr. 36
 – Werner, Beamter S. B. B., Friedenstr. 15
 Flaach, Alfr. Ernst, Tambour-Instr. 3. Divis., Zeigerweg 6
-– Hch Jost, Angestellter. Allmendstr. 39
+– Hch Jost, Angestellter, Allmendstr. 39
 Flachsmann, Adolf, Kfm., Jurablickstrasse 20 (Gurten-Gartenstadt) [45.623]
 Flaigg, Gustav Ad., Prokurist, Kirchenfeldstrasse 32
 Fleck, Anna El. (Schwarz), Wwe., Stalden 1
@@ -11829,7 +11816,7 @@ Flückiger und Flükiger
 – Alfr., Magaziner, Kasernenstrasse 11 d
 – Alfr., Mechaniker, Elisabethenstrasse 29
 – Alfred Erwin, Bankangest., Diesbachstr. 27 [29.847]
-– Alfr.. Fabrikarbeiter, Hohgantweg 5
+– Alfr., Fabrikarbeiter, Hohgantweg 5
 – Alfr., Privatier, Reichenbachstr. 72 [27.128]
 – Alfred, Schlosser, Dapplesweg 2
 – Alfred (v. Wartburg), Schlosser, Metzgergasse 6
@@ -11848,8 +11835,7 @@ Flückiger und Flükiger
 – Eduard. Kaufmann. Lorrainestrasse 21
 – Eduard, Zimmermann, Waldheimstrasse 51
 – Elly Martha. Ladentochter, Zeughausg. 31
-– Emil, Schneidermeister, Scheuermattw. 12
-. [31.015]
+– Emil, Schneidermeister, Scheuermattw. 12 [31.015]
 – Emma, Bureauangestellte, Zeughausg 28
 – Emma H., Drogistin, Reichenbachstr. 72
 – Erika Fr., Bureaulistin, Hauensteinstr. 16
@@ -11865,8 +11851,8 @@ Flückiger und Flükiger
 – Ernst (Läppert), in Fa. Flückiger & Co., Erlachstrasse 5 [23.417]
 – Ferd., Bahnarbeiter, Tscharnerstrasse 22
 – Frieda, Ladentochter, Brunngasse 4
-– Fr.. Schlosser, Herrengasse 8
-– Friedr.. Chauffeur. Zentralweg 20
+– Fr., Schlosser, Herrengasse 8
+– Friedr., Chauffeur. Zentralweg 20
 – Friedr., Handlanger, Engehaldenstr. 200
 – Friedr., Fabrikarbeiter, Seftigenstrasse 19
 – Friedr., Hilfsarbeiter, Postgasse 27
@@ -11894,7 +11880,7 @@ Flückiger und Flükiger
 – Hans Alex., Ausläufer E.-W., Granatweg 2
 – Hans, Depotarbeiter, Freiburgstrasse 472, Bümpliz
 – Hans Otto, Chauffeur, Morellweg 12
-– Hans. Dr. phil.. Gymn.-Lehrer, Hallwylstrasse 28 [36.613]
+– Hans. Dr. phil., Gymn.-Lehrer, Hallwylstrasse 28 [36.613]
 – Hans, Hilfsarbeiter, Werkg. 20, Bümpliz
 – Hans, Hufschmied. Schützenweg 5
 – Hans, Magaziner, Kramgasse 17
@@ -11905,7 +11891,7 @@ Flückiger und Flükiger
 – Hedwig F., Allmendstrasse 36
 – Herm., Buchbinderei. Marktg. 54 [24.981]
 – Hort. Emilie (Guerne), Diesbachstrasse 27
-– Hulda. Damenschneid.. Engehaldenstr. 200
+– Hulda. Damenschneid., Engehaldenstr. 200
 – Ida, Hausiererin, Stauffacherstrasse 5
 – Ida. Speziererin, Murifeldweg 33 [31.291]
 – Jakob (Flury), Aufseher im Parlamentsgebäude, Militärstrasse 46
@@ -11916,7 +11902,7 @@ Flückiger und Flükiger
 – Joh. ITch., gew. Hauswart, Rohrweg 6
 – Joh., Hilfsarbeiter, Werkg. 20, Bümpliz
 – Joh., pens. Bahnarbeiter, Hauensteinstr.16
-– Joh.. Schlosser, Wiesenstrasse 17
+– Joh., Schlosser, Wiesenstrasse 17
 – Joh. Friedr., Schlosser W.-F., Talweg 1
 – Irma, Sekretärin. Liebeggweg 10
 – Karl, Fabrikarbeiter, Murtenstrasse 135
@@ -11934,15 +11920,15 @@ Flückiger und Flükiger
 – Marie, Hilfsarbeiterin, Murifeldweg 33
 – Martha, Beamtin der städt. Armendirektion, Predigergasse 8
 – Martha M., Verkäuferin, Hallerstrasse 19
-– Max Eug., Bankangest., Diesbachstr. 27 .
-– Nikl. Friedr., kant. Angest.. Federweg 29d
+– Max Eug., Bankangest., Diesbachstr. 27
+– Nikl. Friedr., kant. Angest., Federweg 29d
 – Nikl., Mechaniker, Kramgasse 9 [20.813]
 # Date: 1935-12-15 Page: 26020433/128
 Flückiger und Flükiger
 – Oskar (Müller), in Fa. Schüler A.-G., graph. Anstalt Biel, Länggassstrasse 51a [33.050]
 – Otto, Chauffeur, Sägehofweg 17, Bümpliz
 – Paul, Bureaudiener, Elisabethenstrasse 29
-– Paul Siegfr. (Senn), Adjunkt d. kant. Zentralsteuerverwaltg.. Jennerweg 3 [33.218]
+– Paul Siegfr. (Senn), Adjunkt d. kant. Zentralsteuerverwaltg., Jennerweg 3 [33.218]
 – Paul, Dr. jur., Fürspr. (Anshelmstrasse 16 [31.337]), Laupenstrasse 9, Suvahaus [25.317]
 – Paul, Kaufmann, Drosselweg 13
 – Paul Fritz, Sek.-Lehrer, Dorngasse 8
@@ -11953,7 +11939,7 @@ Flückiger und Flükiger
 – Rosa, Hilfsarbeiterin, Rohrweg 6
 – Rosa Klara, Modistin, Muristrasse 54
 – Rosette. Näherin. Kapellenstrasse 18
-– Rud.. Telephonarbeiter. Postgasse 58
+– Rud., Telephonarbeiter, Postgasse 58
 – Rud., Hilfsarbeiter, Kasthoferstrasse 14
 – Ulr., Schneidermeister, Monbijoustrasse 9 [33.193]
 – Walter, Bäcker, Tscharnerstrasse 25
@@ -11966,10 +11952,10 @@ Flückiger und Flükiger
 – Willi Walter, Bereiter, Burgernzielweg 10a
 – & Hofmann, elektr. Installationen, Belpstrasse 39c [29.917]
 – B., & Cie., Rauchabsaugungsanlagen, feuerungstechn. Bureau, Hoch- und Tiefbau, Monbijoustrasse 22 [29.066]
-— E., & Co.. Handel u. Fabrikation v. Druckfarben, Erlachstrasse 5
+— E., & Co., Handel u. Fabrikation v. Druckfarben, Erlachstrasse 5
 Flüeler, Jos. Melchior, Postchauffeur, Wylerfeldstrasse 41
 – Martin Gottl., Informationsbüro Fox (Murifeldweg 5), Marktgasse 42 [21.387]
-Flügel, Friedr. Wilh., pens. Hausmeister, Alleeweg 2i— Karl W. A.. Elektrotechniker, Landoltstr. 77
+Flügel, Friedr. Wilh., pens. Hausmeister, Alleeweg 2i— Karl W. A., Elektrotechniker, Landoltstr. 77
 — Marie Bertha, Holzikofenweg 22
 – Martha, Verkäuferin, Muristrasse 99
 — P., Elektro-Ing. S. B. B., Falkenhöhew. 19 [20.722]
@@ -11983,7 +11969,7 @@ Flühmann, Alex., Handlanger, Stalden 14
 – Anna (Freudiger), Wwe., Wylerstrasse 16
 — Bertha, Bureaulistin, Neufeldstrasse 27b
 – Christ., Elektromonteur, Standstrasse 11
-»— Christ., Maurer, Oberbottigenweg 142, Riedbach
+— Christ., Maurer, Oberbottigenweg 142, Riedbach
 Flühmann, Ed., Spengler, Bümplizstrasse 75
 – Elise, Glätterin, Aebistrasse 15
 – Emil, Malermstr., Länggassstr. 75 [36.475]
@@ -11993,7 +11979,7 @@ Flühmann, Ed., Spengler, Bümplizstrasse 75
 – Fritz. Hilfsarbeiter, Mattenenge 9
 – Fritz, Karrer, Mühleplatz 12
 – Gottfr., Handlanger, Murtenstrasse 58
-– Gottfr., Pferdewärter. Rodtmattstrasse 94
+– Gottfr., Pferdewärter, Rodtmattstrasse 94
 – Gottl., Pferdewärter, Breitfeldstrasse 42
 – Gottl., Steinhauer, Bümplizstrasse 75
 – Hans, Auto-Mechaniker, Bümplizstr. 115
@@ -12006,11 +11992,11 @@ Flühmann, Ed., Spengler, Bümplizstrasse 75
 – Joh., Automechaniker, Unt. Villettenmattstrasse 7
 – Joh., Hilfsarbeiter, Ladenwandstrasse 53
 – Karl, Koch, Freiburgstr. 186, Bümpliz
-– Karl, Wagenreiniger S. B. B.. Aebistr. 15
+– Karl, Wagenreiniger S. B. B., Aebistr. 15
 – Mina Elise, Heimpflegerin, Bümplizstr. 75
 – Rud., Einleger, Hohgantweg 16
 – Rud., Kaufmann, Birkenweg 10
-– Rudolf. Ausläufer S. M. V. G.. Schifflaube 48
+– Rudolf. Ausläufer S. M. V. G., Schifflaube 48
 – Rudo, G.artenarbeiter, Vennerweg 3
 – Samuel, Händler, Bahnhöheweg 102, Bümpliz
 – Samuel Fr., Schlosser, Wachtelweg 15
@@ -12039,7 +12025,7 @@ Flury, Aloys (Leemann), Kaufmann, Spitalackerstrasse 5 [27.740]
 # Date: 1935-12-15 Page: 26020434/129
 Flury, Franz Herm., Kaufmann, Tillierstr. 49 [32.904]
 – Franz, Oberregistrator der Bundeskanzlei, Jubiläumsstrasse 60
-– Fr. Max, Kaufmann, in Fa. E. Flurys Wwe. & Söhne, Humboldtstr. 17 r36.120]
+– Fr. Max, Kaufmann, in Fa. E. Flurys Wwe. & Söhne, Humboldtstr. 17 [36.120]
 – Hermann (Gut), kant. Beamter, Waisenhausplatz 21 [36.642]
 – Herm. Oskar, Elektromechaniker, Stöckackerstrasse 99a, Bümpliz
 – Hugo Mathias, Bureaulist, Brückenstr. 3
@@ -12052,7 +12038,7 @@ Flury, Franz Herm., Kaufmann, Tillierstr. 49 [32.904]
 – Paul (Meyer), Sulgeneckstr. 35 [36.173]
 – Ph., Wwe., in Fa. E. Flurys Wwe. & Söhne, Rainmattstrasse 16 [21.596]
 – R. (Müller), Dr. med., homöopath. Arzt, Aegertenstr. 6, Ecke Bernastrasse [28.838]
-– Steph. .4. (Bannwart), Wwe. des Generaldirektors d. S. B. B.. Wildhainweg 19
+– Steph. .4. (Bannwart), Wwe. des Generaldirektors d. S. B. B., Wildhainweg 19
 – Viktor, Fabrikant, Bühlplatz 1 [35.285]
 – Walter (Mathys), Souschef der S. B. B., Sennweg 15
 – Walter, kaufm. Angest., Seidenweg 60
@@ -12094,7 +12080,7 @@ Forestier, Alexis M., Tapezierer, Freiburgstrasse 53
 Fornara, Ezio, Monteur, Gesellschaftsstr. 25
 Fornaro, Louise M. Fr., Heimarbeiterin, Wiesenstrasse 83
 – Rosa (Jenni), Wwe., Sulgenbachstrasse 14
-Fornerod, Chs. Rob., Techn.,, Bundesrain 12
+Fornerod, Chs. Rob., Techn.., Bundesrain 12
 Fornoni, G., Musiker, Kesslergasse 16
 Foroughi, Abol-Hassan Khan, persischer Gesandter, Hotel Bellevue-Palace
 Forrer, Alfred, Beamter, Daxeihoferstrasse 5
@@ -12144,7 +12130,7 @@ Frachebourg, Cesar, Telegraphist, Brünnenstrasse 105, Bümpliz
 Fräfel, Albert, Kino-Portier, Dalmazirain 34
 – Aug., Kaufmann, Muristrasse 71
 – Joh., Kino-Operateur, Wylerstrasse 67
-Fragniere, Ls., Pferdewärter. Rodtmattstr. 46
+Fragniere, Ls., Pferdewärter, Rodtmattstr. 46
 Franchini, Giuseppe (Bottinelli), Maurer, Weingartstrasse 49
 – Jeanne, Coiffeuse, Damensalon, Schauplatzgasse 27 [33.317]
 – Umberto, Vertreter, Schauplatzgasse 27
@@ -12153,7 +12139,7 @@ Francisco, Enrico, Chefmineur, Berchtoldstrasse 9
 – Juiietta, Falzerin, Berchtoldstrasse 9
 Franck, C. (Socin), Handharfenfabrikant, Reparaturen (Jurastr. 15), Effingerstr. 4 [28.760]
 Francke, s. auch Franke
-– A., A.-G., Buch-, Kunst- und Landkartenhandlung, Bubenbergplatz 6 [21 7151
+– A., A.-G., Buch-, Kunst- und Landkartenhandlung, Bubenbergplatz 6 [21.715]
 Franco, Fabrizio, Sekr. der ital. Gesandtschaft, Egelgasse 49 [20.803]
 Franco-Suisse Edition photographique (Ls. Alfr. Boss), Verlag in Ansichtskarten, Papier en gros. Birkenweg 49 [32.084]
 Frandsen, Anna M., Verkäuf., Gesellschaftsstrasse 22
@@ -12176,7 +12162,7 @@ Frank, Anton, Zuschneider, Wabernstr. 16
 – Robert, Handlanger, Schönauweg 6
 – Rudolf, Uhrmacher, Lentulusstrasse 33
 – Ulrich, Maler, Brunngasse 2
-– Walter. Ausläufer, Brunngasse 16
+– Walter, Ausläufer, Brunngasse 16
 – Walter, MaJer, Belpstrasse 67
 – Werner, Bäcker, Thunstrasse 18
 Franke, s. auch Francke
@@ -12192,7 +12178,8 @@ Franz, Adolf, Handlanger, Neufeldstr. 27a
 – Agnes J. M., Bärenplatz 9
 – Alb. Osk., Kaufmann, Sennweg 5
 – Ernst Otto, Dr. med., Assistent, Mühlemattstrasse 20 [21.822]
-– Marie, Ladentochter, Breitenrainstrasse 41v. Franz - v. Ernst. Ida. Freifrau, Laubeckstrasse 38 [28.138]
+– Marie, Ladentochter, Breitenrainstrasse 41
+v. Franz - v. Ernst. Ida. Freifrau, Laubeckstrasse 38 [28.138]
 Franzi. Theodor, Coiffeurgeschäft. Effingersfrasse 94 [33.i13]
 Franzoni, Alessandro (Stephan), städt. Beamter, Effingerstrasse 65
 – Ettore, Sekretär der Oberpostdirektion, Kirchbergerstrasse 28 [45.499]
@@ -12201,12 +12188,12 @@ Französische Botschaft, Kanzlei, Sulgeneckstrasse 44 [23.854]
 Französisches Konsulat, Kanzlei, Sulgeneckstrasse 44 [23.856]
 Fraschina, Carlo, Chemiker, Maulbeerstr 5
 – Mario, Beamter S. B. B., Neubrückstr. 70
-Frauch, A.. gew Materialverwalter S. B. B., Tscharnerstrasse 20
+Frauch, A., gew Materialverwalter S. B. B., Tscharnerstrasse 20
 Frauchiger, Adelheid, Gehilfin der K. T. D., BrückensUasse 21
-– Alfr ; , Bauhilfsarbeiter, Junkerngasse 15
+– Alfr., Bauhilfsarbeiter, Junkerngasse 15
 – Elise, Fakturistin, Kramgasse 40
-– Ernst (Oppliger), Verw.-Rat, Aarbergergasse 23 [27.5751
-– Ernst Fr.. Prokurist, Diesbachstrasse 25
+– Ernst (Oppliger), Verw.-Rat, Aarbergergasse 23 [27.575]
+– Ernst Fr., Prokurist, Diesbachstrasse 25
 # Date: 1935-12-15 Page: 26020436/131
 Frauchiger, Ernst Fr., Spengler-Installateur, Gesellschaftsstrasse 18
 – Friedr., pens. Bahnangestellter, Muldenstrasse 7
@@ -12239,7 +12226,7 @@ Frauenverein Länggass-Brückfeld, Arbeitsausgabe, Verkaufslokal Länggassstrass
 Frautschi, Friedr. W., Bantigerstrasse 14
 – Joh. A. P., Alleeweg 38
 Fravi, Emma (Casparis), Wwe., Wernerstr. 6 [29.560]
-Frech, Wilh.. Schreinermeister (Blumensteinstrasse 6). Murtenstrasse 37 [22.558]
+Frech, Wilh., Schreinermeister (Blumensteinstrasse 6). Murtenstrasse 37 [22.558]
 Fredoli, Alfredo, Buchdrucker, Tscharnerstrasse 25
 Frei siehe Frey
 Freiburger, Charles, Vertreter, Manuelstr. 72 [32.763]
@@ -12251,7 +12238,7 @@ Freiburghaus, Adolf, Karrer, Weissensteinstrasse 25
 – Arnold Albert, Beamter, Bantigerstr. 28
 – Arnold, Chauffeur, Lorrainestrasse 51
 – Christ., Bauamtarbeiter, Freiburgstr. 131
-– Christ., Fuhrhalter. Stegenweg 21. Bümpliz
+– Christ., Fuhrhalter, Stegenweg 21. Bümpliz
 – Christ Alb., Pflästerer, Forstweg 69
 – Eduard, Radiotechniker, Metzgergasse 56
 Freiburghaus, Elisabeth, Angestellte, Kirchbergerstrasse 1
@@ -12273,7 +12260,7 @@ Freiburghaus, Elisabeth, Angestellte, Kirchbergerstrasse 1
 – Friedr., Möbelschreiner, Sandrainstr. 7
 – Friedr., Schuhmacher, Schulweg 9
 – Fritz, Chauffeur, Blumensteinstrasse 4
-– Fritz. Hilfsarb.. Aehrenweg 21, Bümpliz
+– Fritz. Hilfsarb., Aehrenweg 21, Bümpliz
 – Fritz, Kaufmann, Kalcheggweg 17
 – Fritz, Metzgermeister, Stalden 24 [23.608]
 – Fritz (Berger), Prokurist in Fa. Hs. Christen, techn. Vertretungen « Frigidaire», Gutenbergstrasse 10 [36.237]
@@ -12326,7 +12313,7 @@ Frenz, Dora, Damenschneiderin, Tannenw. 16
 – Frieda. Damenschneiderin, Tannenweg 16
 – Lina (Bücher), Wwe., Tannenweg 16
 – Osk. (Rohny), Kassenbau Berna u. Schlosserei (Freiestrasse 52), Tannenweg 16 [35.875]
-— Willi., Kassenfabrik und Schlosserei (Dalmazirain 32 [28.082}), Grabenpromenade 13 [33.699]
+— Willi, Kassenfabrik und Schlosserei (Dalmazirain 32 [28.082]), Grabenpromenade 13 [33.699]
 Fresard, Blanche M. M., Postangest., Kapellenstrasse 7
 – Marc A. M. G., Postbeamter, Kapellenstr. 7
 – Suz. C. V., Bureaulistin, Kapellenstr. 7
@@ -12344,7 +12331,7 @@ Freudiger, Anna L., Schneiderin, Schwarztorstrasse 96
 – Karl E., Kommis, Breitfeldstrasse 17
 – Karl Jakob, Schlosser, Breitfeldstrasse 17
 – Rob., Materialverwalter, Schwarztorstr. 96 [32.972]
-– Rob- E.. Maschinenschlosser, Schwarztorstrasse 96
+– Rob- E., Maschinenschlosser, Schwarztorstrasse 96
 – Walter A., Elektromechan., Breitfeldstr. 17
 Freuler, Jos. Franz, eidg. Beamter, Sandrainstrasse 83
 Freund, Karl Willi, Musiker, Laupenstr. 33
@@ -12367,7 +12354,7 @@ Frey und Frei
 – Alphons Friedr. (Schweighauser), Uhrmacher u. Uhrenhdlg. (Holzikofenweg 7), Dapplesweg 2 [21.650]
 – Anna, Damenschneiderin, Pestalozzistr. 12
 – Arnold (Kummer), Maler, Murifeldweg 19
-– A., A.-G.. Kleiderfabrik, Verkaufsfiliale: Bahnhofplatz 9 [33.225]
+– A., A.-G., Kleiderfabrik, Verkaufsfiliale: Bahnhofplatz 9 [33.225]
 – August, Muristrasse 3
 – B., Frau, Damenschneiderin, Kasernenstrasse 40 [29.825]
 – Bernhard, Dr. med. vet., prakt. Tierarzt, Hunde- und Kleintiersanatorium, Köniz-Oberbuchsee [45.504]
@@ -12385,11 +12372,11 @@ Frey und Frei
 – Emil Werner, Handlanger, Weidmattw. 12, Bümpliz
 – Emil (Bähler), Beamter S. B. B., Brückfeldstrasse 26
 – Emil, kaufm. Angestellter, Schanzenstr. 6
-– Emil Ad.. Maschinenmeister. Lagerhausweg 2. Bümpliz
+– Emil Ad., Maschinenmeister, Lagerhausweg 2. Bümpliz
 – Emil, Schäfter, Standstrasse 31
 – Emil, Bahnarbeiter, Seftigenstrasse 27
 – Emilie B., Bureaulistin, Brückfeldstr. 35
-– Emilie Kath., Ladentochter. Neuengasse 45
+– Emilie Kath., Ladentochter, Neuengasse 45
 – Emma G., Bureaulistin, Niesenweg 2
 – Erika L., Bureaulistin, Wyderrain 13
 # Date: 1935-12-15 Page: 26020438/133
@@ -12413,7 +12400,7 @@ Frey und Frei
 – Gertrud, Bureaulistin, Murifeldweg 19
 – Gottfr., Elektriker, Aarbergergasse 26
 – Gottfr., Wylerringstrasse 45
-– Gottlieb, Bäckermeister. Betriebsleiter der
+– Gottlieb, Bäckermeister, Betriebsleiter der
 Bäckereigenossenschaft Bern. Konsumstrasse 19
 – Gustav Adolf, Bereiter, Breitfeldstrasse 26
 – Gustav, Maler, Mittelstrasse 19
@@ -12439,7 +12426,7 @@ Bäckereigenossenschaft Bern. Konsumstrasse 19
 Frey und Frei
 – Ida, Ladentochter, Dietlerstrasse 4
 – Ida, Handelsangestellte, Spitalgasse 27
-– J. Alb., Depotchef der S. S. B.. Tscharnerstrasse 19 [25.096]
+– J. Alb., Depotchef der S. S. B., Tscharnerstrasse 19 [25.096]
 – J. E., Schlosser, Brunngasse 28
 – J. E., Magaziner, Metzgergasse 62
 – J. J., Verwalter, Brückfeldstrasse 35
@@ -12460,10 +12447,10 @@ Frey und Frei
 – Julius, Schuhmachermeister, Muristr. 93 [21.593]
 – Karl, Bauamtarbeiter, Wasserwerkgasse 8
 – Karl. Buchbinder, Mittelstrasse 9 [29.688]
-– Karl Jak.. Bureaulist, Lentulusstrasse 44.
+– Karl Jak., Bureaulist, Lentulusstrasse 44.
 – Karoline, Glätterin, Aarbergergasse 34
 – Klara, Damenschneiderin, Altenbergstr. 13
-– Lina, Ladentochter. Neubrückstrasse 71
+– Lina, Ladentochter, Neubrückstrasse 71
 – Lina R., Verkäuferin, Mühlemattstr. 64
 – L. A. (Georges), Lombachweg 38
 – Lina Rosina, Näherin, Stalden 12
@@ -12501,17 +12488,16 @@ Frey und Frei
 – Paul, Coiffeurmeister (Aarstrasse 98), Hotel Bellevue-Palace [24.581]
 – Paul, kaufra. Angestellter, Kramgasse 23
 – Paul, Tapezierer u. Dekorateur, Wohlenstrasse 62c, Bümpliz
-– Rob. G. (Matter), Elektrotechniker, Brückfeldstrasse 29 [28.7961
+– Rob. G. (Matter), Elektrotechniker, Brückfeldstrasse 29 [28.796]
 – Rosa (Guhl), Diesbachstrasse 7 [34.164]
 – Rosina. Korrespondentin, Belpstrasse 11
 – Rud., Chauffeur, Eggimannstrasse 26
-– Rud.. Motor- u. Fahrradhdlg., elektr. Artikel, Dorngasse 2
+– Rud., Motor- u. Fahrradhdlg., elektr. Artikel, Dorngasse 2
 – Simon. Kaufmann. Viktoriarain 3
 – Theodor, Kaufmann, Vertretungen, Gesellschaftsstrasse 78
 – Theod Heinr., Chauffeur, Rossfeldstr. 19
 – Traugolt (Lindegger), Dr. jur., eidg. Beamter, Spitalackerstrasse 17
-– Walter. Prof. Dr. med.. Direktor d. mediz.
-Klinik (Hochfeldstr. 113 [27.407]), Freiburgstrasse 18 [65.337]
+– Walter, Prof. Dr. med., Direktor d. mediz. Klinik (Hochfeldstr. 113 [27.407]), Freiburgstrasse 18 [65.337]
 – Walter, Mechaniker, Schwarztorstrasse 55
 – Walter, Monteur, Rütlistrasse 7
 – Walter, Müller, Wohlenstr. 62c. Bümpliz
@@ -12536,7 +12522,7 @@ Frick und Frik
 – Friedr., Dienstchef der eidg. Oberzolldirektion, Schönbergweg 7 [35.968]
 Frick und Frik
 – Friedr., Elektrotechniker, Kramgasse 29
-– Hans Paul (v. Mülinen), Dr., Oberstlt., Sektionschef d. Generalstabsabtlg.. Schwarztorstrasse 35 [31.901]
+– Hans Paul (v. Mülinen), Dr., Oberstlt., Sektionschef d. Generalstabsabtlg., Schwarztorstrasse 35 [31.901]
 – Heinrich, jun., Kaufm., Weissenbühlw. 15 [20.760]
 – Hermann, Schreiner, Neufeldstrasse 118
 – Jakob, Spezereihdlg., Hubelmattstrasse 58 [36.378]
@@ -12558,7 +12544,7 @@ Fricker, Em., Dr. med., Spezialarzt für Magen- und Darmkrankheiten. Laupenstr. 
 – Ernst, Maler, Elisabethenstr. 36 [31.657]
 – Ernst (Eggler), Restaurant zur Blume, Neuengasse 17 [21.693]
 – J. Frieda (Knecht), Wwe. d. Fürsprechers, Kornhausstrasse 2 [33.492]
-– Jul., pens Bahnangest.. Elisabethenstr. 36
+– Jul., pens Bahnangest., Elisabethenstr. 36
 – Karl Otto, Reisender, Neufeldstrasse 135
 – Margr. L., Neuengasse 17
 – Werner. Beamter S. B. B., Landoltstr. 54
@@ -12644,7 +12630,7 @@ Friedli, Ernst, Kaufm., Unt. Dufourstr. 24
 – Fritz Eug., Bureauangestellter, Schlösslistrasse 45
 – Gertrud, Rodtmattstrasse 60
 – Gottfr., Hilfsarbeiter, Sulgenbaclistrasse 22
-– Gottl.. Spezialgeschäft für Bureaubedarf, Durchschreibebücher, Bernstr. 93, Bümpliz [46.502]
+– Gottl., Spezialgeschäft für Bureaubedarf, Durchschreibebücher, Bernstr. 93, Bümpliz [46.502]
 – Hanna Lydia, Lageristin, Aehrenweg 28, Bümpliz
 – Hans Alfred, Bankbeamter, Berchtoldstrasse 5 [31.330]
 – Hans, Bankprok., Steinerstrasse 5 [21.270]
@@ -12668,7 +12654,7 @@ E. W. B., Bethlehemstrasse 119, Bümpliz
 – M. Otto, Masch.-Schlosser, Pestalozzistr. 40
 – Margrit, Ladentochter, Herzogstrasse 24
 – i Marie, eidg. Beamtin, Thunstrasse 88
-– Marie (Reinli). Wwe.. Konradweg 13
+– Marie (Reinli). Wwe., Konradweg 13
 – Nelly M., Bankangestellte. Schlösslistr. 45
 – -Oskar Rob., stud. phil., Schillingstr. 15
 – Otto Albert, Chauffeur. Sonneggring 18
@@ -12715,7 +12701,7 @@ Fries, Emil Jak. O., eidg. Beamter, Viktoriastrasse 43
 – Karl Hrch., Buchbinder, Balmweg 29
 – Marie, Bureaulistin der O. P. D., Spitalackerstrasse 72
 – Moritz, pens. Angestellter S. B. B., Druckereiweg 3
-– Walter, eidg. Beamter. Berchtoldstrasse 7
+– Walter, eidg. Beamter, Berchtoldstrasse 7
 Frigidaire-Kühlanlagen (Hans Christen), Seilerstrasse 3 [28.711]
 Frignati, Bruno L. G., Maschinensetzer, Rodtmattstrasse 105
 Frigorrex A.-G., Kühlschränke u. Kühlanlagen, Monbijoustrasse 7 [28.049]
@@ -12850,7 +12836,7 @@ Fuchs, Adolf, Polizist, Lorrainestrasse 58
 – Moritz David, Dr. med., Hochfeldstr. 108
 – Paul, Hilfsarbeiter, Greyerzstrasse 44
 – Rud., Beamter, Bernastrasse 53
-– Rud.. Carionarbeiter. Randweg 9
+– Rud., Carionarbeiter, Randweg 9
 – Theresia, Stickerin, Mittelstrasse 6a
 – Zwicker, Schuhsohlerei u. Schuhfärberei, Sportschuhe, Spitalackerstr. 60 [32.998], Filiale Spitalgasse 37
 Fuchser, Alfred, Dienstmann, Steckweg 3
@@ -12907,7 +12893,7 @@ Führer, s. auch Furer
 – Fritz. Spengler, Mühleplatz 12
 – Gottfr., Dreher, Armand weg 8
 – Gottfr. (Blaser), Friedhofgärtner, Papiermühlestrasse 114 [32.319]
-– Gottfr.. Gärtner. Papiermühlestrasse 114
+– Gottfr., Gärtner. Papiermühlestrasse 114
 – Gottfr., Handlanger, Murtenstrasse 153f
 – Gottfr., Milchhandlung (Kornhausplatz 5), Zwiebelngässchen 8 [22.271]
 – Gottl. Friedr., Schmied. Metzgergasse 57
@@ -12942,9 +12928,9 @@ Führer, s. auch Furer
 – Willy Friedr., Magaziner, Altenbergstr. 132
 – Willy, Elektromechaniker, Gewerbestr. 20
 Fuhrimann, Alfred. Monteur, Bümplizstr. 83b
-– Ed. Alb., Radiotelegraphist, Stauffacherstrasse la
+– Ed. Alb., Radiotelegraphist, Stauffacherstrasse 1a
 – Ernst, Postillon, Dietlerstrasse 36
-– Gottfr., Telegr.-Angest. Stauffacherstr. la
+– Gottfr., Telegr.-Angest. Stauffacherstr. 1a
 – Ida. Ladentochter, Aarbergergasse 3
 – Marie (Aeschbacher), Wwe., Wiesenstr. 79
 – Werner, Karrer, Rodtmattstrasse 85
@@ -12968,7 +12954,7 @@ Funk, Alex. Otto, Elektriker, Beundenfeldstrasse 57
 – Paul Alex., Beamter, Kasernenstrasse 21a
 Funke, Otto, Dr., Prof., Wabernstrasse 38 [31.050]
 Fuog, Arthur (Lütolf), pens. Mechan., Wylerstrasse 51
-– Joh. H.. Mechaniker, Werdtweg 10
+– Joh. H., Mechaniker, Werdtweg 10
 Fürderer, Bertha Frieda, Damenschneiderin, Zähringerstrasse 64
 Furer und Furrer, s. auch Führer
 – A. Marie (Baumgartner), Wwe. d. Notars, Luisenstrasse 25 [33.160]
@@ -13005,7 +12991,7 @@ Furer und Furrer, s. auch Führer
 – Karl Rob., Inspektor d. O. Z. D., Finkenhubelweg 22 [28.782]
 – Margar., Ladentochter, Viktoriaplatz 25
 – Reinhold, Dr. jur., Generaldir. d. P. T. T., Zähringerstrasse 4 [25.220]
-– Robert (Sütterlin), Versich.-Beamter. Landoltstrasse 41 [32.449]
+– Robert (Sütterlin), Versich.-Beamter, Landoltstrasse 41 [32.449]
 – Rosa, Glätterei, Flurstrasse 25
 – Rosina (Wittwer), Friedhofarbeiterin, Niederbottigenweg 55, Bümpliz
 – Rud., kaufm. Angest., Ludw.-Forrerstr. 23
@@ -13036,14 +13022,14 @@ Fürst, Agnes (Wagner), Privatiere, Wildermettweg 59
 – Emil (Tschannen), städt. Beamter, Wildermettweg 59 [22.163]
 – Frieda (Brechbühl), Wwe., Zentralweg 23
 – Friedr., Kaufm., Monbijoustr. 18 [21.635]
-– Friedr.. Magaziner, Metzgergasse 69
-– Friedr.. Postgehilfe. Metzgergasse 69
+– Friedr., Magaziner, Metzgergasse 69
+– Friedr., Postgehilfe. Metzgergasse 69
 – Fritz Gottl., Prokurist, Bühlstrasse 44 [32.744]
 – Luise. Lehrerin. Scheuerrain 3
-– Walter. Angestellter S. B. B., Zaunweg 20
+– Walter, Angestellter S. B. B., Zaunweg 20
 – Walter, kaufm Angest., Brunnmattstr. 34a
 – Walter, Schreiner, Blumenbergstrasse 51
-– & Cie.. F., Schuhhandlung, Amthausg. 16 [28.975]
+– & Cie., F., Schuhhandlung, Amthausg. 16 [28.975]
 Furter, Ernst Otto, kaufm. Angest., Zähringerstrasse 47
 – Hans, Zollbeamter, Murtenstrasse 7
 Furtwängler, Elisa Henriette (Rouge), Privatiere. Brunnadernstrasse 36
@@ -13060,7 +13046,7 @@ Gaberthüel, Emma, Damenschneid., Schwarztorstrasse 22
 # Date: 1935-12-15 Page: 26020445/140
 Gabi, Alfr., Fuhrmann, Pavillonweg 13
 – Franz Hugo, Elektriker, Eggnnannstr. 20
-– Gertrud Bertha. Aushilfe, Herrengasse 1
+– Gertrud Bertha, Aushilfe, Herrengasse 1
 Gabi, Ernst Eugen, Magaziner, Römerweg 7
 Gabler, Gertrud A., Ladentochter, Gurteng. 6
 – Ida Frieda, Filialleiterin, Gurtengasse 6
@@ -13070,7 +13056,7 @@ Gabud, Rose A. M., Sekretärin, Effingerstr. 57
 Gabus, Louis, Tramangestellter, Dorng. 10a
 – Marthe, Kettlerin, Elfenauweg 28
 – Raoul Edm., Industrieller, Schwarztorstrasse 23
-Gächter, Hedwig Hulda, Arbeiterin, Gutenbergstrasse 1£
+Gächter, Hedwig Hulda, Arbeiterin, Gutenbergstrasse 19
 – Hulda, Frl., Murtenstrasse 5 [23.581]
 Gack, Martha Marg., Lingere, Bundesgasse 38
 Gaffner, s. auch Gafner
@@ -13159,7 +13145,7 @@ Galli, Gottfr., Bauarbeiter, Jurastrasse 29
 – Gottl., Hilfsarbeiter, Herzogstrasse 7
 – Hans, Techn. Artikel, Staubsauger (Sandrainstrasse 76), Bubenbergplatz 8 [36.546]
 – Jakob, Reisender, Sennweg d
-– J. Gottl.. gew. Telephonarb., Dapplesweg 11
+– J. Gottl., gew. Telephonarb., Dapplesweg 11
 – Lina (Hirschi), Wwe., Mittelstrasse 5
 – Martha E. (Kappeier), Wwe., Greyerzstr. 83
 – Martha (Brunner). Wwe., Konradweg 5
@@ -13335,18 +13321,18 @@ Gasser, Ad., kaufm. Angest. Manuelstrasse 99
 – Alfred, Chauffeur, Mattenhofstrasse 34
 # Date: 1935-12-15 Page: 26020448/143
 Gasser, Alice, Verkäuferin, Scheibenstr. 27a
-– Anna Sus.. Blumenbinderin, Tannenweg 7
-– Armin Hans, Schuhmachermeister. Thunstrasse 16/Ecke Luisenstrasse [31.169]
+– Anna Sus., Blumenbinderin, Tannenweg 7
+– Armin Hans, Schuhmachermeister, Thunstrasse 16/Ecke Luisenstrasse [31.169]
 – Arnold Christ., Revisor der O. P. D., Marziiistrasse 12
 – Arnold, Automietfährten, Waffenweg 11 [31.566]
 – Arnold, eidg. Beamter, Spitalackerstr. 61
-– Arnold. Hilfsarbeiter. Postgasse 27
+– Arnold. Hilfsarbeiter, Postgasse 27
 – Arnold Ludwig. Reisender. Wiesenstr. 30
-– Bertha. Bureaulistin. Rodtmattstrasse 108
+– Bertha, Bureaulistin. Rodtmattstrasse 108
 – Bertha Margr., Verkäuferin, Pestalozzistrasse 32
-– Bertha (Koch). Wwe.. Effingerstrasse 67
+– Bertha (Koch). Wwe., Effingerstrasse 67
 – Chr., pens. Pferdewärter, Rodtmattstr. 108
-– Ed., pens Telegraphen-Angestellter. Laubeckstrasse 1
+– Ed., pens Telegraphen-Angestellter, Laubeckstrasse 1
 – Emil Ed., Dr. phil., Gymn.-Lehrer, Viktoriastrasse 39
 – Emma Bnreaulistin Vereinsweg 11
 – Emma (Minger). Viktoriastr. 57 [28 681]
@@ -13358,7 +13344,7 @@ Gasser, Alice, Verkäuferin, Scheibenstr. 27a
 – Ferd Spengler. Oraffenriedwee 14
 – Frieda, Fabrikarbeiterin, Turnweg 18
 – Fr., Kesslergasse 15
-– Friedr.. Bauamtarbeiter, Langmauerweg 17
+– Friedr., Bauamtarbeiter, Langmauerweg 17
 – Friedr., Bauamtarbeiter, Lorrainestr. 53
 – Friedr., pens. eidg. Beamter, Museumstr. 12
 – Friedr., Garageangest, Könizstrasse 39
@@ -13368,24 +13354,24 @@ Gasser, Alice, Verkäuferin, Scheibenstr. 27a
 – Friedr Sanitätspolizist. Beundenfeldstr 35
 – Friedr Walter, Spengler, Rodtmattstr. 64
 – Fritz (Gruber). Alkoholfreies Rest. Zehendermätteli. Reichenbachstr 161 [32.203]
-– Fritz H.. Sohn. Tapezierermeister, Herrengasse 34 [34.292]
+– Fritz H., Sohn. Tapezierermeister, Herrengasse 34 [34.292]
 – Georges W., Bankangestellter, Brunnmatt17
 – Gertrud, Bureaulistin, Depotstrasse 14
 – Gertrud Alice, kaufm. Angest., Beundenfeldstrasse 35
-– Gottfr.. Schreiner. Fischermätteliweg 10
+– Gottfr., Schreiner. Fischermätteliweg 10
 – Gottfr., Auto-Garage und -Reparaturwerkstätte. Brunngasse 35 [27.656]
-– Gottl.. Hilfsarbeiter, Ulmenweg 15
+– Gottl., Hilfsarbeiter, Ulmenweg 15
 – H., pens. Bahnangest., Schwalbenweg 22
 – Hans. Mechan., Beundenfeldstr. 8 [24.895]
 – Hans, kant. Beamter, Tulpenw. 4 [21.939]
-– Herrn Gottl.. Buchbinder. Lorrainestr.il
+– Herrn Gottl., Buchbinder. Lorrainestr.il
 – Jak., Cafe Marzili, Weiherg. 17 [28.171]
 – Joh. Friedr., kaufm. Angest., Beundenfeldstrasse 35
-– Joh. Jos.. Diener, Kalcheggweg 14
+– Joh. Jos., Diener, Kalcheggweg 14
 – Joh., Installateur, Feilenbergstrasse 19
 – Johann, Maschinenmeister im Zentralschlachthof, Stauffacherstr. 86 [24.492]
 – Joh., Mechaniker, Stauffacherstrasse 86
-Gasser, Joh., Packer, Talweg la
+Gasser, Joh., Packer, Talweg 1a
 – Joh. Jos., Buchbinder. Turnweg 18
 – Joh. Walter, Versich.-Inspektor, Stockerenweg 20
 – Karl Albert, Postbeamter, Hallerstrasse 21
@@ -13402,7 +13388,7 @@ Gasser, Joh., Packer, Talweg la
 – L. Marie, Haustochter, Pestalozzistr. 32
 – Lydia, Ladentochter, Feilenbergstrasse 19
 – Lydia. Reklamezeichnerin, Stauffacherstrasse 29
-– Margar.. Ladentochter, Karl-IIiltystr. 15
+– Margar., Ladentochter, Karl-IIiltystr. 15
 – Maria Rosa, Bureaulistin, Beundenfeldstrasse 35
 – Martha (Bohny), Wwe., Breitenrainstr. 42
 – Martha, Stickerin. Breitenrainstrasse 42
@@ -13412,15 +13398,15 @@ Gasser, Joh., Packer, Talweg la
 – Otto Emil. Schlosser Vereinsweg 11
 – Paul, Güterarbeiter, Federweg 41
 – Paul, Kaufmann. Rodtmattstrasse 108
-– Paul Ad.. Souschef. Muldenstrasse 9
+– Paul Ad., Souschef. Muldenstrasse 9
 – Robert Paul, Elektromech., Bonstettenstr. 0
 – Robert. Elektro-Ingenieur, Landoltstr. 39
 – Rosa (Mühlemann), Wwe. d. Oberrichters, Liebeggweg 9
 – Rosa. Schneiderin, Pestalozzistrasse 32
-– Rosalie. Ladentochter. Schwalbenweg 22
+– Rosalie. Ladentochter, Schwalbenweg 22
 – Rud., Reisender, Laubeckstrasse 1
 – Rud. Hans, Kaufmann, Landoltstrasse 50
-– Rud.. Wäscherei. Waffenweg 16 [36.980]
+– Rud., Wäscherei. Waffenweg 16 [36.980]
 – Rud., Zeichner, Pestalozzistrasse 30
 – Ulrich, Kübler u. Spezereihdlg., Mattenhofstrasse 22
 – Walter (Bühlmann), Buchhalter, Elisabethenstrasse 24
@@ -13428,9 +13414,9 @@ Gasser, Joh., Packer, Talweg la
 – Werner, Mechaniker, Murifeldweg 27
 – Werner Friedr., Hilfsarbeiter, Scheibenstrasse 25a
 – Wilh., Postangestellter, Cäcilienstrasse 28
-– & Co.. Albert. Japanhaus, Import, Export, Agentur. Amthausgasse 7 [34 770]
+– & Co., Albert. Japanhaus, Import, Export, Agentur. Amthausgasse 7 [34 770]
 Gassmann, A (Blank), Oberzolldirektor, Monbijoustrasse 80 [21.330]
-– Arn. Ed.. Dr. med. dent., Zahnarzt (Monbijoustr 80 [21.330]), Gurteng. 6 [28.660]
+– Arn. Ed., Dr. med. dent., Zahnarzt (Monbijoustr 80 [21.330]), Gurteng. 6 [28.660]
 – C. Ph. Curt W., Sekretär des S. F. A. V., Marienstrasse 12 [27.103]
 – Emma, Zeichnungslehrerin, Junkerng. 25 [22.534]
 – Ernst. Bereiter, Allmendstrasse 36
@@ -13447,7 +13433,7 @@ Gassner, Bertha Ther., Frl., Uferweg 10
 Gassyt, Chawa, Sekretärin, Schwanengasse 3
 Gast, Paul, Bureauangestellter, Murifeldw. 7
 Gaswerk [23.511] und Wasserversorgung der Stadt Bern a) Direktion. Bureaux, Verkaufsmagazin, Piquetstelle und Installationsabteilung.: Schanzenstrasse 7 b) Gasfabrik, Betriebsbureau, Koksverkauf und Wohnung des Direktors: Sandrainstrasse 17 [23.517]
-Gatschet, Cecile und Rösa. Frl.. Schanzeneckstrasse 25 (Favorite)
+Gatschet, Cecile und Rösa. Frl., Schanzeneckstrasse 25 (Favorite)
 Gatta, Maurizio E. (Juillerat), Maler, Mattenhofstrasse 29
 Gatti, Elvezio, Hilfsarbeiter, Herzogstrasse 12
 – Franco, Schuhmachermeister, Gesellschaftsstrasse 22
@@ -13459,7 +13445,7 @@ Gattinoni, Edidio P., Maurer, Muldenstr. 46
 Gattlen, Moritz E., Elektro-Schweisserei (Mattenhofstrasse 16), Belpstrasse 38a [20.262]
 Gauch, Albertine (Schifferli), Wwe., Greyerzstrasse 52
 – Hans, Fabrikarbeiter, Frohbergweg 6
-– Jos.. Handlanger, Gerbergasse 17
+– Jos., Handlanger, Gerbergasse 17
 – Peter, Hilfsarbeiter, Gerbergasse 6
 Gauchat. Jeanne Al., Ladentochter, Glockenstrasse 9, Bümpliz
 – Joh. Friedr., Schriftsetzer, Bottigenstr. 51, Bümpliz
@@ -13516,7 +13502,7 @@ Gavin, Emil, Beamter S. B. B., Falkenweg 19 [27.869]
 Wirtschaftsbetriebe, Sulgenrain 6
 Gawronsky, Dimitry, Dr. phil., Privatdozent.
 Lorystrasse 6 [24.072]
-– Vitaly, Dr.. Redaktor, Gartenstrasse 10 [20.723]
+– Vitaly, Dr., Redaktor, Gartenstrasse 10 [20.723]
 Gay, Emma, Bankangest., Militärstrasse 40
 – Eug. Henri, Techniker, Neufeldstrasse 105 [35.176]
 – Marie Amelie, Beamtin, Gartenstrasse 12
@@ -13528,7 +13514,7 @@ Gebhard, Arthur Hrch. (l’Etrange), Archivstrasse 2
 – Emma, Damenschneiderin, Bärengasse 29, Bümpliz
 – Frieda, Glätterin, Bärengasse 29, Bümpliz
 – Friedr., Ziegeleiarbeiter, Bärengasse 29, Bümpliz
-– Friedr.. Hilfsarbeiter, Bäreng. 29, Bümpliz
+– Friedr., Hilfsarbeiter, Bäreng. 29, Bümpliz
 Gedeon, Rieh., Handelsmann, Monbijoustr. 20
 Geel, Emil (Scltermann), Blumengeschäft Hortensia (Dalmaziw. 75 [33.481]), Kramgasse 13 [23.770]
 Geelhaar, Christ. Renatus, Ing., Helvetiastrasse 17
@@ -13546,7 +13532,7 @@ Gegenschatz, Kath. M. (Beisswenger), Wwe., Schläflistrasse 8
 Gehbauer, Hedwig Anna, Damenschneiderin, Stadtbachstrasse 46
 – Karl. Betriebsleiter, Stadtbachstrasse 46
 – Karl, jun., Kaufmann, Stadtbachstr. 46
-– Walter. Gärtner, Stadtbachstrasse 46
+– Walter, Gärtner, Stadtbachstrasse 46
 Gehri, Arnold, Sattler- u. Tapezierermeister, Mattenhofstrasse 15 [34.121]
 – Arnold, Hilfsarbeiter, Rodtmattstrasse 81
 – Charles W., Fürsprecher, Beipstrasse 16 [28.798]
@@ -13578,8 +13564,8 @@ Gehrig, Clara Emilie, Bureaulistin, Engestr. 7
 – Ernst, Silberarbeiter, Standstrasse 15
 – Ernst, Schmied, Cäcilienstrasse 48
 – F., Dr. med., Arzt, Waldblickstr. 13, Wabern [36.380]
-– Fridolin, Generalagent (Humboldtstr. 15 [36.8811), Bollwerk 19 [22.298]
-– -Fr., Billettdrucker S. B. B., Gotthardweg 11
+– Fridolin, Generalagent (Humboldtstr. 15 [36.8811]), Bollwerk 19 [22.298]
+– Fr., Billettdrucker S. B. B., Gotthardweg 11
 – Friedr., Buchbinder, Speichergasse 33
 – Friedr., Feinmechaniker, Standstrasse 15
 – Friedr., Maler, Cäcilienstrasse 48
@@ -13596,19 +13582,19 @@ Gehrig, Clara Emilie, Bureaulistin, Engestr. 7
 – Joh., Elektro-Techniker, Rainmattstr. 18
 – Joh., Hilfsarbeiter, Aehrenweg 21, Bümpliz
 – Joh., Karrer, Murtenstrasse 252, Bümpliz
-– Joh. Alb.. Briefträger, Schwalbenweg 18
+– Joh. Alb., Briefträger, Schwalbenweg 18
 – Karl Fr. A., Buchbinder, Zähringerstr. 48
-– Luise. Ladentochter. Standstrasse 15
+– Luise. Ladentochter, Standstrasse 15
 – Margaritha, Einlegerin, Cäcilienstrasse 48
 – Marianne (Staudenmann), Wwe., Elisabethenstrasse 38
-– Marianne, Friedhofarbeiteri®, Marzilistrasse 32
-– Martha, Ladentochter. Muristrasse 9
-– Martha Anna, Ladentochter. Standstr. 15
+– Marianne, Friedhofarbeiterin, Marzilistrasse 32
+– Martha, Ladentochter, Muristrasse 9
+– Martha Anna, Ladentochter, Standstr. 15
 – Rosa, Damenschneiderin. Muristrasse 9
 – Rud., Fabrikarbeiter, Postgasse 24
 – Rud., Hilfsarbeiter, Freiburgstrasse 180, Bümpliz
 – Rud. Gust, Maler, Kehrgasse 5, Bümpliz
-– - Walter, Maler, Elisabethenstrasse 38
+– Walter, Maler, Elisabethenstrasse 38
 Gehriger, Jakob Walter, Prokurist, Zentralweg 16
 Gehring, Clara, Bankangest., Trechselstr. 6
 – Hans H. O., Zimmermann, Jurastrasse 55
@@ -13616,14 +13602,12 @@ Gehring, Clara, Bankangest., Trechselstr. 6
 – Jakob, Magaziner, Ladenwandstrasse 43
 – Walter Herm., Maler, Fischermätteliweg 2
 Geiger, Adolf, Radioinstallationen, Mittelstrasse 11
-Reproduktionen, techn. Aufnahmen etc. Haliwag Bernliefert die Clichefabrik der Telephon 28. 222
-25/26
 # Date: 1935-12-15 Page: 26020451/146
 Geiger, C., Architekt, in Fa. Geiger & Cie. (Waldhöhew.25 [28.047]), Elisabethenstr.il [20.211]
 – Heinrich (Blaser), Kaffee- u. Speisehalle, Aarbergergasse 22 [24.945]
 – Heinrich, Koch, Aarbergergasse 22
 – Joh. Jak., Einleser. Stocherenweg 15
-– K. L.. alt Abteilungschef S. B. B., Thunstrasse 2 [33.752]
+– K. L., alt Abteilungschef S. B. B., Thunstrasse 2 [33.752]
 – Ludw. Wilh., Masch.-Ingenieur, Thunstr. 2
 – Martha, Falzerin, Hochfeldstrasse 57
 – Max, Pianist. Waldhöheweg 25 [28.047]
@@ -13635,9 +13619,8 @@ Geisberger, Hans. Gipser- u. Malermeister, Kirchbergerstrasse 25 [45.474]
 Geiser, Amalie, Beisende, Freiestrasse 35
 – Anna Verena, Beamtin, Erlenweg 20 [21.528]
 – Arnold (Gerber), Hafnermeister (Länggassstrasse 65 [33.059]), Mittelstrasse 53
-– Arnold Herm., Mechaniker S. O. B., Oberer
-Aareggweg 24
-– B. H , Bahnarbeiter, Flurstrasse 26a
+– Arnold Herm., Mechaniker S. O. B., Oberer Aareggweg 24
+– B. H., Bahnarbeiter, Flurstrasse 26a
 – Bernb., Dr phil, Neubrückstr. 93 [33.748]
 – Daniel, Lehrer an der Schosshaldenschule, Bantiger3trasse 32
 – Ed. Paul. Kaufmann, Gryphenhübeliw. 24
@@ -13654,7 +13637,7 @@ Aareggweg 24
 – Hans Erwin, Prokurist, Seidenweg 54
 – H. Fritz, Bankinsp., Bürkiweg 2 [34.577]
 – Harald Walter, Kaufmann. Viktoriastr. 41 [23.243]
-– Hermann, Hilfsarbeiter. Kasthoferstr. 6
+– Hermann, Hilfsarbeiter, Kasthoferstr. 6
 – Hermann, Ingenieur, Asterweg 18 [27.388]
 – Ida (Rieben), Wwe., Wattenwylweg 23
 – Joh. Friedr., eidg Beamter, Effingerstr. 94
@@ -13721,7 +13704,7 @@ Geissmann, Eugen, Heizer d. W.-F., Wylerstrasse 48
 – Eugen, Schriftsetzer, Wylerstrasse 48
 – Joh., Mützenmacher, Pappelweg 4
 – Maria, Coiffeuse, Sennweg 19
-Gelb, Joh., Bahnbeamter. Brückfeldstrasse 43 [28.292]
+Gelb, Joh., Bahnbeamter, Brückfeldstrasse 43 [28.292]
 Geller, Hermann, Angestellter, Zeitglockenlaube 6
 – Leo, Tuchlidlg., Zeitglockenlaube 6 [21.080]
 – Paula, Verkäuferin, Mittelstrasse 2
@@ -13754,11 +13737,10 @@ Genge, Hildegard, Lehrerin, Stauffacherstr. 41 [33.782]
 Geniebureau (Abteilung für Genie des eidg. Militärdepart), Bundeshaus-Ostbau [61]
 Genier, Arnold A., Polizist, Hopfenweg 46
 Gennert, Klara. Damenschneiderin, Schwarzenburgstrasse 2 [29.128]
-Genossenschaft Alters - Hinterbliebenen-Versicherung, Schwanengasse 4 [33.181]
+Genossenschaft Alters-Hinterbliebenen-Versicherung, Schwanengasse 4 [33.181]
 Genossenschaft Berner Studentenheim, Bollwerk 15
 Genossenschaft bernischer Sägereibesitzer, Sekr.: Bürgerhaus, Neuengasse 20 [28.989]
-Genossenschaft für Bauten beir Station in
-Zollikofen, Christoffelgasse 2
+Genossenschaft für Bauten beir Station in Zollikofen, Christoffelgasse 2
 Genossenschaft für alkoholfreie Obstverwertung Bern, Lerchenweg 31/33 [29.141]
 Genossenschaft für Bauten in der Länggasse Thun, Monbijoustrasse 120
 Genossenschaft für Haus- und Grundbesitz, Marktgasse 11
@@ -13771,7 +13753,7 @@ Genossenschaft für modernen Wohnbau, Schwarztorstrasse 23
 Genossenschaftsbäckerei, Konsumstrasse 19 [21.440]
 Genossenschaftsbuchdruckerei, Viktoriastr 82 [34.552]
 Genossenschaftsbureau, landwirtschaftliches, Speichergasse 12 [23.213]
-Genossenschaft Schweiz. Arbeitersportverlag, Möiibijoustrasse U) [24.671]
+Genossenschaft Schweiz. Arbeitersportverlag, Monbijoustrasse 10 [24.671]
 Genossenschaft Verlag freiwirtschaftl, Schriften, Zinggstrasse 12
 Genossenschaft Zentralschweiz. Ziegeleibesitzer, Verkaufsstelle Bern: Neuengasse 20, Bürgerhaus [21.027]
 Genossenschaftszimmerei Bern, Bernstr. 16, Bümpliz [46.264]
@@ -13780,9 +13762,8 @@ Genswein, Willy, Schneider, Wyttenbachstr. 20
 Genzoni, Gelestino, Früchteverkäufer, Effingerstrasse 43
 Geologisches Institut der Universität, Muldenstrasse 6 [33.558]
 George, Ernest Henri, Bankkontroll., Schläflistrasse 10
-Georges, Edmond Henri, Kaufmann, in Fa.
-Gebr. Georges, Rabbentalstr. 76 [33.355]
-– F. A.. Stock- u. Schirmgeschäft (Herrengasse 18). Kramgasse 31 [32.8071
+Georges, Edmond Henri, Kaufmann, in Fa. Gebr. Georges, Rabbentalstr. 76 [33.355]
+– F. A., Stock- u. Schirmgeschäft (Herrengasse 18), Kramgasse 31 [32.807]
 – Jean F. (Wildbolz), Kaufmann, Schanzenbergstrasse 21 [32.872]
 – Maria, Wwe., Lombachweg 35
 – Robert E., Schanzenbergstr. 17 [36.304]
@@ -13875,7 +13856,7 @@ Inf. d. Militärdep., Spitalackerstrasse 67
 – Ernst Felix, Bureaulist, Allmendstrasse 1
 – Ernst, kaufm. Angest., Breitenrainstr. 25
 – Ernst Alex., Chauffeur S. O. B., Schwarzenburgstrasse 25
-– Ernst, Dr. jur., Fürsprecher, Advokaturbur. A. Lüscher & Dr. E. Gerber (Münzgraben 4 [36.152], Amthausgasse 24 [22.185]
+– Ernst, Dr. jur., Fürsprecher, Advokaturbur. A. Lüscher & Dr. E. Gerber (Münzgraben 4 [36.152]), Amthausgasse 24 [22.185]
 – Ernst, Einleger, Weidmattweg 3, Bümpliz
 – Ernst Emil, Schlossermeister, Stalden 21
 – Ernst, Gipser- und Malermeister, Weissensteinstrasse 62 [33.873]
@@ -13896,11 +13877,11 @@ Gerber, Ernst, Modellschrein., Murtenstr. 153e
 – Erwin Osk., Güterarbeiter S. B. B., Murtenstrasse 137
 – Erwin K., Mechaniker, Bollwerk 27
 – F. E., Postangest., Bubenbergstrasse 12
-– Fr., gew. Droschkenhalter. Brückenstr. 12
+– Fr., gew. Droschkenhalter, Brückenstr. 12
 – Fr. (Fahrni), Glätterei, Bubenbergstr. 12 [31.602]
 – Fr. (Steinhäuser), Postbeamter, Dietlerstrasse 30
 – Franz Otto, Hilfsarbeiter, Fischermätteliweg 7
-– Franz Joh.. Schreiner, Moserstrasse 8
+– Franz Joh., Schreiner, Moserstrasse 8
 – Franz, kaufm. Angest., Bahnhöheweg 36, Bümpliz
 – Frieda (Wyss), Wäscherei und Glätterei, Sonneggweg 17 [45.446]
 – Frieda (Flühmann), Wwe., Murtenstr. 43
@@ -13931,8 +13912,7 @@ Dufourstrasse 37
 – Friedr., Waldarbeiter, Bottigenstrasse 230a, Oberbottigen
 – Friedrich, Gemüsehandel, Freieckweg 7, Bümpliz
 – Friedr., Adjunkt der Sektion für Einfuhr, Murtenstrasse 1 [25.809]
-– Fritz (Urwyler), Installationen u. sanitäre
-Anlagen. Standstrasse 3 [32.045]
+– Fritz (Urwyler), Installationen u. sanitäre Anlagen. Standstrasse 3 [32.045]
 Gerber, Fritz, Abwart Bollwerk 15
 – Fritz Arth., Chauffeur, Alleeweg 32
 – Fritz, Dr., Betriebsleiter, Neufeldstr. 153 [20.604]
@@ -14005,7 +13985,7 @@ P. F. J., Weissensteinstrasse 93 [28.715]
 – Ida, Glätterin, Mezenerweg 4
 – Ida (Nikles), Wwe., Mass-Corselets u. Büstenhalter « Hyspa » (Monbijoustrasse 92 [29.196]), Bärenplatz 9 [24.361]
 – Irma Elisabeth, Jubiläumsstrasse 71
-– J. Fr., Postbeamter. Frohbergweg 10
+– J. Fr., Postbeamter, Frohbergweg 10
 – Jakob, Fabrikarbeiter, Länggassstrasse 53
 – Jakob, Hilfsarbeiter, Tiefenaustrasse 80
 – Jakob, Vertreter, Cäcilienstr. 18 [27.260]
@@ -14014,12 +13994,12 @@ P. F. J., Weissensteinstrasse 93 [28.715]
 – Joh. (Reinhard), gew, Bäckermeister, Freiburgstrasse Ul
 – Joh. Alois, Bahnangestellter, Fischermätteliweg 7
 – Joh. Gottfr., Coiffeurgeschäft, Mittelstr. 10
-– Joh. Paul. Bankangestellter. Hallwylstr. 35
+– Joh. Paul. Bankangestellter, Hallwylstr. 35
 – Joh., Milchhändler, Stöckackerstrasse 70, Bümpliz
-– Joh,, Droschkenhalter, Scheibenstrasse 22 [36.979]
+– Joh., Droschkenhalter, Scheibenstrasse 22 [36.979]
 – Joh., Fabrikarbeiter, Nelkenweg 7
 – Joh., Hauswart b. Nationalbank, Bundesplatz 1
-– Joh.. Hilfsarbeiter, Mühleplatz 14
+– Joh., Hilfsarbeiter, Mühleplatz 14
 – Joh., Landarbeiter, Riedernstr. 63, Bümpliz
 – Joh. (Kunz), Mechaniker, Fischermätteliweg 12
 – Joh. Friedr., Monteur, Bantigerstrasse 14
@@ -14050,7 +14030,7 @@ Gerber, Jules A., Camionneur, Kesslergasse 9
 – Karl, Privatier, Distelweg 17 [23.398]
 – Karl, Rolladen- u. Storenwerkstätte (Belp), Seftigenstrasse 57a [27.517]
 – Karl Joh., Schreiner, Lorrainestrasse 69
-– Karoline (Lüthi). Wwe.. Wylerringstr 43
+– Karoline (Lüthi). Wwe., Wylerringstr 43
 – Katharina, Ladentochter, Wiesenstrasse 25
 – Klara. Bureauhslin Neuhäuserweg 9
 – Klara, Finkenhubelweg 9
@@ -14066,7 +14046,7 @@ Gerber, Jules A., Camionneur, Kesslergasse 9
 – Lina (Ramseyer), Wwe., Stadtbachstr. 58 [36.431]
 – Lucien, Kommis, Bonstettenstrasse 3
 – Luise, Spulerin, Steinauweg 33
-– Lydia Bertha, Ladentochter. Schönauw. lö
+– Lydia Bertha, Ladentochter, Schönauw. lö
 – M. Otto, Bankangest., Falkenweg 9 [27.654]
 – Madeleine J. E., Bureaulistin, Allmendstrasse 1
 – Magdal. (Burri), pens. Abwartin, Weihergasse 14
@@ -14079,7 +14059,7 @@ Gerber, Jules A., Camionneur, Kesslergasse 9
 – Marie (Joss). Gerechtigkeitsgasse 73
 – Marie (Mäder), Kioskhalterin, Werkg. 20, Bümpliz
 – Marie, Bureaulistin, Spitalackerstrasse 66
-– Marie Martha, Bureaul.. Siedlungweg 25
+– Marie Martha, Bureaul., Siedlungweg 25
 – Marie. Fabrikarbeiterin, Sennweg 7
 – Marie. Ladentochter, Forsthausweg 14
 – Marie (Andrist), Wwe., Laubeckstrasse 36
@@ -14130,14 +14110,13 @@ Kraftwerke, Spitalackerstrasse 64
 – Rud., Kraftwagenführer, Sulgenbachstr. 21
 – Rud., Landwirt, Bottigenstr. 181, Oberbottigen
 – Rud., Gärtner, Dapplesweg 2
-– Sam. Nikl.. Monteur, Moritzweg 26
+– Sam. Nikl., Monteur, Moritzweg 26
 – Sophie, Buchhalterin, Sulgenauweg 26
 – Sophie (van Vloten), Wwe. des Pfarrers, Kirchenfeldstrasse 45 [33.971]
 – Theodor, Dr. med., Kinderarzt, Stadtbachstrasse 58 [36.431]
 – Theodor Rud., Coiffeur, Sei denweg 45
 Gerber, Theo Werner, Mineralwasserhandlg., Jurastrasse 15
-– W. Loris, Vertreter der Ge.br. Gondrand
-A.-G., Basel, Tillierstrasse 34 [35.219]
+– W. Loris, Vertreter der Gebr. Gondrand A.-G., Basel, Tillierstrasse 34 [35.219]
 – Walter, Apparatenmont., Bottigenstr. 395, Riedbach
 – Walter, Bauarbeiter, Sägehof weg 3, Bümpliz
 – Walter, Bureaulist, Rodtmattstrasse 56
@@ -14146,7 +14125,7 @@ A.-G., Basel, Tillierstrasse 34 [35.219]
 – Walter, Hilfsarbeiter, Mattenenge 20
 – Walter, Hilfsarbeiter, Bernstr. 101, Bümpliz
 – Walter Ernst, Dr., Ingenieur, Wylerstr. 71 [23.994]
-– Walter Rud., Kaufmann, Depotstrasse 2 [28.0191
+– Walter Rud., Kaufmann, Depotstrasse 2 [28.019]
 – Walter, Milchträger, Stöckackerstrasse 70, Bümpliz
 – Walter, Packer, Hopfenweg 54
 – Walter, Postkommis, Trachselweg 39
@@ -14164,7 +14143,7 @@ A.-G., Basel, Tillierstrasse 34 [35.219]
 – Werner Theod., Malermeister, Heimstr. 31, Bümpliz
 – Wieland L., Vertreter, Tillierstrasse 34
 – Wilh., Fabrikarbeiter, Bottigenstrasse 230a, Bümpliz
-– —Wilh. Gerh., Mechaniker, Schanzeneckstr. 9
+– Wilh. Gerh., Mechaniker, Schanzeneckstr. 9
 – Wilhelmine (Henninger), Wwe., Privat., Finkenhubelweg 9 [20.607]
 – Willy, Maler, Seftigenstrasse 25
 – Willy Osk., Postbeamter, Wylerstrasse 57
@@ -14189,7 +14168,7 @@ Gerichtsschreiberei (Amthaus), Ferd.-Hodlerstrasse 7 [27.471]
 Gericke, Ewald Karl, kaufm. Angestellter, Länggassstrasse 26 [23.323]
 – Karl, Bauaustrocknung, Früchte- und Gemüsehandlung, Länggassstr 26 [21.654]
 Germann, Ewald, Mechaniker, Federweg 23
-– Nelly Hedwig, Ladentochter. Gesellschaftsstrasse 5
+– Nelly Hedwig, Ladentochter, Gesellschaftsstrasse 5
 – Oskar, Versich.-Inspektor, Steigerweg 20 [31.074]
 – Ottilie, Steinauweg 30 [20.974]
 – Theophil, Wagner, Tillierstrasse 36
@@ -14201,8 +14180,7 @@ Brandversich.-Anstalt, Primelw. 7 [34.668]
 – Jean Philippe, Angestellter, Primelweg 7
 Gernet, Ad. Leonz, Oberkellner, Greyerzstr. 26 [29.749]
 Gerold, J. A. M., Frau, Wabernstrasse 7
-Gersonde, Siegfried E. (Van-Heurck), kaufm.
-Angestellter, Gewerbestrasse 23
+Gersonde, Siegfried E. (Van-Heurck), kaufm. Angestellter, Gewerbestrasse 23
 Gerster, Ant. Julie, Vorsteherin der Privatschule f. Knaben u. Mädchen, Seftigenstr. 9 [34.971]
 – Betty Johanna, Klavierlehrerin, Hotelg. 4 [27.628]
 – C. Rob., belg. Konsulat, Verwaltungen, Union cooperative immobiliere (Jubiläumsstrasse 63 [27.146]), Hotelgasse 8 [21.644]
@@ -14212,7 +14190,7 @@ Gerster, Ant. Julie, Vorsteherin der Privatschule f. Knaben u. Mädchen, Seftige
 – Ernst. Magaziner. Seftigenstrasse 57
 – Franz, Fürspr., Sektionschef bei der eidg.
 Kriegsmaterialverwltg., Helvetiastrasse 33 [31.841]
-– Fred A. (Lüscher), «Arco», Reklame und Vertretungen, Holzikofenweg 29 [24 7521
+– Fred A. (Lüscher), «Arco», Reklame und Vertretungen, Holzikofenweg 29 [24 752]
 – H. Jak., Ingenieur, Luisenstr. 24 [36.760]
 – Helene, Zeichnerin, Helvetiastrasse 33
 – Hugo, Drogerie (Eichmattweg 4 [25.984]), Waisenhausplatz 12 u. Neuengasse 8 [22.872]
@@ -14220,7 +14198,7 @@ Kriegsmaterialverwltg., Helvetiastrasse 33 [31.841]
 – Johanna L., Sek.-Lehrerin, Luisenstr. 24
 – Julie (Guldi), Wwe. d. Zahnarzt, Seftigenstrasse 9 [34.971]
 – Karl Rud., Kaufmann, Chutzenstrasse 30
-– Marie Sophie, Priv.. Helvetiastrasse 33 [31.841]
+– Marie Sophie, Priv., Helvetiastrasse 33 [31.841]
 – Paul Aug, gew. Optiker. Bubenbergplatz 4
 – Theodora, Kindergärtnerin, Metzgergasse 1
 Gerstner, Ferd., Photohaus (Monbijoustr. 39), Zwiebelngässchen 16 [28.406]
@@ -14241,7 +14219,7 @@ Gertsch, Adolf, Zahnarzt, Schönburgstr. 5 [31.250]
 – Hans (Wälti), Lehrer, Studerstrasse 64
 – Hs. (Ducret), städt. Beamter, Neubrückstrasse 53
 – Jakob Emil, Elektromonteur, Gesellschaftsstrasse 42
-– Jules Ed., Hilfsarbeiter. Holligenstr. 70
+– Jules Ed., Hilfsarbeiter, Holligenstr. 70
 – Karl, Handlanger, Scheibenstrasse 26
 – Margaritha, Damenschneiderin, Scheibenstrasse 26
 – Metha, Amselweg 7
@@ -14295,7 +14273,7 @@ Gesandtschaftskanzlei
 – Venezuelanische, Ob. Dufourstr. 43 [21.703]
 Geschäftshaus Spitalgasse 40 A.-G., Bubenbergplatz 8
 Gesellschaft der Ludw. v. Roll’schen Eisenwerke. Giesserei Bern. Fabrikstrasse 2 [25.066]
-Gesellschaft, Evangel.. Nägeligasse 9 und 11 [22.583] und Nydeckgasse 11
+Gesellschaft, Evangel., Nägeligasse 9 und 11 [22.583] und Nydeckgasse 11
 Gesellschaft für landwirtschaftliche und industrielle Interessen, A.-G. t Theodor-Kochergasse o
 Gesellschaft für Rechts- und Kapitalhilfe Bern, Marktgasse 51
 « GESGA », Schweizerische Gesellschaft für Gastrologie, Zentralverwaltung: Murtenstrasse 52 [35.734]
@@ -14309,7 +14287,7 @@ Gewerbekasse [22.826] in Bern besorgt alle Banktransaktionen. Kredite, Darlehen,
 Gewerbemuseum, kantonales. Zeughausgasse 2 (Kornhaus) [25.959]
 Gewerbeschule, Zeughausgasse 2 (Kornhaus) [28.901]
 Gewerbesekretariat des Handwerker- u Gewerbeverbandes. Bürgerhaus, Neueng. 20/22 [20.162]
-Gewerbeverband, Schweiz.. Sekretariat, Neuengasse 20/22 (Bürgerhaus) [21.226]
+Gewerbeverband, Schweiz., Sekretariat, Neuengasse 20/22 (Bürgerhaus) [21.226]
 Gewerbezeitung, Schweiz., Redaktion Neueugasse 20 (Bürgerhaus) [33.918]
 Gex, Gerald, Monteur, Gerechtigkeitsgasse 2
 Geyer, Richard. Steinindustrie, Marmorwerk
@@ -14317,7 +14295,7 @@ Weissenbühl (Seftigenstrasse 64 [27.058]), Rosenweg 5
 Geymayr, Anton (Joss), Notar (Haspelw. 44 [33.930]), Effingerstrasse 2 [29.379]
 – Else M., Haspelweg 44 [33.930]
 Geymet, Edith Anna, Stenographin, Ensingerstrasse 12
-Gfeller, Ad., Dachdeckermeister. Turnweg 27b [28.746]
+Gfeller, Ad., Dachdeckermeister, Turnweg 27b [28.746]
 – Ad., Magaziner, Mattenhofstrasse 38
 – Alb., Handlanger, Gerbergasse 8
 – Alb., gew. Kassier, Brügglerweg 22 [35.980]
@@ -14354,14 +14332,14 @@ Gfeller, Ad., Dachdeckermeister. Turnweg 27b [28.746]
 – Erw. Werner, Chauffeur, Weissenbühlw. 8
 – Eugen, Handlanger, Postgasse 24
 – Fr. (Grimm), Gipser- und Malermeister, Spitalackerstrasse 74 [32.168]
-– Friedr., Dr med. dent., Zahnarzt (Niederscherli [84], Marktgasse 31 [23.720]
+– Friedr., Dr med. dent., Zahnarzt (Niederscherli [84]), Marktgasse 31 [23.720]
 – Friedr., Handlanger, Federweg 25
 – Friedr., Maschinenmeister, Pestalozzistr. 3
 – Friedr., Milchprod., u. Spezereihandlung, Römerweg 22 9 [28.759]
 – Friedr. Rud., gew. Fuhrmann, Neubrückstrasse 192
 – Friedr. Rud., Handlanger, Marzilistr. 26
 – Friedr., Karrer, Schwarztorstrasse 27
-– Friedr.. Schreiner, Schönauweg 4
+– Friedr., Schreiner, Schönauweg 4
 – Fritz, Handlanger, Bümplizstrasse 75
 – Fritz, Lehrer, Statthalterstr. 46, Bümpliz
 – Fritz, Magaziner, Sandrainstrasse 8
@@ -14383,10 +14361,10 @@ Gfeller, Fr., Maschinenmeister, Schwarzenburgstrasse 8
 – Hanna, Modistin, Kramgasse 28
 – H., Festangestellter, Mattenhofstrasse 33
 – Hans. Auto-Taxi. Schönburgstrasse 38
-– Hans. Postverwalter. Gesellschaftsstr. 37
+– Hans. Postverwalter, Gesellschaftsstr. 37
 – Hans Alfr., Elektriker, Viktoriaplatz 2
 – Hans, Gasarbeiter, Weissensteinstrasse 29
-– Hans Willy, Handelsangest.. Effingerstr. 71
+– Hans Willy, Handelsangest., Effingerstr. 71
 – Hans, Schreiner, Luisenstrasse 27
 – Hans, Schriftsetzer. Polygonweg 10
 – Hedwig E., Bureaulistin, Muesmattstr. 15
@@ -14394,16 +14372,16 @@ Gfeller, Fr., Maschinenmeister, Schwarzenburgstrasse 8
 – Hermann, Direktor der Zigarettenfabrik
 Batschai’i, Hch.-Wildstrasse 12 [31.173]
 – Herm. (Lüdi), Maurer, Güterstrasse 34
-– Ida Rosa Ladentochter. Turnweg 27b
+– Ida Rosa Ladentochter, Turnweg 27b
 – Ida Berta, Telegraphistin, Brückenstr. 67
 – Jakob, Maurer, Gerbergasse 8
 – Jak. Chr., pens. Revisor der kant. Steuerverwaltung, Kramgasse 28
 – Joh., pens. Visiteur S.B.B., Brünnenstr. 47, Bümpliz
 – Joh., Dienstmann, Polygonweg 13
-– Joh. Chr. Ed.. Hadernhändler. Dammw. 23
+– Joh. Chr. Ed., Hadernhändler. Dammw. 23
 – Joh., Kaufmann, Bümplizstrasse 3
 – Joh. Otto, Hilfsarbeiter, Metzgergasse 28
-– Joh.. Packer. Bümplizstrasse 3
+– Joh., Packer. Bümplizstrasse 3
 – Joh., Maler, Mühlemattstrasse 14a
 – Joh., Maschinensetzer, Wagnerstrasse 16
 – Joh. Friedr., Vertreter, Amthausgasse 14
@@ -14412,8 +14390,7 @@ Batschai’i, Hch.-Wildstrasse 12 [31.173]
 – Karl E., kaufm. Angestellter, Stalden 3
 – Karl, Maurer, Länggassstrasse 72
 – Karl Werner, Werkzeugmacher, Greyerzstrasse 38
-– Lena, Fürsprecher, Advokaturbüro (Vereinsweg 12 [23.353]), Laupenstrasse 5
-. [20.230]
+– Lena, Fürsprecher, Advokaturbüro (Vereinsweg 12 [23.353]), Laupenstrasse 5 [20.230]
 – Luisa, Bankangestellte, Allmendstrasse 2 [29.912]
 – Lydia (Oswald), Neuengasse 21
 – M. Luise (Zuberbühler), Wwe., Blumensteinstrasse 10
@@ -14434,10 +14411,9 @@ Gfeller, Martha, Fabrikarb., Bümplizstr. 77
 – Oskar Paul, Hutmacher, Wylerringstr. 47
 – Otto, Auto-Elektriker, Brünnenstrasse 47, Bümpliz [46.630]
 – Otto, Packer, Quartiergasse 9
-– Otto. Hilfsarbeiter. Quartiergasse 9
+– Otto. Hilfsarbeiter, Quartiergasse 9
 – Otto, Abteilungsvorstand der Rechnungskontrolle und Hauptbuchhaltung S. B. B., Donnerbühlweg 17 [31.385]
-– Otto, Ing., Geschäftsführer der Chr. Gfeller
-A.-G., Brünnenstr. 58, Bümpliz [46.195]
+– Otto, Ing., Geschäftsführer der Chr. Gfeller A.-G., Brünnenstr. 58, Bümpliz [46.195]
 – Paul, Beamter O. T D., Bürkiweg 2a [21.425]
 – Paul, Elektromonteur, Neufeldstrasse 125
 – Paul Ernst, Kaufmann, Alleeweg 25 [33.771]
@@ -14471,12 +14447,11 @@ Gfeller, Werner, Elektrotechniker, Keltenstrasse 99, Bümpliz [4-6.050]
 – Werner (Eichenberger), Lehrer, Mittelstrasse 64 [31.975]
 – Werner, sanit. Anlagen, Stockerenweg 1 [32.748]
 – -Wilhelm, Musiklehrer, Zähringerstrasse 40
-– Rindlisbacher, J., A.-G.. Kaffee- und Küchliwirtschaft, Bärenplatz 21 u. Käfiggässchen 22 [29.255]
+– Rindlisbacher, J., A.-G., Kaffee- und Küchliwirtschaft, Bärenplatz 21 u. Käfiggässchen 22 [29.255]
 Gfrörer, Adr., Modehaus, Mass u. Konfektion (Gutenbergstrasse 31), Bubenbergplatz 12 [36.472]
 Ghedini, E., Musiker, Länggassstrasse 29
 – Guido. Musiker. Länggassstrasse 29
-Ghezzi, Carlo, Ingenieur, Sektionschef b. eidg.
-Amt f. Wasserwirtschaft, Gutenbergstr. 10 [23.199]
+Ghezzi, Carlo, Ingenieur, Sektionschef b. eidg. Amt f. Wasserwirtschaft, Gutenbergstr. 10 [23.199]
 – Egon C. M., kaufm. Angest., Gutenbergstrasse 10 [23.199]
 Ghielmetti, Angelo, Bautechn., Brunnhofweg 4
 – B. (Gaggione), Bauführer, Brunnhofweg 4 [34.257]
@@ -14518,8 +14493,7 @@ Giesbrecht, Emma, Ladentochter, Morillonstrasse 19
 – Paul, Versieh.-Angestellter, Morillonstr. 19
 – Rob., in Fa Rob. Giesbrecht & Schalch, Beundenfeldstrasse 18 [33.120]
 – Robert, & Schalch, vormals Robert Giesbrecht & Co., Glas- u. Spiegelmanufaktur, Sickingerstrasse 6 [29.133]
-– Rosa Elsa (Abderhalden), Wwe., in Fa.
-Alfr. Giesbrecht & Co., Helvetiastrasse 17 [21.897]
+– Rosa Elsa (Abderhalden), Wwe., in Fa. Alfr. Giesbrecht & Co., Helvetiastrasse 17 [21.897]
 – Rudolf, Sattler, Morillonstrasse 19
 – Rudolf, Schuhmachermstr., Morillonstr. 19
 – Wwe., Alfred, Glas- und Spiegelmanufaktur, Helvetiastrasse 17 [21.897]
@@ -14545,13 +14519,13 @@ Giger, s. auch Gyger
 – Karl, Chauffeur, Donnerbühlweg 19
 – Margaritha, Bureaulistin, Murtenstrasse 3
 – Maria G., Bureaulistin, Hubelmattstr. 5
-– Walter. Autcmechaniker, Länggassstr. 83
+– Walter, Autcmechaniker, Länggassstr. 83
 – Walter Rud., Mechaniker, Quartierhof 13
 Gigon, Justin, eidg. Beamter, Militärstrasse 6
 – Paul H., Maler, Viktoriarain 21
 Gilardi, Ant., Beamter d. S. B. B., Muesmattstrasse 20
 Gilg, Arnold, Dr., Prof., Haspelw. 50 [24.795]
-Gilgen, Alb.. Schriftsetzer, Thunstrasse 16
+Gilgen, Alb., Schriftsetzer, Thunstrasse 16
 – Alb., pens. Friedhofarbeiter, Werkgasse 31, Bümpliz
 Umbauten erfordern den Rat des erfahrenen u. gewissenhaften Architekten
 Gehr. Keller, Architekten Spitalgasse 20 Tel. 23.204
@@ -14578,7 +14552,7 @@ Wasserwirtschaft, Viktoriastr. 65 [36.285]
 – Ernst, Güterarbeiter S. B. B., Herzogstr. 19
 – Ernst, Hilfsarbeiter, Gerechtigkeitsg. 38
 – Ernst, Packer, Berehtoldstrasse 54
-– Ernst G., Kaufmann, Karl-Staufferstr.. 26
+– Ernst G., Kaufmann, Karl-Staufferstr., 26
 – Ernst, Kaufmann, Peterweg 4, Bümpliz
 – Ernst, Magaziner, Cäcilienrain 3
 – Ernst, Schlosser, Rehhagstr. 42, Bümpliz
@@ -14586,7 +14560,7 @@ Wasserwirtschaft, Viktoriastr. 65 [36.285]
 – Frieda, Damenschneiderin, Lorbeerstr. 2, Bümpliz
 – Frieda. Strickerin, Moserstrasse 35
 – Friedr., Bahnarbeiter, Morgenstrasse 4, Bümpliz
-– Friedr., Kondukt, d. S. B. B.. Lerchenw. 29
+– Friedr., Kondukt, d. S. B. B., Lerchenw. 29
 – Friedr., Magaziner, Brunnhofweg 23
 – Friedr., Zimmermann, Morgenstrasse 15, Bümpliz
 – Fr., Oberbriefträger, Elisabethenstrasse 15
@@ -14697,15 +14671,15 @@ Gipser- u. Malergenossenschaft Bern, Wagnerstrasse 11 [24.187]
 Gipswerke Kräftigen u. Heimberg, Mattenhofstrasse 16 [24.003]
 Girard, Alb Ed., Elektro-Ingenieur, Bubenbergstrasse 49
 – Edm. Cas., Hilfsarbeiter, Ulmenweg 5
-– Fritz, Handlanger, Weissensteinstrasse la
+– Fritz, Handlanger, Weissensteinstrasse 1a
 – Genevieve Marie, Bureaulistin, Jubiläumsstrasse 47
 – M. (Heer), Frau, Schläflistr. 2 [32.967]
 – Marie (Scheidegger), Wwe., b. Zeitglockenturm 1 [31.832]
 Girard, Paul, Kaufmann, Schläflistrasse 2 [32.967]
 – Rene, Bankangest., Reichenbachstrasse 1 [24.007]
-– Rob., Handlanger, Weissensteinstrasse la
-– Rud., Handlanger, Weissensteinstrasse la
-– Rud., Schneidermeister, Weissensteinstr. la
+– Rob., Handlanger, Weissensteinstrasse 1a
+– Rud., Handlanger, Weissensteinstrasse 1a
+– Rud., Schneidermeister, Weissensteinstr. 1a
 Girardet, Adele Luise, eidg. Beamtin, Falkenweg 11
 – Gilbert J., kaufm. Angest., Siedlungsweg 5
 Girardier, Henri Andre, Bremser d. S. B. B., Sennweg 19
@@ -14742,7 +14716,7 @@ Gisi, siehe auch Gysi und Gisin
 – Walter, Ingenieur, Greyerzstr. 34 [27.973]
 Gisiger, Anna, Glätterin, Schwarztorstrasse 71
 – Charles, eidg. Beamter, Pavillonweg 6
-– Ernst, Schahmactiermstr.. Lorrainestr. 19 [36.391], Filiale Thunstr. 20 [34.824]
+– Ernst, Schahmactiermstr., Lorrainestr. 19 [36.391], Filiale Thunstr. 20 [34.824]
 – Frieda,-Verkäuferin, Lorrainestrasse 27
 – Lina, eidg. Beamtin, Tillierstrasse 53
 – Max, Verwalter des Burgerspitals, Bubenbergplatz 4
@@ -14758,7 +14732,7 @@ Gisler. siehe auch Gysler
 – Alfred, Zollaufseher, Holligenstrasse 72
 – Edith Josefine. Modistin, Stauffacherstrasse 11a
 – Eduard, Fabrikarbeiter, Felsenaustrasse 24
-– G., Beamter S. B. B.. Hallerstrasse 54
+– G., Beamter S. B. B., Hallerstrasse 54
 – Gustav, Postchauffeur, Engehaldenstr. 99
 – Heinrich, kaufm. Angestellter, Elisabethenstrasse 36
 – Heinrich. Sattler. Elisabethenstrasse 36
@@ -14769,10 +14743,10 @@ Glahn, Ludw. Gottfr. Chr., Optingenstrasse 5 [29.314]
 Glanz, Joh., Schriftsetzer, Wylerfeldstr. 42
 Glanzmann, Ad., Tapezierermstr., Stalden 20
 – Edmund (Meyer), Masch.-Techniker. Monbijoustrasse 18 [29.300]
-– E., Prof.. Dr. med.. Spezialarzt für Kinderkrankheiten. Zieglerstr. 44 [24.068]
+– E., Prof., Dr. med., Spezialarzt für Kinderkrankheiten. Zieglerstr. 44 [24.068]
 – Gottfried, Stalden 13
 – Hans (Kunz), Notar, Humboldtstrasse 11 [34.025]
-– Joh., Kondukteur der S. B. B.. Bridelstr. 76
+– Joh., Kondukteur der S. B. B., Bridelstr. 76
 – Maria (Guggisberg), Wwe., Steigerweg 26
 Glapey, Luisa. Bankans-est, Neubrückstr. 127
 Glaser, Emil, Geschäftsführer, Schärerstr. 11
@@ -14781,7 +14755,7 @@ Glaser, Emil, Geschäftsführer, Schärerstr. 11
 – Rosa (Wyttenbach), Freiburgstrasse 82
 – Sophie, Privatpension, Maulbeerstrasse 7 [36.005]
 – Willi Alb., Restaurant Bürgerhaus, Neuengasse 20 [24.631]
-Glass, Aug.. Angestellter. Industrieweg 16
+Glass, Aug., Angestellter, Industrieweg 16
 – Aug., Heizungstechniker, Industrieweg 16
 Gläss, Paul, Heizungstechn., Neufeldstr. 133
 Glattfelder, Eug., Maler, Badgasse 4
@@ -14789,7 +14763,7 @@ Glatthard, Ed. J., Beamter, Viktoriarain 12
 – Ernst Bend, (v Arx), Bankbeamter, Spitalackerstrasse 27
 – Hedwig Magdal., Bureautochter, Viktoriarain 12
 – Johanna Dora, Verkäuferin, Viktoriarain 12
-– Karl, Bankangestellter. Luisenstrasse 43
+– Karl, Bankangestellter, Luisenstrasse 43
 – Moritz, Hilfsarbeiter, Papiermühlestr. 11a
 Glatz, Fr., gew. Schriftsetzer, Nydeckhof. 37
 – Friedr., Bäckermeister, Mittelstrasse 8 [31.649]
@@ -14808,9 +14782,9 @@ Glaus, A. Stanzer, Eggimannstrasse 28
 – Ernst (Hajos), Ingenieur, Niggelerstr. 8 [36.375]
 – Ernst. Magaziner, Sonneggring 6
 – Ernst. Tel.-Monteur, Eggimannstrasse 28
-– Fr . Postkommis. Könizstrasse 63
+– Fr., Postkommis. Könizstrasse 63
 – Fritz (Burgener), Hilfsarbeiter, Zaunw. 20
-– Gottfr., Hilfsarbeiter. Breitenrainstr. 21
+– Gottfr., Hilfsarbeiter, Breitenrainstr. 21
 – Hans, Lok.-Heizer S B. B., Martiweg 11
 – Hedwig Bertha, Einlegerin, Sulgeneckstrasse 64
 – Hermann Ernst, Ausläufer, Bernstrasse 4, Bümpliz
@@ -14818,12 +14792,12 @@ Glaus, A. Stanzer, Eggimannstrasse 28
 – Jakob, Hausierer, Gerechtigkeitsgasse 52
 – Karl, Hilfsarbeiter, Wiesenstrasse 81
 – Otto Karl, Masch -Zeichner. Seftigenstr. 66
-– Rob.. Lehrer. Aebistrasse 20 [36.205]
+– Rob., Lehrer. Aebistrasse 20 [36.205]
 – Rosa, Filialleiterin, Schwarztorstrasse 21
 – Rud., Billetteur S. S. B., Frikartweg 16
 – Rud., Angestellter, Weissensteinstrasse 25
 – Rud., Mechaniker, Eggimannstrasse 25
-– Werner. Bahnarbeiter. Muldenstrasse 48
+– Werner. Bahnarbeiter, Muldenstrasse 48
 – Werner Friedr., kaufm. Angest., Könizstrasse 63
 Glausen, Friedr., Gärtner, Mindstrasse 4
 Glauser, s. auch Klauser
@@ -14839,7 +14813,7 @@ Glauser, s. auch Klauser
 – Emil, kaufm. Angestellter, Wylerstrasse 63
 – Ernst, Coiffeur, Gerechtigkeitsgasse 27
 – Ernst, pens Wegmeister, Rodtmattstr. 51
-– Ernst Walter. Werkmeister, Kyburgstr. 1
+– Ernst Walter, Werkmeister, Kyburgstr. 1
 – Eugen, Reisender, Feldheimweg 42a, Bümpliz
 – Ferd., Buchbinder, Mittelstrasse 15
 – Ferd., Hilfsarbeiter, Felsenaustrasse 18
@@ -14853,7 +14827,7 @@ Glauser, s. auch Klauser
 – Gertrud Margr., Modistin, Marienstr. 14
 # Date: 1935-12-15 Page: 26020464/159
 Glauser, s. auch Klauser
-– Gottfr., Fabrikarbeiter. Felsenaustrasse 25
+– Gottfr., Fabrikarbeiter, Felsenaustrasse 25
 – Gust., Mech., Bernstrasse 86, Bümpliz
 – Hans, Bautechniker, Humboldtstrasse 27
 – Hans (Maybach), Beamter der B. L. S., Marienstrasse 14 [20.852]
@@ -14862,19 +14836,19 @@ Glauser, s. auch Klauser
 – Heidi Rosa, Telephonistin, Marienstr. 14
 – Helene Alice. Reichenbachstrasse 64
 – Hermann, Knecht, Sandrainstrasse 4
-– Joh.. Schlosser, Felsenaustrasse 49
+– Joh., Schlosser, Felsenaustrasse 49
 – Joh., Weber, Greyerzstrasse 49
 – Joh. Gottfr., Mechaniker, Engerain 28
 – Joh. Rud., Handlanger, Bubenbergrain 21
 – Johanna, Ladentochter, Gerbergasse 43
 – Jules Ami, Tapezierer, Turnweg 18
 – K. Johann (Berger), Baumeister (Humboldtstrasse 37 [36.178]), Spitalackerstr lb [22.217]
-– Karl Gottfr., Hotelangestellter. Neueng. 43
+– Karl Gottfr., Hotelangestellter, Neueng. 43
 – Karl Herm., Automechan., Gartenstr. 19
 – Lina Marie, Ladentochter, Greyerzstr. 27
 – M Helene (Ritter), Wwe., Hochfeldstr. 26
 — Marg., Kindergärtnerin, Emanuel-Friedlistrasse 31
-– Margar. Luise, Ladentochter. Lentulusstr.69
+– Margar. Luise, Ladentochter, Lentulusstr.69
 – Marie, Falzerin, Felsenaustrasse 49
 – Marie (Friedrich), Wwe., Zielweg 9
 – Marie (Ryser), Wwe., Hallerstrasse 31
@@ -14892,7 +14866,7 @@ Glauser, s. auch Klauser
 – Rosalie, Sekundarlehrerin, Schwarztorstrasse 20 [35.445]
 – Rud Walter, Feinmechaniker, Brunng. 42
 – Rud. Hans. Geschäftsagent, Murifeldw. 21
-– Rud.. Maler, Brunngasse 42
+– Rud., Maler, Brunngasse 42
 – Rud., gew. Telephonarbeiter, Greyerzstr. 27
 – Valentin Arnold. Redaktor, Weingartstrasse 57
 – Violette, Lehrerin, Chutzenstrasse 39 [28.984]
@@ -14900,7 +14874,7 @@ Glauser, s. auch Klauser
 – Walter, Hilfsarbeiter, Aarbergergasse 53
 – Walter, Vertreter, Hubelmattstrasse 50a [20.295]
 – Werner (Hummel). Reichenbachstrasse 64 [35.850]
-– Willy Rud.. Kommis, Hochfeldstrasse 26
+– Willy Rud., Kommis, Hochfeldstrasse 26
 Glaiz, Alex (Sutter), Zementer, Weissensteinstrasse 64
 Gleu, A. H., Musiker, Rossfeldstrasse 31
 – Hermann A., Kommis. Seftigenstrasse 64
@@ -14910,7 +14884,7 @@ Glock, Helene, Schneiderin, Neubrückstr. 75
 Glöckner, Alice El. W., Bureaulistin. Kyburg-Strasse 13
 – Fritz, kant. Experte, Kyburgstr. 13 [26.118]
 Gloge, P., Journalist, Bahnhof platz 3 [22.801]
-Gloggner, Arthur Jos. Ad.. Dr. jur., Thunstrasse 15
+Gloggner, Arthur Jos. Ad., Dr. jur., Thunstrasse 15
 – Marie F., Frau, Privatiere. Thunstr. 15
 – Marie E., Bureaulistin Thunstrasse 15
 – Oskar K., Privatier, Kramgasse 15
@@ -14921,8 +14895,8 @@ Gloor, A A. H., pens. Briefträger, Falkenpl. 6
 – Emil, Berchtoldstrasse 5
 – Emil, Angestellter, Wylerstrasse 101
 – Erika G., Verkäuferin, Falkenplatz 6
-– Ernst, Bahnbeamter. Berchtoldstrasse 5
-– Ernst Ferd.. Mechaniker, Freieckweg 14, Bümpliz
+– Ernst, Bahnbeamter, Berchtoldstrasse 5
+– Ernst Ferd., Mechaniker, Freieckweg 14, Bümpliz
 – Ferd., eidg. Beamt., Freieckw. 14. Bümpliz
 – Ferd., Vertreter, Freieckweg 14, Bümpliz
 – Frieda Luise, Telephonistin, Spitalackerstrasse 15
@@ -14937,18 +14911,18 @@ Gloor, A A. H., pens. Briefträger, Falkenpl. 6
 – Marg. (Meyer), Modes (Erlachstrasse 10), Marktgasse 36 [33.878]
 – Maria, Fabrikarbeiterin, Fluhweg 7
 – Maria El., Empfangsfräulein, Hirscbengr. 8
-– Oskar, Postbeamter. Mattenhofstrasse 36
+– Oskar, Postbeamter, Mattenhofstrasse 36
 – Rud. G., Hilfsarbeiter, Mezenerweg 10
 – Walter, Architekt, in Fa. Dubach & Gloor, Sulgenrain 6 [32.866]
 – Walter, gew. Betriebsinspektor d. S. B. B., Ensingerstrasse 33 [21.867]
 – Walter, Erlachstrasse 10von Glotz, Gertrud, Lehrerin, Wylerstr. 45
-Glück. Walter. Kommis. Mittelstrasse 68
+Glück. Walter, Kommis. Mittelstrasse 68
 – Wilhelm (Häberli), Textil-Techniker, Felsenaustrasse 12
-Glur, Ad.. Techniker, Kirchgasse 6
+Glur, Ad., Techniker, Kirchgasse 6
 – Ad. (Biitschi), Länggassstrasse 74
 – B C. (Wyder). Wwe. d. Dr. phil., Weihergasse 17 [34.904]
-– E. R., Billetteur S. S. B.. Kirchbülilweg 17
-– Elise Emma (Wälti). Wwe.. Freiburgstr. 69
+– E. R., Billetteur S. S. B., Kirchbülilweg 17
+– Elise Emma (Wälti). Wwe., Freiburgstr. 69
 – Emil, Kaufmann, Monbijoustrasse 70
 – Frieda Lina, Murtenstrasse 16
 – Fritz (Balz). Patissier. Schattenweg 7
@@ -15062,14 +15036,15 @@ Goldschmidt, Fernand, Monbijoustrasse 51 [21.416]
 – Jacques, Viehhändler, Effingerstrasse 35 [27.280]
 – Lucien, Vieh- u. Pferdehandel, Monbijoustrasse 51 [21.416]
 – Mathilde (Dreyfuss), Wwe., Monbijoustr. 51
-Gollini, Giov. (Meyer), Maurer, Gewerbestr. 16v. Goltz, Gertrud Ilse, Lehrerin, Wylerstr. 45
+Gollini, Giov. (Meyer), Maurer, Gewerbestr. 16
+v. Goltz, Gertrud Ilse, Lehrerin, Wylerstr. 45
 Gölz, Friedr., Einrahmer, Erikaweg 6
 Gomes, Margrit E. (Stucki), kaufm. Angest., Wylerringstrasse 7
 Gonin, Pierre Louis, Beamter der Internat.
 Eisenbahnbeförderung, Neufeldstr. 103
 Gönner, Friedr., Kaufmann. Marzilistr. 22
 Gonzenbach, Aug., Monteur. Willadingweg 30
-– E. H. W., Bankangest.. Jubiläumsstr. 23
+– E. H. W., Bankangest., Jubiläumsstr. 23
 – Ernst Otto (Hofer), Kassier, Tscharnerstrasse 7 [29.386]
 – Mario, Versieh.-Agent, Kapellenstrasse 30 [25.823]
 – Oskar W., Zigarrengeschäft (Köniz), Bubenbergplatz 4b [23.376]
@@ -15089,7 +15064,7 @@ Goretzki, Eug. (Keusen), Gantrischstrasse 14
 Görg, J. W., Elektr., Könizstr. 61 [32.519]
 Gorge, Alice, Lingerie (Brückenstrasae 57 [36.496]), Amthausgasse 12 [36-496]
 – A. Klara, Damenschneiderin, Brückenstr. 7
-– Camille B. D.. Sektionschef b. Polit. Departement, Humboldtstrasse 11 [36.143]
+– Camille B. D., Sektionschef b. Polit. Departement, Humboldtstrasse 11 [36.143]
 – Helena, Angestellte, Langmauerweg 12
 – M. M., Ladentochter, Thunstrasse 30
 – Margr., Bureaulistin, Langmauerweg 12
@@ -15134,7 +15109,7 @@ Götschel, Armand, Aktiengesellschaft, Basel, Filiale Bern, Seidenstoffe, Samte,
 – Jeanne Blanche (Blum), Wwe., Seminarstrasse 28 [33.561]
 – Martha Marie (Levy), Wwe., Riedweg 17 [23.970]
 – Max. Kaufmann, Optingenstr. 16 [35.793]
-– Roger, stud,, Riedweg 17 [23.970]
+– Roger, stud., Riedweg 17 [23.970]
 # Date: 1935-12-15 Page: 26020467/162
 Götschi, Emil, Packer, Brünnenstrasse 75, Bümpliz
 – Emma, Glätterin, Platanenweg 12
@@ -15143,8 +15118,8 @@ Götschi, Emil, Packer, Brünnenstrasse 75, Bümpliz
 – Werner, Schneider, Brunnmattstrasse 34a
 Götschmann, Alfred, Bahnarbeiter, Kehrgasse 31, Bümpliz
 – Alice, Verkäuferin, Neubrückstrasse 8
-– Bertha. Frau. Ladenwandstrasse 84
-– Christ.. Ausläufer, Brunngasse 54
+– Bertha.,Frau. Ladenwandstrasse 84
+– Christ., Ausläufer, Brunngasse 54
 – Ernst. Chauffeur S. O. B., Bernstrasse 8, Bümpliz
 – Friedr., Fahrdienstarbeiter, Jurastrasse 69
 – Fritz Ed , Chauffeur. Militärstrasse 45
@@ -15152,9 +15127,9 @@ Götschmann, Alfred, Bahnarbeiter, Kehrgasse 31, Bümpliz
 – Johann Georg, Chefwärter der Reitschule, Neubrückstrasse 8
 – Joh., Handlanger, Burgunderstrasse 142, Bümpliz
 – Josephine, Damenschneiderin, Marktg. 36
-– Otto. Feinmechaniker. Greyerzstrasse 34
+– Otto, Feinmechaniker, Greyerzstrasse 34
 – Philipp, Chauffeur, Neufeldstrasse 27d
-– Werner. Hilfsarbeiter. Brunngasse 52
+– Werner. Hilfsarbeiter, Brunngasse 52
 – Werner, Spengler. Bernstr 101. Bümpliz
 Götte. Niklaus, Elektriker, Jolimontstrasse 16
 Gottesmann, Maria, Ladentochter, Viktoriastrasse 89
@@ -15168,7 +15143,7 @@ Götti, Alessandro, Maurer, Quartierhof 3
 Götti, Emil, Kaminfegermeister, Steinhauerweg 1/Ecke Muesmattstrasse [33.133]
 – Emil Louis, Kaminfeger, Steinhauerweg 1
 Gottier, Ad., Spengler, Stationsweg 38
-– Alice, € Whygena», Neuheiten aller Art, Bierhübeliweg 33
+– Alice, «Whygena», Neuheiten aller Art, Bierhübeliweg 33
 – Gottfr., Gipser, Scheibenstrasse 21
 Göttler, Joh., Beamter der S. B. B., Simplonweg 19
 – Otto Karl, Vertreter, Simplonweg 19
@@ -15203,13 +15178,13 @@ Gräber, A. Ernst. Aktuar b. Regierungsstatthalteramt I. Zähringerstrasse 31
 – Emma (Vogt), Wwe., Bernstr 96, Bümpliz
 – Ernst. Magaziner, Rossfeldstrasse 15
 – Ernst, Schriftsetzer, Wachtelweg 23
-– Ernst, Schuhmachermeister. Murifeldw. 3
+– Ernst, Schuhmachermeister, Murifeldw. 3
 – Erwin, Zahnarzt (Schillingstr. 32 [33.140]), Kornhauspiatz 2 [33.605]
 – Eugen Friedr., Kaufmann. Friedheimw. 49
 – Flora. Näherin, Brunngasse 6
-– Fr. Bertha, Papeterie en gros, Römerw. 13r.34 806]
+– Fr. Bertha, Papeterie en gros, Römerw. 13 [34.806]
 – Friedr. Karl, Hilfsarbeiter, Gerechtigkeitsgasse 52
-– Friedr.. pens. Bach- und Kloakenaufseher, Langmauerweg 17a
+– Friedr., pens. Bach- und Kloakenaufseher, Langmauerweg 17a
 – Friedrich, Liegenschaftsagentur, Freieckweg 5, Bümpliz [46.252]
 – Friedr. Joh., Telephonmonteur, Egelg. 20b [35.147]
 – Friedr., Mechan., Photohaus Metro (Simonstrasse 15 [29.410]), Waisenhausplatz 27 [21.842]
@@ -15221,7 +15196,7 @@ Gräber, A. Ernst. Aktuar b. Regierungsstatthalteramt I. Zähringerstrasse 31
 – Hans S. (Baumann), Kaufmann, Holzikofenweg 18
 – Hans Theophil, Hilfsarbeiter, Brunng. 6
 – Hermann Notar. Adjunkt d. Hypotbekarkasse. Bantigerstrasse 32 [32 879]
-– Joh. Friedr.. Hilfsbereiter, Herzogstr.il
+– Joh. Friedr., Hilfsbereiter, Herzogstr.il
 – Joh., Zuschneider, Seidenweg 24
 – Lina (Köhler), Wwe., Bühlstrasse 35
 – Luise. Schneiderin. Länggassstrasse 57
@@ -15230,7 +15205,7 @@ Gräber, A. Ernst. Aktuar b. Regierungsstatthalteramt I. Zähringerstrasse 31
 – Marie (Berger), Wwe., Bantigerstrasse 32
 – Martha L., Verkäuferin, Bühlstrasse 35
 – Otto Max. Drogist, Monbijoustrasse 26 [29.193]
-– Paul Alb., Bankangestellter. Sennweg 19
+– Paul Alb., Bankangestellter, Sennweg 19
 # Date: 1935-12-15 Page: 26020468/163
 Gräber, Paul Herm., eidg. Beamter, Höheweg 26 [27.889]
 – Paul (Lüthi), Dr. jur., Fürspr. (Humboldtstrasse 25 [29.612]), Marktgasse 39 [32.311]
@@ -15308,7 +15283,7 @@ Graf, Hermann, Hilfsarbeiter, Dalmaziweg 57
 – Otto, Kaufmann, Cäcilienstrasse 40
 – Paul, Handlanger, Altenbergstrasse 32
 – Paul, Dr., eidg. Beamter, Greyerzstr. 26 [22.484]
-– Rosa. Ladentochter. Schöneggweg 21
+– Rosa. Ladentochter, Schöneggweg 21
 – Rosalie (Schlup), Wwe., Angest., Marzili-Strasse 6
 – Rud. (Steger), Holligenstrasse 90 [36.711]
 – Rudolf, Weber, Schifflaube 30
@@ -15320,7 +15295,7 @@ Graf, Hermann, Hilfsarbeiter, Dalmaziweg 57
 Graf, Fr. (Weber), Kaufmann, Thunstr. 33 [31.269]
 v. Graffenried, Albert, Fürsprecher, in Firma
 Henzi, v. Graffenried & Cie. (Junkerng. 45 [32.905]), Bundesgasse 30 [21.107]
-– C., Di. med.. Spezialarzt f. Haut- u. Harnkrankheiten, Röntgen- u. Lichtbehandlung (Kl. Aargauerstalden 2 [23.530]), Amthausgasse 24 [24.866]
+– C., Di. med., Spezialarzt f. Haut- u. Harnkrankheiten, Röntgen- u. Lichtbehandlung (Kl. Aargauerstalden 2 [23.530]), Amthausgasse 24 [24.866]
 – Emanuel K. F. J. (de Villars), Baron, Dapplesweg 15 [21.008]
 – Gerard E. B., Direktor, in Fa. G. de Graffenried & Cie., Jungfraustrasse 18
 – H. R-, Bankbeamter, Rainmattstrasse 17
@@ -15371,13 +15346,13 @@ Gräppi, Ed., Kaufmann, Breitenrainstr. 87
 – Friedr., Mechaniker, Bäckereiweg 11
 – Friedr., Zimmermann, Bäckereiweg 11
 Graser, Max Adelbert, Bureaulist. Karl Staufferstrasse 22
-«—Hermann (Corbaz), Bereiter, Wattenwylweg 26
+— Hermann (Corbaz), Bereiter, Wattenwylweg 26
 Gräser, Karolina, Frau, Glätterin, Schillingstrasse 20
 – Th., Schuhmachermeister (Freiestrasse 52), Bonstettenstrasse 2, Eingang Neubrückstr.
 – Willy, Maschinenzeichner, Greyerzstr. 95
 Grasset, Rene J. L., Vertreter, Junkerng. 29
 Grassi, Renato A., Maurer, Birkenweg 15
-Grässli, Andreas Max, eidg. Beamter. Sulgenauw eg 27 [31.465]
+Grässli, Andreas Max, eidg. Beamter, Sulgenauw eg 27 [31.465]
 Grätzer, Jos. Martin, Büchsenmacher, Waffenweg 2i
 Grau, Karl Joh., Schneider, Brünigweg 27
 – Klara Hedwig, Bureaulistin, Brünigweg 27
@@ -15395,7 +15370,7 @@ Gräub, Alfred, Bauschlosser, Dammweg 5
 – Herm. G., Apotheke u. Drogerie z. Ryfflibrunnen (Verw.: E. F. Uhler) (Reichenbachstrasse 63 [33.944]), Aarbergerg. 37 [27.061]
 – Hermann, städtischer Beamter, Brunnhofweg 18
 – Hermann, Hilfsarbeiter, Seidenweg 62
-– Margr.. Strickerin, Jurastrasse 55
+– Margr., Strickerin, Jurastrasse 55
 – Marianne, Angestellte, Junkerngasse 41
 – Marie, gew Bureaulistin, Erlachstr. 24
 – Walter, Hilfsmonteur, Kesslergasse 37
@@ -15405,7 +15380,7 @@ Grauwiler, Gustav (Maurer), Kolonialwarenhandlung, Lentulusstrasse 19 [22.873]
 – Gust., Milchproduktenhandlung (Lentulusstrasse 19 [22.873]), Jubiläumsstrasse 42 [36.882]
 Gravensteiner-Grundstück A.-G., Waisenhausplatz 4
 Greber, Ferdinand C., Hilfsarbeiter, Mühleplatz 8
-– Franz Xaver, Direktions-Sekr. d. Schweiz. Speisewagen-Gesellschaft, Spitalackerstr.63 [22.830]
+– Franz Xaver, Direktions-Sekr. d. Schweiz. Speisewagen-Gesellschaft, Spitalackerstr. 63 [22.830]
 – Friedrich Jak., Schlosser, Belpstrasse 49
 – Herm., Maschinentechniker, Speicherg. 12
 – Johanna, Glätterin, Bubenbergplatz 4
@@ -15429,7 +15404,7 @@ Greisenasyl und Roschi-Stiftung, Seftigenstrasse 107/109/111 [21.944]
 Gremaud, Juliette, Postgehilfin, Kanonenw. 14
 Greminger, Eduard, Postbeamter, Tavelw. 27
 – Emil, pens. Bureauchef b. Generalsekretariat der S. B. B., Neufeldstr. 128 [29.826]
-Gremion, Alice E.. Schneiderin, Schillingstr.12
+Gremion, Alice E., Schneiderin, Schillingstr.12
 – Cecile Bertha, kaufm. Angest., Mittelstr. 42
 Grenacher, Hermann, Buchbinder, Neufeldstrasse 27b
 Grendelmeyer, Josef Kaspar, Spengler, Wylerstrasse 40
@@ -15460,7 +15435,8 @@ Greuter, Johanna Gertrud (Mäder), Wwe., Weissensteinstrasse 118
 Greutert, Ernst, Karrer, Stalden 6
 Greutert, Joh. Alb., Sekretär d. Schweizer.
 Lithographenbundes, Beaumontweg 19 [31.808]
-– Karl, Pianotechniker, Mittelstrasse 32v. Greyerz, Elisabeth (Tscbanz), Witwe des Pfarrers, Kirchenfeldstrasse 40a
+– Karl, Pianotechniker, Mittelstrasse 32
+v. Greyerz, Elisabeth (Tscbanz), Witwe des Pfarrers, Kirchenfeldstrasse 40a
 – Gottl. E. H., Gymn.-Lehrer, Effingerstr. 67
 – Otto, pens. Prof. Dr., Rud.-Wyssweg 6 [33.659]
 – Paul (Gross), Notar, Sachwalter (Luisenstrasse 20 [33.293]), Zeughausgasse 14 [21.134]
@@ -15474,7 +15450,7 @@ Gribi, Adolf (Schnyder), eidg. Beamter, Liebfeggweg 18 [25.867]
 – Friedr., Hilfsarbeiter, Neuengasse 1
 – Fritz (Ramp), Metzger, Neuengasse 1
 – Hans (Brügger), Kaufmann, Humboldtstrasse 11 [35.484]
-– Klara, Gehilfin P. T. T.. Wabernstrasse 20 [21.850]
+– Klara, Gehilfin P. T. T., Wabernstrasse 20 [21.850]
 – Leon, Kino-Operateur, Neueng. 1 [31.497]
 – Lina (Witschi), Wwe., Zwyssigstrasse 18
 – Marie (Lieber), Wwe., Daxeihoferstrasse 15 [22.950]
@@ -15509,9 +15485,9 @@ Grimbühler, Alfred Paul, Coifteurgeschäft, Kramgasse 2 [36.541]
 – Sven A., Elektromoteur, Federweg 21
 Grimm, Alb. (Hofer), pens. Bundesbeamter, Humboldtstrasse 55
 – Alfr., Angestellter d. Fa. Kehrli & Oeler, Lentulusstrasse 32
-– - Alfr . Postbeamter Länggassstrasse 38a
+– Alfr., Postbeamter Länggassstrasse 38a
 – A. Maria. Angestellte. Lentulusstrasse 30
-– Arnold Gottfr., Mechan.. Stauffacherstr. 5
+– Arnold Gottfr., Mechan., Stauffacherstr. 5
 – Charles J Coiffeurgeschäft (Kornhausstrasse 6 [29.616]), Amthausg. 3 [35.436]
 – Christ, E , Mechaniker, Zähringerstr. 16b
 – E. Osk., Angestellter, Monbijoustrasse 101
@@ -15528,7 +15504,7 @@ Grimm, Alb. (Hofer), pens. Bundesbeamter, Humboldtstrasse 55
 – J., Präparator, Kaffee- und Speiserestaurant, Gerechtigkeitsgasse 80 [24.330]
 – Jenny, Bureaulistin, Mindstrasse 7
 – Joh. Alb., Kaufmann, Humboldtstrasse 55
-– Joh.. Schreiner, Lentulusstrasse 30
+– Joh., Schreiner, Lentulusstrasse 30
 – Johanna J E., Bureaulistin, Muldenstr. 15
 – Johanna, Damenschneiderin, Stauffacherstrasse 9
 – Maria Hedwig, städt. Beamtin, Humboldtstrasse 55
@@ -15542,8 +15518,8 @@ Grimm, Alb. (Hofer), pens. Bundesbeamter, Humboldtstrasse 55
 – Rud. (König), Landwirt, Wankdorfweg 35 [23.506]
 – Rud. Herm., Schriftgiesser, Friedheimw. 51
 – Rud., städt. Beamter, Spitalackerstr. 72
-– Walter Erwin, Heizer S. B. B . Seidenw. 36
-– Wfalter, Schriftenmaler (Druckereiweg 3), Schwarztorstrasse 1 [31.272]
+– Walter Erwin, Heizer S. B. B., Seidenw. 36
+– Walter, Schriftenmaler (Druckereiweg 3), Schwarztorstrasse 1 [31.272]
 – Werner Viktor Maler. Kasthoferstrasse 6
 Grimmbuhler, Karol K., Schlosser, Federweg 21
 Grimmer, Anna (Rutz), Wwe., Privatiere. Jubiläum sstrasse 31 [36.792]
@@ -15557,8 +15533,8 @@ Grizzetti, Aifredo, Maurer, Seidenweg 1
 – Amileare, Maurer, Muldenstrasse 42
 – Giuseppe. Maurer. Muldenstrasse 42
 – Luigia (Gambarini), Wwe., Ralligweg 14
-Grob, Alb.. Zimmermann, Rodtmattstr. 51
-– Alf.. Schulabwart. Speichergasse 4
+Grob, Alb., Zimmermann, Rodtmattstr. 51
+– Alf., Schulabwart. Speichergasse 4
 – Alois, Zimmermann, Rodtmattstrasse 51
 – Anna Scheuerem 3a
 – Ed. (Muff), Tiefbauteehn., Landoltstr. 46
@@ -15572,37 +15548,36 @@ Grob, Alb.. Zimmermann, Rodtmattstr. 51
 – Irene, Bureaulistin, Schauplatzgasse 1
 – J. J., Beamter d S. B B., Zähringerstr. 75
 – Joh. Jakob, Krankenpfleger, Holligenstr. 19
-– Joh. (Witz), eidg Beamter. Aegertenstr 53
+– Joh. (Witz), eidg Beamter, Aegertenstr 53
 – Karl F. L., Kaufmann, Jungfraustrasse 24
 – Karl Joh., Zimmermann. Bodtmattstr 51
 – Karl, Zimmerpolier. Rodtmattstrasse 51
 – Marcel E. Vertreter, Seilerstrasse 22
 – Marie (Iseli), Metzgerei, Viktoriarain 8 [23.509]
 – Olga, Fabrikarbeiterin, Burgunderstr. 134 , Bümpliz
-– Otto, Zigarren - Spezialgeschäft, Importe (Thunstrasse 103 [32.773]), Kornhauspl. 14 [24.905]
-– Rud. Ad. (Brönnimann), Kaufm.. Knüsiihubelweg 5 [45.134]
+– Otto, Zigarren-Spezialgeschäft, Importe (Thunstrasse 103 [32.773]), Kornhauspl. 14 [24.905]
+– Rud. Ad. (Brönnimann), Kaufm., Knüsiihubelweg 5 [45.134]
 – Wilhelm, Metzger, Thunstrasse 90
 Grobatscheck, Alice, Glätterin, Engehaldenstrasse 71
 – Lina (Marti), Wwe., Feinwäscherei und Glätterei, Engehaldenstrasse 71 [33.185]
 – Walter, Maschinenmeister, Engehaldenstrasse 71
-Grobet, Armand, Druckfarbenfabrik Graphica (Monbijoustrasse 67 [35.908]), Liebefeld
-145.076]
-– Martha (Brosy), Wwe.. Optingenstrasse 49
+Grobet, Armand, Druckfarbenfabrik Graphica (Monbijoustrasse 67 [35.908]), Liebefeld [45.076]
+– Martha (Brosy), Wwe., Optingenstrasse 49
 – Rene, Sek.-Lehrer, Optingenstrasse 49
 Grobety, Paul Henri. Vertreter (Muristr. 15 [36 448]), Schwanengasse 5 [36.191]
 – Paul Andre, Masch.-Techniker. Muristr 15
 Gröbli, Albert Ernst. Maschinensetzer, Murist rasse 33
 – Hans W., Goldschmied. Kehrg.20, Bümpliz
-– Joh. A.. Billetteur. Weberstrasse 21
-– Joh Conr.. Magaziner. Murtenstrasse 26
+– Joh. A., Billetteur. Weberstrasse 21
+– Joh Conr., Magaziner. Murtenstrasse 26
 – Karl Rieh., eidg. Beamter, Brünigweg 25
-– Lydia M.. Damenschneiderin. Weberstr 21
-Groenewep, J H.. Konsul d. Niederlande und Kanzleichef der Niederländ. Gesandtschaft, Sulgenbachstrasse 5 [21.098]
+– Lydia M., Damenschneiderin. Weberstr 21
+Groenewep, J H., Konsul d. Niederlande und Kanzleichef der Niederländ. Gesandtschaft, Sulgenbachstrasse 5 [21.098]
 Grogg, Alb., Hilfsarbeiter, Scheibenstrasse 55
 – Alfred. Hilfsarbeiter E. W. B., Birkenw. 34
 # Date: 1935-12-15 Page: 26020472/167
 Grogg, Alfred, Chirurg. Instrumentenmacher, Postgasse 18
-– E.. Bahnarbeiter, BTeitfeldstrasse 42
+– E., Bahnarbeiter, BTeitfeldstrasse 42
 – Ernst. Postangestellter, Wylerfeldstr. 64
 – Ernst, gew Lehrer a. d. Breitenrainschule.
 – Moserstrasse 26 [22.504]
@@ -15613,17 +15588,18 @@ Grogg, Alfred, Chirurg. Instrumentenmacher, Postgasse 18
 – Jakob, Handlanger. Lerchenweg 28
 – Jak. Herm., Güterarbeiter, Eigerweg 3
 – Joh., Bahnarbeiter, Wylerfeldstrasse 64
-– Joh.. Handlanger, Breitfeldstrasse 40
+– Joh., Handlanger, Breitfeldstrasse 40
 – Lisette (Siegenthaler), Wwe., Kirchbühlweg 44
-– Otto, Dr.. Christoffel-Apotheke und Sanitätsgeschäft (Viktoriastrasse 67 [35.296]), Christoffelgasse 3 [34.483]
+– Otto, Dr., Christoffel-Apotheke und Sanitätsgeschäft (Viktoriastrasse 67 [35.296]), Christoffelgasse 3 [34.483]
 – Otto. Masch.-Schlosser. Wylerfeldstr. 64
-– Paul. Hilfsarbeiter. Wylerfeldstrasse 64
+– Paul. Hilfsarbeiter, Wylerfeldstrasse 64
 – Johanna, & Nerlieh, Max, Damensalon, Marktgasse 3 [29.594]
 Gromuz, Albert, Angestellter, Neuengasse 37
 Gröli, Alfr., Gipser- u. Malergeschäft, Aarbergergasse 29 [34.413]
 Grolimund, Adolf, Handharfen u. Grammophone, Handharmonikalehrer, Marktg. 65 [35.851]
 – Hans E., kaufm. Angest., Bühlstrasse 40
-– Max, Werkzeugmacher, Seidenweg 20de Groof, Arnoldus, Musiker, Kramgasse 52t29.654]
+– Max, Werkzeugmacher, Seidenweg 20
+de Groof, Arnoldus, Musiker, Kramgasse 52 [29.654]
 – Piet Herm., Musiklehrer, Lentulusstr. 57
 – Rösy (Hrabal), Coiffeuse im Stadttheater, Kramgasse 52 [29.654]
 Groshans, Georg, Automechaniker, Mühlemattstrasse 64
@@ -15644,7 +15620,7 @@ Gross, Alph, Abwart, Lenzweg 6
 – Helene. Modistin. Gutenbergstrasse 19
 – Jakob, Magaziner, Stauffacherstrasse t
 – K., mechan. Werkstitte, Bosenweg 14 [36.069]
-– Mina, Bureaulistin., Stauffacherstrasse la
+– Mina, Bureaulistin., Stauffacherstrasse 1a
 Gross, Maurice, Dr. med., Spezialarzt f. Kinderkrankheiten, Junkerngasse 31 [20.931]
 – Paul Alfr., Dr. phil., Brunnmattstrasse 67
 – Robert, Heizungstechn., Freiburgstr. 125
@@ -15660,7 +15636,7 @@ Grossen, Adolf, Automechaniker, Scheuermattweg 14
 – Hans, Dr., Sek.-Lehrer, Kirchbühlweg 49 [35.702]
 – Hans, Uhrengeschäft, Aarbergergasse 32
 – Paul. Reisender, Seidenweg 2
-– Werner. Hilfsarbeiter. Freiburgstrasse 149
+– Werner. Hilfsarbeiter, Freiburgstrasse 149
 Grossenbacher, Alfred, Handlanger, Bremgartenstrasse 51
 – Alfr. Werner, Hilfsarbeiter der S. B. B., Wachtelweg II
 – Alwina Fanny (Hubeli), Wwe., Monbijoustrasse 73
@@ -15687,8 +15663,8 @@ Grossenbacher, Alfred, Handlanger, Bremgartenstrasse 51
 – Hans, Kaufmann, i. Fa, Grossenbacher & Co., Sulgeneckstrasse 27 [28.048]
 – Ida M., Bureauangestellte, Tillierstr. 47 [34.650]
 – Joh., Fabrikarbeiter, Stationsweg 36
-– Joh.. Bauamtarbeiter, Muesmatlstrasse 28
-– Joh.. Maler. Murtenstrasse 15
+– Joh., Bauamtarbeiter, Muesmatlstrasse 28
+– Joh., Maler. Murtenstrasse 15
 – Karl, Magaziner, Blumensteinstrasse 15
 – Karl, Schlosser, Wahernstrasse 93
 # Date: 1935-12-15 Page: 26020473/168
@@ -15702,7 +15678,7 @@ Grossenbacher, Lisette, Knabenschneiderin, Brünnenstrasse 4, Bümpliz
 – Otto Werner, Gärtner, Steigerweg 13
 – Otto, Hilfsarbeiter, Metzgergasse 6
 – Otto, Hilfsmonteur, Schifflaube 40
-– Paul, Beamter S B B.. Jennerweg 5
+– Paul, Beamter S B B., Jennerweg 5
 – Rob., Bauglaserei u. Einrahmungsgeschäft (Quartiergasse 15), Herrengasse 11 [36.415]
 – Rud., Schneider, Birkenweg 33
 – Rud., Wegaufseher, Schönauweg 3
@@ -15729,7 +15705,7 @@ Grossi, Luigi, Architekt, Engestrasse 5 [34.007]
 Grossmann, Albert, Glasgraveur-Kaufmann, Cyrostrasse 8
 – Alfred Emil, Telegraphist, Greyerzstr. 51
 – Eug. Jak., Maler, Greyerzstrasse 51
-– Fritz, Aufseher B. L. S.. Heimstrasse 24, Bümpliz [46.223]
+– Fritz, Aufseher B. L. S., Heimstrasse 24, Bümpliz [46.223]
 – Hans, Hilfsarbeiter, Murtenstrasse 22
 – Joh. Karl, Telegraphist, Weingartstr. 57
 – Karoline Eug., Ladentochter, Greyerzstr. 51
@@ -15749,7 +15725,7 @@ Grubauer, Othmar, kaufm. Angest., Gutenbergstrasse 31
 Grube, Aug. K. Dan., Mützenmacher, Mittelstrasse 20
 – Willy, Bäckerei-Konditorei, Mittelstr. 20 [34.863]
 Grubenmann, Ed. O., Ing., Willadingweg 38
-– Jakob, Vertreter. Seidenweg 18
+– Jakob, Vertreter, Seidenweg 18
 Gruber, Anna Elise (Frari), Wwe., Haldenw.8
 – Bertha Glir., kaufm. Angest., Kramg. 79
 – Bertha (Wenger), Wwe. Kl. Muristald. 28
@@ -15763,11 +15739,11 @@ Gruber, Anna Elise (Frari), Wwe., Haldenw.8
 – Franz, Schriftsetzer, Spitalackerstrasse 1
 – Frieda (Winter), Arbeitslehrerin, Gutenbergstrasse 26 [36.527]
 – Friedr., eidg Beamter, Mindstrasse 8
-– Friedr., Kaufmann, Beundenfeldstrasse 52 [32.9321
+– Friedr., Kaufmann, Beundenfeldstrasse 52 [32.932]
 – Fr. Herm., Beundenfeldstrasse 52 [32.932]
 – Friedr., Schreiner, Aarbergergasse 28
 – Friedr. Jul., Taxichauffeur, Dammweg 21
-– Fritz, eidg. Beamter. Papiermühlestr. 21e
+– Fritz, eidg. Beamter, Papiermühlestr. 21e
 – Fritz, Notar, alt Regierungsstatthalter, Kirchenfeldstrasse 61 [33.864]
 – Gottfr., Bankbeamter, Luisenstrasse 8
 – Gottfr, Gärtner. Freiburgstrasse 48
@@ -15800,7 +15776,7 @@ Grubmüller, Franz. Schirmmacher. Lagerw. 1
 Gruler, Albert. Pension Mirabeau. Effingerstrasse 34 (Villa Ulmenau) [33.717]
 Grumbeck, Karl. Schlosser, Steckweg 3
 Grumser, Gottfr. F., Metzger, Zwiebelngässchen 14
-Grunau, Gust., Dr. phil.. Buch- und Kunstdruckerei u. Verlag, Falkenpl. 11 [24.346]
+Grunau, Gust., Dr. phil., Buch- und Kunstdruckerei u. Verlag, Falkenpl. 11 [24.346]
 – Marie Gertrud, Fürsorgerin, Sulgenrain 4 [32.880]
 Grünau, Wohnheim, Wabern [21.979]
 Grunauer, Fr., Elektrotechniker beim städt.
@@ -15813,15 +15789,15 @@ Grundbacher, Christ., Hilfsarbeiter, Scheibenstrasse 38
 – Friedr., Magaziner, Murtenstrasse 39a
 – Hans, internat. Buchdruckersekretär. Länggassstrasse 36 [27.046]
 – Hans, kaufm. Angest., Selibühlweg 15
-– Joh. Friedr.. Ausläufer, Seidenweg 16
+– Joh. Friedr., Ausläufer, Seidenweg 16
 – Joh., Bauamtarbeiter, Seidenweg 16
 – Lydia E., Angestellte, Trechselstrasse 4
 – Rudolf, Magaziner, Rütlistrasse 13
 – Ulrich, Hilfsarbeiter, Freiburgstrasse 70
-Grundbuchamt des Amtsbezirkes Bern, Ferdinand-Hodlerstrasse 7 [24.0341
+Grundbuchamt des Amtsbezirkes Bern, Ferdinand-Hodlerstrasse 7 [24.034]
 – eidg., Bundeshaus-West [61]
 Gründer, Alfr., Reisender, Wildermettweg 22f [31.078]
-– Alice, Ladentochter. Forstweg 68
+– Alice, Ladentochter, Forstweg 68
 – Anna Elisabeth, Modistin, Effingerstr. 97
 – Anna M Telephonistin, Lorrainestr. 36
 – Arthur Th., Angestellter, Länggassstr. 74
@@ -15831,7 +15807,7 @@ Gründer, Alfr., Reisender, Wildermettweg 22f [31.078]
 – Ernst W., Angestellter, Lagerhausweg 18, Bümpliz
 – Ernst Otto, Hilfsarbeiter, Kehrgasse 57, Bümpliz
 – Ernst, Hilfsarbeiter d. S. B. B., Rodtmattstrasse 114
-– Ernst, Schneidermstr.. Kehrg. 57. Bümpliz
+– Ernst, Schneidermstr., Kehrg. 57. Bümpliz
 – Ernst Gottfr K., Schreiner. Jolimontstr. 16
 – Ernst, Verwalter, Lagerhausw. 18, Bümpliz
 – Fritz, Schneider, Ladenwandstrasse 19
@@ -15846,7 +15822,7 @@ Gründer, Gertrud, Telephonistin, Stockerenweg 5 [32.897]
 – Hermine, Coiffeuse, Bolligenstrasse 5
 – Ida Regina, Fabrikarbeiterin. Bollwerk 23
 – Jak., Dr. phil., Gymnasiallehrer. Steinerstrasse 25 [27.638]
-– K., gew. Heizer der S. B. B.. Schwalbenweg 20
+– K., gew. Heizer der S. B. B., Schwalbenweg 20
 – Karl, eidg. Beamter, Wylerstr. 21 [25.648]
 – Karl, Lehrer, Effingerstrasse 97 [32.643]
 – Kath. (Stettier), Wwe., Weingartstr. 55
@@ -15885,11 +15861,11 @@ Grüner, Aug., Pfarrer, Bezirkshelfer, Stauffacherstrasse 2 [33.916]
 # Date: 1935-12-15 Page: 26020475/170
 Grüner, Dorothea, Lindenrain 3
 – Emilie, Gerechtigkeitsgasse 42
-– Emma Elisabeth, Frl.. Bubenbergplatz 4
+– Emma Elisabeth, Frl., Bubenbergplatz 4
 – Ida, Malerin, Gerechtigkeitsgasse 42
 – Paul (Bovet), Dr. phil., Professor d. theor.
 Physik, Lindenrain 3 [24.630]
-Grunewald, Paul, Angestellter. Tillierstr. 47
+Grunewald, Paul, Angestellter, Tillierstr. 47
 Grünig, Ad. Ernst, Maurer, Rodtmattstr. 50
 – Adolf, Mechaniker, Mühlemattstrasse 43
 – Adolf, Schlosser, Quartiergasse 21
@@ -15908,7 +15884,7 @@ Grünig, Ad. Ernst, Maurer, Rodtmattstr. 50
 – Elise Emma, Bureaulistin, Breitenrainstrasse 27
 – Ella Alice, Postgehilfin, Mühlemattstr. 43
 – Emil, Bahnarbeiter d. S. B. B., Freiburgstrasse 383, Bümpliz
-– Erich Ed.. Drogist, Muristalden 32
+– Erich Ed., Drogist, Muristalden 32
 – Ernst Traugott, Ausläufer, Ahornweg 1
 – Ernst, Gipser u. Maler, Sodweg 7
 – Ernst, Maler, Talweg 9
@@ -15918,7 +15894,7 @@ Grünig, Ad. Ernst, Maurer, Rodtmattstr. 50
 – Frieda Hilda, Postgehilfin, Breitenrainstrasse 27
 – Friedr., Milchhändler, Weidgasse 3, Bümpliz
 – Fritz, Post-Obergehilfe, Neubrückstr. 73
-– Fr., Schneidermeister. Rodtmattstrasse 107
+– Fr., Schneidermeister, Rodtmattstrasse 107
 – Gustav Alb., Dr. med. dent., Zahnarzt (Gutenbergstrasse 33 [33.152]), Neuengasse 28, Ryfflihof [24.189]
 – Hans, Bankangestellter, Sulgenrain 8
 – H. E., Buchbinder. Morillonstrasse 3
@@ -15938,12 +15914,13 @@ Grünig, Ad. Ernst, Maurer, Rodtmattstr. 50
 – Otto, Hilfsarbeiter, Tannenweg 12
 – Paul Rud., Angest. S. B. B., Weissenbühlweg 34
 – Paul Christ., Hilfsarbeiter, Quartierhof 14
-– Rob. Adolf, Mechan.. Mühlemattstrasse 43
+– Rob. Adolf, Mechan., Mühlemattstrasse 43
 – Rosa, Frau, Fabrikarbeiterin, Brunng. 12
 Grünig, Rosina, Kioskhalterin, Brunng. 46
 – Rud., Küfermstr., Werkgasse 22, Bümpliz
 – Werner, Bahnarbeiter, Riedbachstr. 262, Bümpliz
-– Willy. Maschinenmeister, Thunstrasse 18v. Grünigen, Arn., Adjunkt d. Kantonskriegskommissärs, Gottl.-Kuhnweg 12 [32.208]
+– Willy. Maschinenmeister, Thunstrasse 18
+v. Grünigen, Arn., Adjunkt d. Kantonskriegskommissärs, Gottl.-Kuhnweg 12 [32.208]
 – Arnold, jun., Kaufm., Gottl.-Kuhnweg 12
 – E. (Wenger), Wwe., Liebeggweg 6 [28.044]
 – Frieda, Schwarztorstrasse 55a
@@ -15953,7 +15930,7 @@ Gymnasium, Jubiläumsstrasse 9 [22.663]
 – Jakob, Sekundarlehrer, Jubiläumsstr. 54 [33.746]
 – Julia, Modes (Schwarztorstrasse 55a), Waaghausgasse 16 [36.737]
 – K. (Geiser), eidg. Beamter, Hubelmattstrasse 60 [31.185]
-– Luzia (Lori), Wwe.. Schwarztorstr. 55a
+– Luzia (Lori), Wwe., Schwarztorstr. 55a
 Grüniger, Ferd. Alb., Schlosser, Zielweg 15
 – Waiter (Oberson). Kaufmann, Hallerstr. 56
 Grüninger, Flora (Rüetschi), Wwe., Neufeldstrasse 153
@@ -15971,7 +15948,7 @@ Grüssi, Emma (Bachmann), Ladentochter, Metzgergasse 66
 – Ernst, Hilfsarbeiter, Jolimontstrasse 18
 – Frieda Margr., Ladentochter, Monbijoustrasse 120
 – Fritz, Chauffeur, Metzgergasse 27
-– Gottfr., Beamter S S. B.. Bubenbergstr. 2
+– Gottfr., Beamter S S. B., Bubenbergstr. 2
 – H. F., pens. Telephonmonteur, Standstr. 7
 – Hans Fr., Monteur, Tulpenweg 3
 – Joh Fr., Mechaniker. Rodtmattstrasse 75
@@ -16019,9 +15996,9 @@ Grütter, Elise Margr. (Schreiber), Wwe., Schwarztorstrasse 3
 Grützner, Aib., Schreiner, Jolimontstrasse 12
 – Anton Alfr., Elektromechaniker. Postg. 60
 – Ida Th., Ladentochter, Aebistrasse 14
-– Karl Otto, Bankbeamter. Jubiläumsstr. 51 [36.587]
+– Karl Otto, Bankbeamter, Jubiläumsstr. 51 [36.587]
 – Ludwig Samuel. Kommis. Obstbergweg 2
-– Martha, Ladentochter. Sandrainstrasse 50
+– Martha, Ladentochter, Sandrainstrasse 50
 – Rud. Wilh , Bankmeister, Mattenhofstr. 6
 Gschwend, Gust., Bankbeamter, Donnerbühlweg 1
 – Ida Hedwig, Angestellte, Eichmattweg 5
@@ -16043,7 +16020,7 @@ Gsteiger, Adolf, Schriftsetzer, Gutenbergstr.27
 – Rosa, Wirtin, Herrengasse 36
 Guallini, Jos. Humbert, Schriftsetzer, Steigerweg 19
 Guanella, Guido, kaufm. Angestellter, Effingerstrasse 12
-Guanter, Theresa (Tunt)an), Wwe., Schanzeneckstrasse 25
+Guanter, Theresa (Turban), Wwe., Schanzeneckstrasse 25
 Gubelmann, Herm., Dipl. Ingenieur, Wildermettweg 16 [33.899]
 Gubler, Alf., Schlosser, Murtenstrasse 153g
 – Alfred, Hilfsarbeiter, Weissenbühlweg 32
@@ -16053,7 +16030,7 @@ Gubler, Alf., Schlosser, Murtenstrasse 153g
 – Joh., Telephonarbeiter, Berchtoldstrasse 27
 – Joh. Alfred, Maschinenzeichner, Berchtoldstrasse 19
 – Marie, Schneiderin, Murtenstrasse 153g
-– Otto, kaufm. Angest.. Holzikofenweg 24
+– Otto, kaufm. Angest., Holzikofenweg 24
 – Pauline, in Fa. P. Gubler & Co., Meisenweg 25
 – Walter, Dr. med. dent., Zahnarzt, Dozent (Schanzenbergstrasse 15 [31.287]), Münzgraben 4 [22.380]
 – Werner Rud., Postbeamter, Fischerweg 14
@@ -16071,12 +16048,12 @@ Güdel, Alb., Beamter, Hopfenweg 44
 – Jakob, Fabrikarbeiter, Brünnackerweg 13, Bümpliz
 – Kath. (Schär), Wwe., Eggimannstrasse 22
 – Rud. (Zingg), Auto-Elektr Anlagen (Neuhausweg 610 [45.617]), Belpstr. 16 [22.194]
-– Walter, Angestellter. Schanzeneckstr. 7
+– Walter, Angestellter, Schanzeneckstr. 7
 – Walter, Auto-Elektriker, Gesellschaftsstr. 86 [27.850]
 – & Zaugg, Vertretg. der «Scintilla»-Fabr., elektromech. Werkstätte, elektr. Apparatefür Autos. Laupenstrasse 17 [27.117]
 Güder, Ed. (Herr), Jungfraustr. 28 [36.338]
 – Lina R., Frl., Bubenbergplatz 4
-– Paul R.. gew. Pfarrer, Jungfraustrasse 28
+– Paul R., gew. Pfarrer, Jungfraustrasse 28
 Gueissaz, Gertrud Emma A., Näherin, Altenbergstrasse 46
 – Isabelle L. H., Schneiderin, Altenbergstrasse 46
 – L. A. (Bornand), Altenbergstrasse 46
@@ -16099,7 +16076,7 @@ Gugelmann, Anna Klara, Bureaulistin, Tscharnerstrasse 5
 – Joh. Arn., Chauffeur, Tscharnerstrasse 5
 – Oskar, Schreiner, Aarbergergasse 55
 – Walter Jak., Techniker, Monbijoustrasse 99
-– & Cie.. Spinnerei Felsenau [22.216]
+– & Cie., Spinnerei Felsenau [22.216]
 Guggenbühl, Ernst. Handelsgärtnerei und Blumengeschäft, Herrengasse 19 [21.421]
 – Kaspar, Angest. der städt. Feuerwache, Wiesenstrasse 54 [33.028]
 – Lydia Rosa, Bureaulistin, Wiesenstr. 54
@@ -16136,7 +16113,7 @@ Gugger, J. E. (Bessire), Wwe., Unt. Dufourstrasse 14 [33.373]
 – Rud., Chauffeur, Seidenweg 27
 – Rud., Kommis, Lagerweg 6
 – Rud. (Christen), Stauffacherstrasse 31
-– Rudolf (Liniger), Prokurist, Stöckackerstrasse 97a, Bümpliz [46.5711
+– Rudolf (Liniger), Prokurist, Stöckackerstrasse 97a, Bümpliz [46.5711]
 – Violetta, Bauzeichnerin, Unt. Dufourstr. 14
 – Walter, Prokurist, Landoltstrasse 49
 – Willy P., Maschinenzeichner, Stauffacherstrasse 31
@@ -16145,15 +16122,15 @@ Guggisberg, Alb., Lohnkutscherei, Auto- und Taxibetrieb, Dählhölzliweg 3 [28.2
 – Albert, Eierhändler, Kehrgasse 5, Bümpliz [46.257]
 – Alfred, Installateur, Chutzenstrasse 28
 – Anna (Stauffer), Wwe. des Polizeidirektors, Allmendstrasse 1 [33.415]
-– B. V. (Gretener),, Wwe., Stockerenweg 13
+– B. V. (Gretener)., Wwe., Stockerenweg 13
 – Chr., Landwirt, Worbstrasse 9
 – Christ., Sohn, Landwirt, Worbstrasse 9
-– Christ. Rud.. Landwirt. Worbstrasse 9
+– Christ. Rud., Landwirt. Worbstrasse 9
 – Ed., Advokatur, Fürsprecher (Blumenbergstrasse 46 [36.187]), Christoffelgasse 4 [24.094]
 – Elise, Schneiderin, Böcklinstrasse 13
 – Elsa Gertrud, Bureaulistin, Jurastrasse 4a
 – Emil, Vertreter, Mühlemattstrasse 68
-– Emil, alt Zugführer der S. B. B.. Mattenhofstrasse 3
+– Emil, alt Zugführer der S. B. B., Mattenhofstrasse 3
 – Emma Ida, eidg. Beamte, Kirchenfeldstrasse 34 [31.557]
 – Emma (Schober), Wwe., Feldheimweg 45, Bümpliz
 – Ernst, Chauffeur, Könizstrasse 39a
@@ -16163,7 +16140,7 @@ Guggisberg, Alb., Lohnkutscherei, Auto- und Taxibetrieb, Dählhölzliweg 3 [28.2
 – Ernst, Pferdewärter, Stauffacherstrasse 41
 – Ernst F., Schreinermeister, Fischerweg 16
 – Ernst, Schreinermstr., Belpstr. 55 [28.588]
-– Erwin Rob., Notar, Effingerstrasse 37 [33.189
+– Erwin Rob., Notar, Effingerstrasse 37 [33.189]
 – Frieda, Pflegerin, Dählhölzliweg 3
 – Friedr., gew. Droschkenhalter, Bubenbergstrasse 33
 – Friedr., Schlosser, Pestalozzistrasse 34
@@ -16230,7 +16207,7 @@ Guhl, Ferdinand Richard, Apotheke u. Drogerie, Gesellschaftsstrasse 36 [31.910]
 – Werner, Mechaniker, Kapellenstrasse 7
 Guichoud, Andree Eugenie, Angestellte, Weingartstrasse 43
 – Denise Marcelle, Bureaulistin, Weingartstrasse 43
-– L. M. Etienne, sanitäre Anlagen (Weingartstrasse 43 [28.6431), Stauffacherstr. 4 [28.314]
+– L. M. Etienne, sanitäre Anlagen (Weingartstrasse 43 [28.6431]), Stauffacherstr. 4 [28.314]
 – Robert L., Installateur, Weingartstr. 43
 Guidon, Maria, Wwe. des Dr. jur., Muristr. 64 [22.477]
 Guignard, Alb., Sekretär der Oberpostdirektion, Kirchenfeldstrasse 63 [35.665]
@@ -16242,8 +16219,7 @@ Guillaume, Emil Ad., Holzmaschinist, Weissensteinstrasse 16
 Guillaumet, Emma (Förster), Wwe., Bollw. 35
 Guillebeau, Fanny (Mathys), Wwe. d. Prof., Hirschengraben 3 [33.603]
 Guillod, Henri E., Elektromonteur, Seidenweg 34
-Guinand, Jules. Stellvertr. d. Direktors d. eidg.
-Amtes für Gold- und Silberwaren, Marienstrasse 35
+Guinand, Jules. Stellvertr. d. Direktors d. eidg. Amtes für Gold- und Silberwaren, Marienstrasse 35
 – Paul, Ingenieurbureau, elektr. Unternehmungen, Könizstr. 517, Liebefeld [45.114]
 Guinchard, Charles, Beaumontweg 30
 – Rene Alfr., eidg. Angest., Lilienweg 16
@@ -16265,7 +16241,8 @@ Güngerich, Ernst, Polizist, Standstrasse 4
 # Date: 1935-12-15 Page: 26020479/174
 Güngerich, Marie, Frl., Humboldtstrasse 19
 – Werner, Zahntechnisches Laboratorium (Wattenwylweg 17), Neueng. 28 [22.849]
-Gunsheimer, Fr., Schneiderin, Viktoriarain 17v. Gunten, s. auch v. Gonten
+Gunsheimer, Fr., Schneiderin, Viktoriarain 17
+v. Gunten, s. auch v. Gonten
 – Ad., Postbeamter, Länggassstrasse 72
 – Adolf, Installateur, Hallerstrasse 22
 – Alb. Marcel, Kontrolleur, Hopfenweg 14
@@ -16286,12 +16263,12 @@ Gunsheimer, Fr., Schneiderin, Viktoriarain 17v. Gunten, s. auch v. Gonten
 – Emil O. (Wanzenried), Magaziner, Berchtoldstrasse 60
 – Emil, Telegr.-Angestellter, Neufeldstr. 125
 – Ernst Rud., Instrumentenmacher, Ladenwandstrasse 96
-– Friedr., Postangestellter. Lorrainestr. 69
+– Friedr., Postangestellter, Lorrainestr. 69
 – Friedr., mech. Schreinerei, Stalden 38 [31.789]
 – Gottfr., gew. Bahnhofangest., Freiestr. 54
 – Gottfr., Schreiner, Neufeldstrasse 27c
 – Hans Franz, Ingenieur, Aegertenstrasse 71 [27.194]
-– Hans Ulrich. Postbeamter. Aebistrasse 18
+– Hans Ulrich. Postbeamter, Aebistrasse 18
 – Hans Walter, Hilfsarbeiter, Neubrückstr;-sse 55a
 – — Hans, Spengler, Wyttenbachstrasse 28
 – Hans, ziegeleitechnisches Bureau, Dapplesweg 12 [22.646]
@@ -16299,7 +16276,7 @@ Gunsheimer, Fr., Schneiderin, Viktoriarain 17v. Gunten, s. auch v. Gonten
 – Herold Rud., kaufm. Angestellter, Frohbergweg 3
 —Jakob, Hillsarbeiter, Aarbergergasse 31
 – Jean A., Schreiner, Herzogstrasse 25
-– Joh., Hilfsarbeiter. Sulgenbachstrasse 42
+– Joh., Hilfsarbeiter, Sulgenbachstrasse 42
 – Joh. Alfr., Mechaniker, Murtenstrasse 58
 – Joh., Schlachthofarbeiter, Herzogstr. 25
 – Johanna, Verkäuferin, Freiestrasse 50
@@ -16312,7 +16289,8 @@ Gunsheimer, Fr., Schneiderin, Viktoriarain 17v. Gunten, s. auch v. Gonten
 – Magdalena, Spezereihdlg., Hoiligenstr. 45 [35.627]
 – Marie Rosa, pens. Arbeitslehrerin, Eigerweg 9
 – Marie (Bücher), Wwe., Marzilistrasse 34
-– Martha, Verkäuferin, Wachtelweg 21v. Gunten, s. auch v. Gonten
+– Martha, Verkäuferin, Wachtelweg 21
+v. Gunten, s. auch v. Gonten
 – Marthe A. L., Verkäuferin, Monbijoustrasse 17
 – Rosina (Leisi), Wwe., Muldenstrasse 49a
 – Rud., Maurer, Aebistrasse 19
@@ -16355,14 +16333,14 @@ Gürber, Ed., Schneider, Länggassstrasse 57
 Gürbetalbahn, Direktion, Genfergasse 11 [21.182]
 – Station Weissenbühl [23.774]
 Gurgize, Vera, Journalistin, Schillingstr. 29 [31.685]
-Gurtenbahn Bern A.-G., Direktion: Eigerplatz 3 [23.121]), Station Gurtenkulm [45.180]
+Gurtenbahn Bern A.-G., Direktion: Eigerplatz 3 [23.121], Station Gurtenkulm [45.180]
 Gurten-Gartenstadt-Terrain A.-G., Bundespl. 2
 # Date: 1935-12-15 Page: 26020480/175
 Gürtler, Emil, Südfriichtehdlg. en gros (Hochfeldetrasse 111 [22.536]), Monbijoustr. 16 [22.500]
 – Herm., Buchdrucker. Hallerstrasse 21
 – Louis Jos., Ing., Böcklinstr. 12 [23.680]
 – Rudolf, Kaufmann, Beaulieustrasse 43
-– Th. (Vogt), Ingenieur, Allmendstrasse 12 [22.7851
+– Th. (Vogt), Ingenieur, Allmendstrasse 12 [22.785]
 Gurtner, Adalbert, Maurer, Gerechtigkeitsg. 36
 – Adolf, Gärtner, Moserstrasse 28
 – Alb., Installateur, Stöckackerstrasse 108, Bümpliz [46.087]
@@ -16383,12 +16361,12 @@ Gurtner, Adalbert, Maurer, Gerechtigkeitsg. 36
 – Friedr., Installateur, Freiburgstrasse 53
 – Friedr., Bümpliz-Apotheke und Drogerie (Verw. Zigerlig), Bernstrasse 72, Bümpliz [46.062]
 – Friedr. Herm., Schreiner, Metzgergasse 16
-– Fritz, . Hilfsarbeiter, Bahnhöheweg 38, Bümpliz
+– Fritz, Hilfsarbeiter, Bahnhöheweg 38, Bümpliz
 – Fritz, Hilfsarbeiter, Altenbergstrasse 48
 – Fritz, Mechaniker, Marzilistrasse 2
 – G. (Frei), pens. Sekretär-Adjunkt d. Bundeskanzlei, Lorrainestrasse 2
 – Gottfr., Handlanger, Lentulusrain 6
-– Gottfr. Walter. Magaziner, Rütlistrasse 11
+– Gottfr. Walter, Magaziner, Rütlistrasse 11
 – Gottl., Brennmaterialien, Mattenhofstr. 35 [31 355]
 – Hans (Konrad), Angestellter, Breitfeldstrasse 69
 – Hans, Dienstmann, Postgasse 47
@@ -16400,12 +16378,12 @@ Gurtner, Adalbert, Maurer, Gerechtigkeitsg. 36
 – J. Emil, Kaufm., Eichmattweg 6 [28.051]
 – Joh., Dienstmann, Postgasse 47
 – Joh., Handlanger. Bäckereiweg 19
-– Joh.. Maler, Fröschmattweg 42. Bümpliz
+– Joh., Maler, Fröschmattweg 42. Bümpliz
 – - Joh. Friedr., Schlosser, Standstrasse 33
 – Karl, Maler, Weberstrasse 17
 – Karl, Schmied, Turnweg 31
 – Karl, Schreiner, Könizstrasse 69
-– Karl Friedr.. Bahnarbeiter, Stöckackerstrasse 76. Bümpliz (
+– Karl Friedr., Bahnarbeiter, Stöckackerstrasse 76, Bümpliz
 – Karl, Vertreter, Gesellschaftsstrasse 4
 – Leo, Gesangspädagoge M. P. V., Effingerstrasse 43
 – Marg. (Inäbnit), Wwe., Landoltstrasse 71
@@ -16415,7 +16393,7 @@ Gurtner, Martha, Frau, Install.-Gesch., sanitäre Anlagen, Stöckackerstr 108. B
 – Oswald. Kommis, Neufeldstrasse 27f
 – Otto, Gasarbeiter, Wabernstrasse 79
 – Rud., Hilfsarbeiter, Wangenstr. 27, Bümpliz
-– Samuel, Hilfsarbeiter. Mittelstrasse 16
+– Samuel, Hilfsarbeiter, Mittelstrasse 16
 – Samuel, Papeterie, Neubrückstrasse 82 [31.221]
 – Th. (Sterchi), Kaufmann, Neubrückstr. 127 [33.784]
 – W., Generalvertreter der «La Genevoise», Genfer Lebensversicherungs - Gesellschaft (Lombachweg 32 [23.525]), Genferhaus, Bahnhofplatz [22.547]
@@ -16423,7 +16401,7 @@ Gurtner, Martha, Frau, Install.-Gesch., sanitäre Anlagen, Stöckackerstr 108. B
 – Walter Rudolf, Handlanger, Bahnhöheweg 38. Bümpliz
 Gurzeler, Friedrich, gew. Wirt, Mühlemattstrasse 16 [34.518]
 – Martha, Bureaulistin, Weststrasse 9
-Guschelbauer, M.. Maler. Bantigerstrasse 33
+Guschelbauer, M., Maler. Bantigerstrasse 33
 Gusset, Louise (Spychiger), Wwe., Kramg. 27
 – Hans. Schneider, Jurastrasse 58
 – Werner (Kleeb), Velomechaniker, Scheibenstrasse 35
@@ -16435,7 +16413,7 @@ Gut, siehe auch Gueth
 – Bertha Hedwig, Telephonistin, Effingerstrasse 29
 – Daniel, Magaziner, Stationsweg 27
 – Ella, Bestickungsatelier, Waisenhauspl. 21 [36.642]
-– Emil Otto (Aegerter), Revisor-Bureauchefb. d. G. D. P. T. T., Spitalackerstrasse 25 [26.266)
+– Emil Otto (Aegerter), Revisor-Bureauchef b. d. G. D. P. T. T., Spitalackerstrasse 25 [26.266]
 – Eugen, Beamter S B. B., Neufeldstr. 122
 – Frieda, Stickerei-Atelier (Viktoriarain 21), Bahnhofplatz 1
 – Hans Matth., Kaminfegermeister, Altenbergstrasse 134 [32.721]
@@ -16447,7 +16425,7 @@ Gut, siehe auch Gueth
 – Marie (Marti), Wwe., Mittelstrasse 32
 – Oskar, Feinmechaniker, Forsthausweg 2
 – Rob. Th., Angestellter, Druckereiweg 1
-– Rosina (Lanz), Wwe.. Altenbergstr. 134 [32.721]
+– Rosina (Lanz), Wwe., Altenbergstr. 134 [32.721]
 – Rud., städt. Beamter, Effingerstrasse 29 [34.811]
 – Walter Martin, Schuhmachermstr., Aegertenstrasse 69 [33.370]
 Gutekunst & Klipstein (s. unter Klipstein)
@@ -16467,7 +16445,7 @@ Gutjahr, Andreas, Gemüsehdlg., Alleeweg 1
 – Walter, Hausierer, Bottigenstr. 59, Bümpliz
 – Werner, kaufm. Angest., Schanzenbergstrasse 30 [21,032]
 – Wilh. A. Ch., kaufm. Angestellter, Rossfeldstrasse 31
-Gutknecht, Alfred, Dr. phil., Versich.-Experte, .Engeriedweg 7 [23.781]
+Gutknecht, Alfred, Dr. phil., Versich.-Experte, Engeriedweg 7 [23.781]
 – Alfred, Zimmermann, Freiburgstrasse 348, Bümpliz
 – Eduard, Monotypgiesser, Effingerstr. 88
 – Ernst, Maurer, Gerbergasse 36
@@ -16488,8 +16466,7 @@ Gutmann, Ad., Maschinenmeister, Breitenrainstrasse 59
 — P. (Moser), Vorst, d. Diakonen- u. Krankenpfleger-Station Mattenhof. staatl. dipl.für Fusspflege u. schwed. Massage, Untere Villettenmattstrasse 7 [20.157]
 – Rud., Postkommis, Fischerweg 21
 Gutschart, Rosa, Ladentochter, Brunnhofw. 26
-Gutsmolkerei Hofwyl 20.733
-Zentralmolkerei der Stadt Bern, Bärenplatz 29 und Verkaufsladen: Effingerstrasse 41d [20.735]
+Gutsmolkerei Hofwyl 📞 20.733 Zentralmolkerei der Stadt Bern, Bärenplatz 29 und Verkaufsladen: Effingerstrasse 41d [20.735]
 Güttinger, AnnaB., Angestellte, Schänzlistr.43
 – Dora, Bureaulistin, Zeughausgasse 16
 – Johanna, pens. Angestellte, Friedbühlstrasse 11
@@ -16620,8 +16597,8 @@ Gyr, Alois, Beamter, Falkenhöheweg 24
 Gyseler, Walter Christ., Hilfsmonteur, Gruberstrasse 12
 Gysi, s. auch Gysin und Gisi
 – A. Walter, Konfiserie, Bogenschützenstr. 8, Eingang: Schanzenstrasse [21.907]
-– August. A.-G.. Tapezierer- u. Möbelgesch., Amthausgasse 3 [23.261]
-– Bertha. Bureaulistin, Waaghausgasse 8
+– August. A.-G., Tapezierer- u. Möbelgesch., Amthausgasse 3 [23.261]
+– Bertha, Bureaulistin, Waaghausgasse 8
 – Emil, Beamter, Könizstrasse 31
 – Emma (Stucki), Wwe., Metzgergasse 17
 – Ernst Albert, Kaminfeger, Steckweg 11
@@ -16636,12 +16613,12 @@ Länggasse, Länggassstrasse 62
 – Paul, Kaufm., Humboldtstr. 43 [32.463]
 – Rud. (Zimmermann), kaufm. Angestellter, Brunnmattstrasse 69
 – Walter, Buchdrucker. Beundenfeldstr. 41
-– Walter, Handel in gebrauchten Maschinen, Motoren, Automobilen (Rainmattstrasse 7 [27.1051), Spitalgasse 36b, Eingang: von Werdt-Passage [24.760]
+– Walter, Handel in gebrauchten Maschinen, Motoren, Automobilen (Rainmattstrasse 7 [27.1051]), Spitalgasse 36b, Eingang: von Werdt-Passage [24.760]
 – Werner, Dekorationswerkstätte u. Möbelhandlung, Belpstrasse 16 [29.098]
 Gysin, siehe auch Gisin
 – Ad., Kaufmann, Stauffacherstr. 35 [26.267]
 – Edgar H., kaufm. Angest., Wylerstrasse 63
-– Gustav Ch. E. V. (Kölliker), eidg. Beamter. Karl-Schenkstrasse 7
+– Gustav Ch. E. V. (Kölliker), eidg. Beamter, Karl-Schenkstrasse 7
 – Julius G, Silberwarengeschäft, Bijouterie (Biel). Zeitglockenlaube 4 [27.872]
 – Karl, gew. Stellvertreter d. Oberbetriebschefs d. S. B. B., Wabernstr. 20 [33.556]
 – Martha, Fabrikarbeiterin, Länggassstr. 88
@@ -16665,17 +16642,17 @@ Haag, Dora Hedw., Bureaulistin. Flurstr. 4
 – Eric Fr., Dr. med. dent., Zahnarzt (Humboldtstrasse 27 [28.709]), Christoffelg. 2 [24 821]
 – Ernst Fr., Automechaniker, Effingerstr. 4a
 – Friedr., Beamter, Tavelweg 10 [31.262]
-– Gertrud Ida. Näherin. Flurstrasse 4 »
+– Gertrud Ida. Näherin. Flurstrasse 4
 – H., Dr. med., Ohren-, Nasen- u. Halsarzt (Helvetiastrasse 47 [35.412]), Christoffelgasse 2 [24.821]
 – Johanna Lse., Bureaulistin, Flurstrasse 4
 – Klara, Frau, Aegertenstrasse 56 [36.905]
-– Paul Ernst, kaufm. Angest.. Flurstrasse 4
+– Paul Ernst, kaufm. Angest., Flurstrasse 4
 – Paula, Schneiderin, Rütlistrasse 15
 – Rob Ed., Kaufmann, Helvetiastrasse 47
 – Walter Emil (Roth), Kanzlist d. K. K. K., Attinghausenstrasse 19
 – Wilhelm (Streit), Werkstätte f. Präzisionsmechanik, Seilerstrasse 9 [23.874]
 Haari, s. auch Hari
-Haarmann, Fritz, Mechan.. Waffenweg 25
+Haarmann, Fritz, Mechan., Waffenweg 25
 Haas, Alois Jos., Hilfsarbeiter, Altenbergstrasse 16
 – A. Marie (Flückiger), Töchterpens., Speichergasse 10
 – Ad. (Flückiger), Schneidermeister, Speichergasse 10
@@ -16704,7 +16681,7 @@ Haas, Friedr. Willy, Mech., Spitalackerstr. 68
 – Klara, Verkäuferin, Sennweg 9
 – Kurt Ed., Gärtner, Weissenbühlweg 49
 – Leonhard, Gottfr., Dr. phil., Archivar, Schillingstrasse 26
-– Paul. Dr.. Bureau für Betriebswirtschaft (Muri [42.272]), Laupenstr. 11 (Suvahaus) [21.386]
+– Paul. Dr., Bureau für Betriebswirtschaft (Muri [42.272]), Laupenstr. 11 (Suvahaus) [21.386]
 – Rob., Prokurist, Engehaldenstrasse 206
 – Rud., Schneider. Rainmattstrasse 18
 – Samuel, Chefredaktor. Direktor d. Schweiz.
@@ -16724,16 +16701,16 @@ Habegger, Alfr. Otto, Postangestellter, Gewerbestrasse 22
 – Ferd., Reisender, Brünnackerweg 23, Bümpliz
 – Frieda, Bankangestellte, Bühlstrasse 46 [27.079]
 – Friedr., Sattler u. Tapezierer, Moserstr. 33
-– Friedr., Pferdewärter. Moserstrasse 33
+– Friedr., Pferdewärter, Moserstrasse 33
 – Gottfr., Schriftsetzer, Zielweg 17
 – Gottl, Hilfsarbeiter, Tscharnerstrasse 27
 – Jakob, Handlanger, Bümplizstrasse 62a
 – Joh., kaufm. Angest., Werkg. 16, Bümpliz
 – Maria (Portmann), Wwe., Bühlstrasse 46
 – Marie. Delikatessen- u. Molkereiprndukte, Lagerweg l [36.618]
-– Mina E.. Ladentochter. Alleeweg 2
+– Mina E., Ladentochter, Alleeweg 2
 – Oskar Werner. Maurer. Alleeweg 2
-– Otto. eidg. Beamter. Ludw.-Forrerstr. 28
+– Otto. eidg. Beamter, Ludw.-Forrerstr. 28
 – Otto (Loosli), Maschinenmeister, Breitenrainplatz 38
 – Otto Max, Schriftsetzer, Wylerstrasse 75 [27.034]
 – Paul Heinrich, Musiker, Zielweg 17
@@ -16743,25 +16720,25 @@ Habegger, Alfr. Otto, Postangestellter, Gewerbestrasse 22
 – Rosa Klara, Postgehilfin, Balderstr 32
 – Walter Joh., Handlanger, Freiburgstr. 60
 # Date: 1935-12-15 Page: 26020484/179
-Haberer, Ernst, sen.. in Fa. Ernst Haberer & Cie., Sulgenauweg 39 [34.201]
+Haberer, Ernst, sen., in Fa. Ernst Haberer & Cie., Sulgenauweg 39 [34.201]
 – Ernst W., jun., in Fa. Ernst Haberer, vorm. E. u. O. Haberer, Humboldtstr. 45 [28.539]
-– Ernst, & Cie., Stuckdekorat.. Malerei und Gipserei, Sulgenauweg 38 u. 38a [22.943]
+– Ernst, & Cie., Stuckdekorat., Malerei und Gipserei, Sulgenauweg 38 u. 38a [22.943]
 – Ernst, vorm. E. u. U. Haberer, Malerei, Gipserei, Stukkaturen, Optingenstrasse 43 [29.015]
 – Frieda (Authenrieth), Wwe., Wäsche und Gummiwaren, Waisenhausplatz 16
 – Georg Otto (Fortmann), Stukkaturen, Schaufensterfiguren (Scheuermattweg 21 [36.701]), Monbijoustrasse 103 [36.701]
 Häberli, s. auch Häberlin
 – Adolf (Minder), Bank Prokurist, Blumenbergstrasse 3
-– A.. pens. Staatsanwalt. Asterweg 5 [29.036]
+– A., pens. Staatsanwalt. Asterweg 5 [29.036]
 – Adolf, Dr., Sek.-Lehrer, Lorbeerstrasse 5, Bümpliz [46.092]
-– Alb.. Tramführer. Hauensteinweg 12
+– Alb., Tramführer. Hauensteinweg 12
 – Alfred, Buchhalter, Spitalackerstrasse 65
 – Alwine Math., Zeughausgasse 16
 – Arnold, Schriftenmaler, Lorrainestrasse 68
 – Berta (Trittibach), Wwe., Spitalackerstr. 65
 – Christ., Schreiner. Werdtweg 10
 – Denyse Y., Geschäftsinhaberin, Genferg. 12
-– Elisab.. Krankenschwester, Gerechtigkeitsgasse 70
-– Elise Widmer), Wwe., Florastrasse 3
+– Elisab., Krankenschwester, Gerechtigkeitsgasse 70
+– Elise (Widmer), Wwe., Florastrasse 3
 – Elsa Margr., Pedicure, Florastrasse 3
 – Emil, Arbeiter b. Gaswerk, Armandweg 5
 – Emil Osk., Färbermeister, in Fa. Häberli & Co., Tscharnerstrasse 39
@@ -16793,7 +16770,7 @@ Häberli, Turnweg 33
 Häberli, s. auch Häberlin
 – Marie Elise (Rieben), Wwe., Gewerbestr. 12 [35.666]
 – Max, Notar (Spitalackerstrasso 65), Christoffelgasse 2 [25.856]
-– Nikl.. Gutsbesitzer. Buchweg 16. Riedbach
+– Nikl., Gutsbesitzer. Buchweg 16. Riedbach
 – Otto K., städt. Beamter, Neufeldstr. 122
 – Otto, Metzger, Bümplizstrasse 108
 – Paul Ed., Elektromonteur, Effingerstr. 51
@@ -16827,7 +16804,7 @@ Habich. Us. A. Fr., Ingen. S. B. B., Brunnadernrain 25 [33.326]
 Habisreutinger, Hermance, Pianistin. Amthausgasse 2 [33.264]
 Hablützel, Bruno, kaufm. Angest., Fischerweg 8
 Haccius, G. A. Ch., Kaufm., Schosshaldenstrasse 16
-– R. A. E. (v. Büren), Oberstlt.. Kommandant d. Kavallerie-Remontendepots, Schosshaldenstrasse 16 [23.862]
+– R. A. E. (v. Büren), Oberstlt., Kommandant d. Kavallerie-Remontendepots, Schosshaldenstrasse 16 [23.862]
 Hachen, Alice, Modistin, Ahornweg 3
 – Christ., pens. Vorarbeiter, Hochfeldstr. 47
 – Daniel, Mechaniker, Ahornweg 3
@@ -16841,7 +16818,7 @@ Hachen, Frieda Gertrud, Ladentochter, Hoclifeldstrasse 47
 – Werner, Mechaniker. Lentulusstrasse 40
 Hächler, Albert, kaufm. Angestellter, Burgunderstrasse 103, Bümpliz
 – E., Garagechef, Burgunderstr. 103, Bümpliz
-– Fritz. Tramkondukt.. Mattenhofstrasse 6
+– Fritz. Tramkondukt., Mattenhofstrasse 6
 – Hans, Malermstr., Effingerstr. 101 [31.521]
 – Jak. Fr., Beamter S. B. B., Berchtoldstr. 45
 – J., Bäckerei u. Konfiserie, Thunstr. 113 [36.576]
@@ -16873,7 +16850,7 @@ Hadorn, Alfr. Karl, Reisender, Brunngasse 2
 – Dora, Bureaulistin, Spitalackerstrasse 66
 – Elise (Hofstetter), Wwe., Wachtelweg 21
 – Ella Elvira, Modistin, Murtenstrasse 48
-– Emil, Pferdewärter. Wiesenstrasse 28
+– Emil, Pferdewärter, Wiesenstrasse 28
 – Erna Lina, Verkäuferin, Könizstrasse 65
 – Ernst, Installateur, Graffenriedweg 4
 – Ernst, Magaziner, Fellenbergstrasse 16
@@ -16892,7 +16869,7 @@ Hadorn, Fritz Werner (Schuh), Metzger, Lentulusstrasse 32
 – Jean Alf., Landjägerwachtmeister, Ferd.-Hodlerstrasse 7
 – Joh., Abwart, Bubenbergplatz 10
 – Joh., Handlanger, Sandrainstrasse 78
-– Karl Andr.. eidg. Beamter, Vereinsweg 6
+– Karl Andr., eidg. Beamter, Vereinsweg 6
 – Karl, Abwart, Pestalozzistrasse 38
 – Karl Emil, Landwirt, Matzenriedstr. 112, Bümpliz
 – Karl, Oberpferdewärter, Militärstrasse 30
@@ -16928,7 +16905,7 @@ Häfeli, Alice, Hilfsarbeiterin, Bremgartenstrasse 43
 – J. R., Schriftsetzer, Belpstrasse 49
 – Johanna A., Bureaulistin Herrengasse 25
 – Lina, Weissnäherin, Optingenstrasse 39
-– Oskar, Hilfsarbeiter. Freiburgstrasse 45
+– Oskar, Hilfsarbeiter, Freiburgstrasse 45
 – Otto, Beamter der O. P. D., Muesmattstr. 20 [33.485]
 – Rud., Photograph, Tscharnerstrasse 14
 – Viktor, Bäckerei u. Konditorei, Quartiergasse 27 [36.521]
@@ -16940,7 +16917,7 @@ Häfelin, Emil Joh., kaufm. Angest., Brunnhofweg 21
 – Rud., Pferdewärter, Standstrasse 11
 Hafen, Arnold, Altenbergstrasse 44
 – Arnold, Mechaniker, Schifflaube 36
-– Arn., Obermaschinenmeister. Schifflaube 48
+– Arn., Obermaschinenmeister, Schifflaube 48
 – Gertrud. Schneiderin. Schifflaube 48
 – Klara (Lehmann), Wwe., Wattenwylw. 19 [22.341]
 – L., Auto-Reparaturwerkstätte, Einbau von
@@ -16952,7 +16929,7 @@ Häfliger, Anna Elsbeth, Ladentochter, Freiburgstrasse 60
 – Anton, Motor- u. Fahrradhdlg., Radioapparate u. Repar., Monbijoustr. 30 [23.366]
 – Elisabeth, Näherin, Muristrasse 29
 – Emma (Wandeier), Wwe., Weberstrasse 3
-– Ernst (Eberhard), in Fa. Ernst Häfliger & Rossel, Terrassenweg 16 [21.0101
+– Ernst (Eberhard), in Fa. Ernst Häfliger & Rossel, Terrassenweg 16 [21.010]
 – Ernst, Masch.-Techniker, Terrassenweg 16
 – Gottl., in Fa. Häfliger & Hochuli, Weissenbühlweg 4
 – Hans. kant. Angestellter, Freiestrasse 30
@@ -16980,8 +16957,7 @@ Hafner, A. (Mühlenstedt), Frau, Kolonial- u. Rauchwaren, Stauffacherstr. 35 [27
 – Gustav Ad., kaufm. Angest., Pestalozzistrasse 18
 – Jakob, Bierbrauer, Hallerstrasse 22
 – Karl, Angestellter, Stauffacherstrasse 35
-Hafner, Karl, Kontrollgehilfe der kriegstechn.
-Abtlg. d. Militärdepart., Breitenrainpl. 30
+Hafner, Karl, Kontrollgehilfe der kriegstechn. Abtlg. d. Militärdepart., Breitenrainpl. 30
 – Lina (Hegg), Broderiegeschäft (Breitenrainplatz 30), Waisenhauspl. 22 [23.482]
 – Paul, Automechaniker, Seilerstrasse 7
 – Pius, Schriftsetzer. Neufeldstrasse 111
@@ -16995,7 +16971,7 @@ Hagen, Anna Gertrud. Frau. Bureaulistin, Schwarztorstrasse 3 [31.963]
 – Wilhelm Alois, Mechaniker und Chauffeurd. O. T. D., Tavelweg 8 [35.137]
 Hagenbach, Arnold, Journalist (Donnerbühlweg 3 [22.494]), Waisenhauspl. 27 [20.616]
 – Dora Emilie, Bureaulistin. Bühlstrasse 53
-– E. (Mörker), Wwe.. Bühlstrasse 53
+– E. (Mörker), Wwe., Bühlstrasse 53
 – Martha (Henchoz), Wwe., Donnerbühlw. 3
 – Martha (Schwarz), Wwe., Egghölzliweg 82 [32.745]
 – Paul A., Fürsprecher, Egghölzliweg 82 [32.745]
@@ -17030,14 +17006,14 @@ Hagi, Jakob Heinr., Maurer, Weidmattweg 14, Bümpliz
 – Joh., Schulimacliermeister, Brunngasse 62
 – Johanna L., Bureaulistin, Brünnenstr. 38, Bümpliz
 – Maria (Liechti), Wwe., Amselweg 5
-Hagi, Lina E.. Buchhalterin. Bahnhofplatz 11
+Hagi, Lina E., Buchhalterin. Bahnhofplatz 11
 – Martha (Pfister), Wwe., Wäscherin, Wylerfeldstrasse 61
 Hagin, E. W., Coiffeur, Länggassstrasse 32
 Hagist, Friedr., Buchdrucker, Holzikofenw. 24
 Hagmann, Hans Walter, Elektrotechniker, Lorystrasse 4
-– J. Aug., Direktor der Schweizer. Speisewagengesellsch.. Brückfeldstr. 32 [34.0.071
+– J. Aug., Direktor der Schweizer. Speisewagengesellsch., Brückfeldstr. 32 [34.007]
 – Viktor (Quiblier), Coiffeur, Berchtoldstr. 6
-Hagnauer, Jul. Leo, Postkommis. Länggassstrasse 32a
+Hagnauer, Jul. Leo, Postkommis, Länggassstrasse 32a
 Hahlen, Gottfr., Hilfsarbeiter, Pulverweg 82
 – Ida, Coiffeuse, Damensalon, Blockweg 9
 – Martha K., Fabrikarbeit., Scheibenstr. 39
@@ -17045,10 +17021,10 @@ Hahn, Gustav Wilhelm, Modellschreiner, Zähringerstrasse 63
 – H. L. Rud., Kaufm., Muristr. 11a [35.972]
 – Louise, Gerechtigkeitsgasse 3
 – Phil. G., Techniker, Brunnmattstrasse 77
-Hahnemann, K.. Spezierer, Quartiergasse 15
+Hahnemann, K., Spezierer, Quartiergasse 15
 Hahnloser, Hans (Wilckens), Dr. phil., Prof., Kollerweg 9 [23.565]
 Hainard, Dcra Rosa, Gymnastiklehrerin, Kirchenfeldstrasse 16
-– Emil, pens. Bureauchef der Hauptbuchhaltung S. B. B.. Kirchenfeldstrasse 16
+– Emil, pens. Bureauchef der Hauptbuchhaltung S. B. B., Kirchenfeldstrasse 16
 – Ernst (Reichle), Kaufm., Dittlingerweg 6
 – Paul (Marbach), Kaufmann, Ob. Dufourstrasse 23 [20.205]
 – Walter Emil, Küchenchef, Stauffacherstrasse 46
@@ -17068,8 +17044,7 @@ Haldemann, s. auch Haldimann
 — Ernst, Chauffeur, Weberstrasse 15
 – Ernst, Prokurist, Viktoriastr. 47 [33.173]
 – Ernst, Pfarrer, Scheibenstr. 61 [33.525]
-– Ernst, Schneider, Marktgasse 25, Eingang
-Amthausgässchen 3
+– Ernst, Schneider, Marktgasse 25, Eingang Amthausgässchen 3
 Haldemann, s. auch Haldimann
 – G. (Glur), Beamter B. K. W., Tiefmattstr. 6
 – Hans Werner, Kaufmann. Hopfenrain 25
@@ -17086,12 +17061,12 @@ Haldemann, s. auch Haldimann
 Haldenwang, M., Konditor, Murtenstrasse 40
 Haldi, Alfred, Wirt, Murtenstrasse 22
 – Alb., Koch, Wallgasse 4
-– Arnold, Hilfsarbeiter. Scheibenstrasse 27b
+– Arnold, Hilfsarbeiter, Scheibenstrasse 27b
 – Gottfr., Magaziner, Brunngasse 44
 – Hans, Inspektor der Generaldir. P. T. T., Müslinweg 15 [25.238]
 – Katharina Sophie, Schneiderin, Wallg. 4
 – Klara, Bureaulistin, Sonnenbergstrasse 12
-– Lina Ros.. Freiburgstrasse 53
+– Lina Ros., Freiburgstrasse 53
 – Margrit, Bureaulistin, Elfenauweg 17a
 – Margaritha, Angestellte, Monbijoustr. 67
 – Samuel (Wasem), Karrer, Güterstrasse 50
@@ -17104,7 +17079,7 @@ Haldimann. s. auch Haldemann
 – E. F., gew. Münzarbeiter, Moritzweg 18
 – E. Hermine, Privatiere, Optingenstrasse 6 [27.550]
 – Elise, Kramgasse 54
-– Elise (Hofer), Wwe.. Brunnmattstr. 38a
+– Elise (Hofer), Wwe., Brunnmattstr. 38a
 – Elisabeth (Burla), Wwe., Marzilistrasse 26
 – Emma (Häberli), Wwe., Militärstrasse 55
 – Ernst. Dachdeckermeister, in Firma Fritz
@@ -17147,8 +17122,7 @@ Hallenbad « Sommerleist», Maulbeerstr. 14 [28.639]
 Hallenbarter, L., Schneidermeister, Marktg. 3
 Hallersche Buchdruckerei & Wagnersche Verlagsanstalt, A.-G., Ecke Breitenrainstr. 97u. Viktoriarain [28.222]
 Haller, A., Postangestellter, Archivstrasse 8
-– A. Werner, Bauunternehmer (Sägegasse
-Nr. 110b, Liebefeld [45.221]), Murtenstrasse 141a
+– A. Werner, Bauunternehmer (Sägegasse Nr. 110b, Liebefeld [45.221]), Murtenstrasse 141a
 – Ad., Angestellter O. Z. D., Aarbergerg. 21
 – Ad., Vertreter, Militärstrasse 64
 – Alfr., Techniker, Zinggstrasse 25
@@ -17167,7 +17141,7 @@ Nr. 110b, Liebefeld [45.221]), Murtenstrasse 141a
 – Ernst (Urfer), Bankbeamter, Breitenrainstrasse 77
 – F. B., gew. Dir. des eidg. Amts für geist.
 Eigentum, Schwarzenburgstrasse 21
-– Friedr., Bahnangestellter. Breitenrainstr.77
+– Friedr., Bahnangestellter, Breitenrainstr.77
 – Fritz (Bion), Höheweg 11 [31.239]
 – Fritz (Saner), Zugführer, Muldenstr. 15
 – Fritz, Dr. med., Arzt, Schanzenstrasse 23
@@ -17203,7 +17177,7 @@ Haller’sche Buchdruckerei u. Wagner’sche Verlagsanstalt, Buchdruck, Offsetdr
 Halm, V/. Fritz, Techniker S. B. B., Kapellenstrasse 18 [20.180]
 Halmer, Nelly Margr., Kanzlistin, Zähringerstrasse 23
 Halter, Alfr., Chemiker, Tillierstrasse 47
-– Jakob, Buchhalter. Stockerenweg 20
+– Jakob, Buchhalter, Stockerenweg 20
 – Louis, Glasmaler und Kunstglaserei (Altenbergstrasse 56): Klösterlistutz 10
 – Paul, Postbeamter, Viktoriarain 3
 Haltiner, Ernst Jak., Magaziner, Freiburgstrasse 55
@@ -17239,7 +17213,7 @@ Hämmerli, Charles Ernst (Buache), Heizer d. S. B. B., Gesellschaftsstrasse 79
 – Ernst Emil, Monteur S. B. B., Pappelw.il
 – Ernst, Zollbeamter, Seidenweg 66
 – Fr. Alfr., Uebersetzer, Spitalackerstr. 65
-– Gottfr., Polizeigefreiter. Lorrainestrasse 58
+– Gottfr., Polizeigefreiter, Lorrainestrasse 58
 – Trma, Telephonistin, Pappelweg 11
 – Rosina (Rösch), Wwe., Melchenbühlweg 56
 – Rud., Schneidermeister, Brunnmattstr. 34a [35.557]
@@ -17255,7 +17229,7 @@ Handelsgerichtskanzlei, Schanzenstrasse 17, Eingang Kanonenweg [27.631]
 Handelskammer, Zentral-, f. Latein-Amerika, Bubenbergplatz 8 [25.666]
 Handelsregisterbureau f. d. Amt Bern (Amtsgerichtsschreiberei), Ferd.-Hodlerstr. 7 [27.471]
 Handelsregisterbureau, Schweiz., Bundeshaus-West [61]
-Handelsschule Rüedy A.-G.. Bollwerk 35 [31.030]
+Handelsschule Rüedy A.-G., Bollwerk 35 [31.030]
 Handels- und Gewerbekammer, bern. kaut., Kirchgasse 2 [21.769]
 Handels- und Industrieverein, kant.-bern.
 Zentralsekretariat, Aeuss. Bollwerk 19 [22.430]
@@ -17297,7 +17271,7 @@ Hänni u. Häni, s. auch Hänny
 – Albertine (Wyss), Advokatin (Seftigenstrasse 95 [34.273]), Laupenstr. 2 [20.396]
 # Date: 1935-12-15 Page: 26020490/185
 Hänni u Häni, s. auch Hänny
-– Albrecht, Marmor- und Bildhauergeschäft, Pulverweg 68 (Schosshaldenfriedhof) [41.0601
+– Albrecht, Marmor- und Bildhauergeschäft, Pulverweg 68 (Schosshaldenfriedhof) [41.060]
 – Albrecht, Handlanger, Niederriedweg 47, Riedbach
 – Alex., Dr. med., homöopath. Arzt, Schanzenbergstrasse 23 [25.633]
 – Alfr., Hilfsarbeiter, Schwalbenweg 14
@@ -17306,11 +17280,11 @@ Hänni u Häni, s. auch Hänny
 – Alfred, Packer, Kramgasse 51
 – Alfred, Ausläufer. Lentulusstrasse 28
 – Anna, Glätterin, Länggassstrasse 10
-– Arnold, Hilfsarbeiter. Quartierhof 3
+– Arnold, Hilfsarbeiter, Quartierhof 3
 – Bernh., Bauamtarbeiter, Elisabethenstr. 46
 – Bertha, Fabrikarbeiterin. Sodweg 7
 – Chr., Pferdewärter, Breiteweg 12
-– Chr.. Hilfsarbeiter, Bottigenstrasse 241, Oberbottigen
+– Chr., Hilfsarbeiter, Bottigenstrasse 241, Oberbottigen
 – Chr., Mechaniker, Bümplizstrasse 171
 – Christ., Säger, Holz- u. Kohlenhdlg., Gerbergasse 8 [36.596]
 – E. (Krähenbühl), Beamter d. eidg. Oberkriegskommiss., Lorbeerstr. 12, Bümpliz [46.518]
@@ -17348,7 +17322,7 @@ Hänni u Häni, s. auch Hänny
 – Gertrud Lydia, Alexandraweg 22
 – Gottfr., Gasarbeiter, Lentulusstrasse 28
 Hänni u. Häni, s. auch Hänny
-– Gottfr., Tapezierermeister. Archivstrasse 8 [36.132]
+– Gottfr., Tapezierermeister, Archivstrasse 8 [36.132]
 – Gottfr., Handlanger, Murtenstrasse 153g
 – Gottfr., Mechaniker, Murtenstrasse 153g
 – Gottfr., Sattler, Niederriedweg 45, Oberbottigen
@@ -17370,7 +17344,7 @@ Hänni u. Häni, s. auch Hänny
 – J. (Aschwanden), Wwe. des Baumeisters, Blumenbergstrasse 46
 – Jakob, städt. Lebensmittelinspektor, Hochfeldstrasse 106 [20.467]
 – Joh., Handlanger, Brunnmattstrasse 75
-– .Tob.. Hilfsarbeiter. Gerbergasse 8
+– Tob., Hilfsarbeiter, Gerbergasse 8
 – Joh., Magaziner, Ladenwandstrasse 37
 – Joh. Jakob, pens. Pf er de wärter, Scheibenstrasse 26
 – Joh. Sam., Magaziner, Zentralweg 27
@@ -17429,7 +17403,7 @@ Hänni u Hänl, s. auch Hänny
 – Rosa Marg., Bureaulistin P. T. T., Wiesenstrasse 72
 – Rud., Bauhandlanger, Bottigenstrasse 67, Bümpliz
 – Rud., Metzgerei, Quartierhof 7 [27.582]
-– Rud.. Obergehilfe, Bundesbahnweg 31
+– Rud., Obergehilfe, Bundesbahnweg 31
 – Walter Otto, kaufin. Angest., Gryphenhübeliweg 31
 – Walter, Postangestellter, Güterstrasse 44
 – Walter Alb., Radio-Reparaturwerkstätte, Genfergasse 8 [25.962]
@@ -17457,13 +17431,13 @@ Hänseler, Emil, Geschäftsführer, Veilchenweg 4, Bümpliz
 Hanselmann, A. William, techn. Neuheiten, Neubrückstrasse 43
 – Friedr., Fostgehilfe, Engerain 34
 – Joseph, Hilfsarbeiter, Rand weg 9
-– Juliette M,, Schneiderin, Murtenstrasse 30
+– Juliette M., Schneiderin, Murtenstrasse 30
 – Roger Osk., Schneider, Engerain 34
 Hanser, Joh. Jak., Buchbinder, Mittelstr. 17
 – Klara (Moser), Wwe., Reichenbachstr. 2
 – Rosa, Ladentochter, Zähringerstrasse 63
 Hansjakob, Emil (Rodt), Buchbinder, Speichergasse 12
-Hansjakob, Franz ]28.542] Mass-Schneiderei für Damen und Herren. Grosses Lager in englischen Stoffen. Effingerstrasse 6a
+Hansjakob, Franz [28.542] Mass-Schneiderei für Damen und Herren. Grosses Lager in englischen Stoffen. Effingerstrasse 6a
 – Germann (Schlier), Angestellter E. W. B., Berchtoldstrasse 49
 – Irmengard, Ladentochter, Stauffacherfitrasse 31
 – Kasp., Schneidermstr., Gerechtigkeitsg. 3
@@ -17488,8 +17462,6 @@ Haerdi, s. auch Haerdy
 – Emil, Betten- und Polstermöbelwerkstätte (Köniz), Badgasse 49
 – Sam. (Walter), Notar, in Fa. Hserdi & Hertig (Monbijoustrasse 89 [85.778]), Spitalgasse 34 [27.133]
 – & Hertig, vormals Fleuti & Hserdi, Notariats- u. Verwaltungsbureau, Spitalg 34 [27.133]
-Gebr. Keller, Architekten, Spitalgasse 20 Tel. 23.204
-Umbauten erfordern den Rat des erfahrenen u. gewissenhaften Architekten
 # Date: 1935-12-15 Page: 26020492/187
 Hardtmeyer, Karl, Zollbeamter, Kniislihubelweg 5 [45.651]
 Haerdy, s. auch Haerdi
@@ -17509,7 +17481,7 @@ Hari und Harri
 – Rud., Bad- u. Massage-Institut, Neueng. 37 [27.491]
 Häring, Ed., Vorarbeiter T.-W., Landhausweg 30 [31.476]
 – Margar., Angestellte, Schanzenstrasse 23
-– Robert, prov. Angestellter. Marzilistr 18
+– Robert, prov. Angestellter, Marzilistr 18
 Harnisch, Alice, pens. Buchhalterin, Alpenstrasse 13
 – Anna, Vorgängerin, Liebeggweg 16
 – Gottfr., Trödler, Kesslergasse 15
@@ -17522,13 +17494,14 @@ Haerry, Ernst Tr., Hausierer, Morellweg 10
 — Walter, Dr. phil., Hochschulverwalt., Monbijoustrasse 37 [32.644]
 Harsch, Ed Friedr., Schriftgiesser, Flurstr.30
 — Joan, Tanzinstitut, Maulbeerstrasse 7
-Hart, Friedr., Melker, Bümplizstrasse 73v. Harten, Karl, Jurist, Habsburgstrasse 6 [22.885]
+Hart, Friedr., Melker, Bümplizstrasse 73
+v. Harten, Karl, Jurist, Habsburgstrasse 6 [22.885]
 Hartenbach, Maurice E. (Spinner), Ingen., Frikartweg 22
 Hartmann, Ad., Bautechniker, Eigerplatz 12 [22.878]
 – Alfr. (Gadesmann), Adjunkt b. Hochbauamt, Elfenauweg 22 [34.368]
 – Alfred, Sek.-Lehrer, Seidenweg 36
 – Anna E., Lehrerin. Schwarzenburgstr. 36
-– Arn.. Klaviermacher-Vorarbeiter, Muldenstrasse 11
+– Arn., Klaviermacher-Vorarbeiter, Muldenstrasse 11
 – C F., Fahr. hyg. Bekleidungsartikel (Lentulusstrasse 20), Murtenstrasse 78 [20.110]
 – Curt Hans, Kaufmann, Rabbentalstr. 79
 – Dora, Sek-Lehrerin, Beaumontweg 11 [35.862]
@@ -17537,7 +17510,7 @@ Hartmann, Ad., Bautechniker, Eigerplatz 12 [22.878]
 – Emma (Leuch), Wwe., Bubenbergplatz 4
 – Ernst, Aktuar, Breitenrainstrasse 69
 Hartmann, Ernst W., Maler, Frohbergweg 9
-– Ernst. Schuhmachermeister. Gewerbestr. 32
+– Ernst. Schuhmachermeister, Gewerbestr. 32
 – Ernst, Spengler-Installateur, Schifflaube 26
 – Erwin Karl. Bahnarheiter, Schulweg 9
 – Frieda, Schneiderin, Kramg. 6 [33.296]
@@ -17548,7 +17521,7 @@ Hartmann, Ernst W., Maler, Frohbergweg 9
 – Georg, Bauführer, Monbijoustr. 96 [35.430]
 – Georg Eug., Prediger, Bernstr. 68, Btimpliz
 – Georg, Techniker. Kniislihubelweg 7
-– Gottl., Hilfsarbeiter. Gerbergasse 13
+– Gottl., Hilfsarbeiter, Gerbergasse 13
 – Hans, Installateur G.-W., Wintermattw. 10, Bümpliz
 – H. Walter, Schmiedmeister, Tscharnerstrasse 37 [21.789]
 – Joh., Tramführer, Muldenstrasse 43a
@@ -17644,13 +17617,13 @@ Hastiger, Emma, Bureaulistin, Wiesenstr. 26
 – Ida, Glätterin, Seftigenstrasse 32
 – J. M. (Baumgartner), Wwe., Seftigenstr. 32
 – Jos., Mechaniker, Wiesenstrasse 26
-– K. Friedr.. Schlosser, Rohrweg 12
+– K. Friedr., Schlosser, Rohrweg 12
 Hasse, Anna, Ladentochter, Tavelweg 38
 – A. Frieda (Schärer), Wwe., Balderstr. 42
 – Karl (Sägesser), Kanzlist der kant. Direktion des Innern, Tavelweg 38 [20.991]
 – Marg., Kindergärtnerin, Tavelweg 38
 – Theodor, Uhrmacher, Tavelweg 38
-Hassenstein, Frieda (Sutter), Wwe., Privatkochschule und Pension, Spitalgasse 9 [21.4451
+Hassenstein, Frieda (Sutter), Wwe., Privatkochschule und Pension, Spitalgasse 9 [21.445]
 – Siegfr. H. W., Angestellter, Spitalgasse 9
 Hässig, Anna (Hänni), Spezereihandlung, Altenbergstrasse 24 [22.902]
 – Fr., Kaufmann, Altenbergstrasse 24 [22.902]
@@ -17720,7 +17693,7 @@ Haueter, Alfred, Fabrikarbeiter, Jurastr. 77
 – Bertha (Hänni), Wwe., Lorrainestr. 8a
 – Emil A., Sattler, Rodtmattstrasse 50
 – Ernst, Bautechniker, Lorrainestrasse 8a
-– Friedr.. Handlanger, Eggimannstrasse 33
+– Friedr., Handlanger, Eggimannstrasse 33
 – Friedr., Polizist, Stationsweg 38
 – Fritz, Chauffeur, Mühlemattstrasse 14
 – Fritz, Hilfsarbeiter, Steinweg 11
@@ -17776,7 +17749,7 @@ Hausammann, Agnes R., Gehilfin d. P. T. T., Hochfeldstrasse 95
 – Ernst Alfr., Schriftsetzer, Sandrainstr. 86
 – Erwin Osk., Maler, Hochfeldstrasse 95 [29.473]
 – Frz. (Thomann), Bahnarbeiter, Hochfeldstrasse 95 [29.473]
-– Friedr., Bahnarbeiter. Engehaldenstr. 204
+– Friedr., Bahnarbeiter, Engehaldenstr. 204
 – Friedr. Alb. (Ryser), Photograph, Waffenweg 25
 – Fritz, Maurer, Scheibenstrasse 21
 – Fritz, Mechaniker, Attinghausenstrasse 27
@@ -17848,14 +17821,14 @@ Hauser, Marg. E. (Siegfried), Wwe., Privat., Forsthausweg 7
 – Paul Ernst. Kaufmann, Marktgasse 55
 – Rosa, Fabrikarbeiterin, Waffenweg 17
 – Rud., gew. Vertreter der Mühlebauanstalt
-Daverio Henrici & Cie.. A.-G.. Zürich, Neufeldstrasse 122 [32.267]
+Daverio Henrici & Cie., A.-G., Zürich, Neufeldstrasse 122 [32.267]
 – Sophie, Malerin, Beatusstrasse 38 [21.778]
 – Stephan, pens. Weichenwärter, Sonneggring 14
 – Walter Heb., eidg. Beamter, Tillierstr. 46
 – Werner, Vertreter, Sennweg 7
 Häuser A.-G., Bärenplatz 9
 Häuserbau A.-G., Viktoriastrasse 67
-Häusermann. Alb.. Polizeigefreiter, Alleew. 2
+Häusermann. Alb., Polizeigefreiter, Alleew. 2
 – Gertrud (Zehntner), Wwe., Falkenhöheweg 16
 – Gustav. Schneider, Pestalozzistrasse 10
 – Samuel, Oberzollinsp., Sonnenbergrain 4 [21.896]
@@ -17867,7 +17840,7 @@ Hausherr, Karl (Falkner), Zollbeamter, Bürglenstrasse 24
 – R. Erwin, Optiker, Brunnadernstrasse 63a [28.097]
 Hausin, Else. Schule für Gymnastik, Bewegungskunst u. Tanz, Jubiläumsstrasse 42 [34.596]
 – M. Emma, Papeteriewarengesch. (Fischerweg 8 [25.094]), Aarhergerg. 17 [31.412]
-– Maria Lydia. Ladentochter. Fischerweg 8
+– Maria Lydia. Ladentochter, Fischerweg 8
 – Paul (Bietenholz), Postangestellter, Breitenrainplatz 37
 Häusle, Silvia, Angest., Schanzenbergstr. 32
 Häusler, Alice Martha, Coiffeuse, Schwarztorstrasse 103 [33.792]
@@ -17875,7 +17848,7 @@ Häusler, Alice Martha, Coiffeuse, Schwarztorstrasse 103 [33.792]
 – August. Schriftsetzer. Schöneggweg 28
 – Dora, Radiotelegraphistin, Brunnmattstr.57
 – Ernst, Magaziner, Seidenweg 11
-– Friedr.. Architekt. Länggassstr 68 [28.254]
+– Friedr., Architekt. Länggassstr 68 [28.254]
 – Fritz, Elektromechaniker, Wylerringstr. 62
 – Fritz Walter (Matti), Magaziner, Mühleplatz 10
 – Gottfr., Schreiner, Nordweg 10
@@ -17897,30 +17870,30 @@ Häusler, Rob., Architekturbureau und Zeichnungsatelier, Werdtweg 17 [31.967]
 Hausmann, A., städt. Beamter, Heimstr. 16, Bümpliz
 – Bertha, Pension Stamm, Bernastrasse 6 [22.515]
 – E. Jak., Dekorationsmaler. Lentulusrain 5
-– Emil Walter. Käser, Aarbergergasse 12
-– Gustav Hans. Postbeamter. Neufeldstr. 38a
+– Emil Walter, Käser, Aarbergergasse 12
+– Gustav Hans. Postbeamter, Neufeldstr. 38a
 – Gustav (Ris), Lokomotivführer d. S. B. B., Gewerbestrasse 26
 – Heinrich, Schreiner. Pestalozzistrasse 24
 – Maria Martha, Bureaulistin. Gewerbestr. 26
 Haussener, Alex., Kaufmann. Predigerg. 6
 – Ernst Maler, Altenbergstrasse 84
-– Friedr., Vertreter. Neubrückstr. 51 [20.585]
+– Friedr., Vertreter, Neubrückstr. 51 [20.585]
 – Fritz, Schreiner, Blumenbergstrasse 5
-– Gottfr.. Metzger, Wylerstrasse 101
+– Gottfr., Metzger, Wylerstrasse 101
 – Hans. Vertreter, Wylerringstrasse 7
 – Ida, Frau, Lingere, Predigergasse 6
 – Karl, eidg. Beamter, Wabernstrasse 16 [31.501]
 – Martha, Ladentochter, Altenbergstrasse 84
 – Mina. Weissnäherin, Scheibenstrasse 43
 – Rudolf W., Bautechniker, Gewerbestr. 26
-– Traug.. eidg. Beamter, Blumenbergstr. 5
-– Walter. Sattler, Scheibenstrasse 43
+– Traug., eidg. Beamter, Blumenbergstr. 5
+– Walter, Sattler, Scheibenstrasse 43
 – Werner K L., Dr. jur., Beamter, Monbijoustrasse 90
 Häusslein, Karl, Mechan., Sulgenbachstr. 14
 Haussier, Eric Ed., kaufm. Angest., Muldenstrasse 49a
 – Kate (Lord), Wwe., Muldenstrasse 49a
 Hauswirth, Adolf, Hausbursche, Sandrainstrasse 10
-– Alfr., Dr. med.. Stadtarzt (Engestrasse 9 [20.468]), Gurtengasse 6 [20.466]
+– Alfr., Dr. med., Stadtarzt (Engestrasse 9 [20.468]), Gurtengasse 6 [20.466]
 – Armin Notar Sekretär d. kant. Sanitätsdirektion, Schönbergweg 14 [20.727]
 – Christ. H., Dr. jur., Adjunkt d Bern.-kant.
 Handels- u. Industrievereins, Nydeckg. 13 [27.668]
@@ -17936,7 +17909,7 @@ Hauzenberger, Gottfr., Postgehilfe, Elisabethenstrasse 53
 – Paul, Schlosser, Elisabethenstrasse 53
 Havlik, Jos., Metalldrucker, Brunnmattstr. 32
 Hawks, Stanley, 1. Sekr. der amerikan. Gesandtschaft, Junkerngasse 5 [35.801]
-Hax, Heinr.. Kontrolleur d. Schweiz. Speisewagenges., Gantrischstrasse 24 [24.965]
+Hax, Heinr., Kontrolleur d. Schweiz. Speisewagenges., Gantrischstrasse 24 [24.965]
 Haymoz, Albert, Bauarbeiter, Gruberstr. 16
 – Emil, Magaziner, Bollwerk 23
 – Francois, Hilfsarbeiter, Wabernstrasse 25
@@ -17957,7 +17930,7 @@ Hebeisen, Ad., Oberlehrer, Lorrainestrasse 34 [36.411]
 – Ernst, & Cie., Mercerie-, Bonneterie- und Quincailleriegeschäft, Zeughausgasse 20 [33.495]
 – Fritz, Kaufmann, Tillierstrasse 6
 – Fritz, sanit. Installat. u. Zentralheizungen (Bühlstrasse 57), Morillonstr. 15a [23.033]
-– Heinrich, Gasarbeiter. Rohrweg 10
+– Heinrich, Gasarbeiter, Rohrweg 10
 – Hilda Bertha, Mercerie-Bonneterie, Magazin Stauffacher (Zeughausgasse 20), Stauffacherstrasse 3
 – Hilda Olga, Bureaulistin, Martiweg 9
 – Joh., Gärtner, Breitfeldstrasse 61
@@ -18091,7 +18064,7 @@ Heierle, Alice M., Postgehilfin, Schlösslistr. 49
 Heil, Ernst, Schriftsteller, Schwarztorstr. 82
 Heilsarmee, Nat. Hauptquartier f. d. Schweiz, Laupenstrasse 5 [20.591]
 – Immobiliengesellschaft. Laupenstrasse 5 [20.591]
-– Handelsdepartement (Stoffe- und Tee-Verkauf, Laupenstrasse 5 [20.591]
+– Handelsdepartement (Stoffe- und Tee-Verkauf), Laupenstrasse 5 [20.591]
 – Kadettenschule, Muristrasse 6 [22.046]
 – Versammlungslokale: Laupenstrasse 5 und Genossenweg 22 [36.201]
 – Frauenheim, Laupenstrasse 27 [36.119]
@@ -18139,8 +18112,8 @@ Heiner, Ernst Alfred, Polierer, Waldheimstrasse 10b
 Heinichen, Alfred Ad., Musiker, Wiesenstr. 13
 Heiniger, Alb., Verwaltungsrat, Manuelstr. 56 [33.742]
 – Alfred, Hilfsarbeiter, Wylerstrasse 97
-– Alfred, Hilfsarbeiter der W.-F., Blumenweg la
-– Alfred, Magaziner, Blumenweg la
+– Alfred, Hilfsarbeiter der W.-F., Blumenweg 1a
+– Alfred, Magaziner, Blumenweg 1a
 – Alfred, Postbeamter, Weingartstrasse 49
 – Alfred (Ott), Wärter, Breiteweg 8
 – Elise (Wälchli), Wwe., Vertretungen, Weissensteinstrasse 83
@@ -18152,9 +18125,9 @@ Heiniger, Alb., Verwaltungsrat, Manuelstr. 56 [33.742]
 – Franz, pens. Bahnangest., Schönbergw. 5
 – Franz Emil, Beamter der B. K. W., Viktoriastrasse 57 [27.067]
 – Frieda (Aebersold), Frau, Damensalon, Länggassstrasse 41 [36.910]
-– Frieda, Ladentochter, Blumenweg la
+– Frieda, Ladentochter, Blumenweg 1a
 – Frieda Joh., Modistin, Schönburgstrasse 5
-– Friedr., Heizer S. B. B.. Steinauweg 20
+– Friedr., Heizer S. B. B., Steinauweg 20
 – Friedr., Kaufmann, Weissenbühlweg 15
 – Friedr. A., Handlanger, Eggimannstr. 21
 – Friedrich, Aufseher beim Stadtbauamt, Nünenenweg 15 [24.932]
@@ -18178,16 +18151,16 @@ Heiniger, Germaine M., Frau, Schwarztorstrasse 17 [32.210]
 – Hermine. Fabrikarbeiterin, Lerchenweg 28
 – J. F., Vorsteher des städt. Arbeitsamtes, Hubelmattstrasse 19
 – Johann Hausierer, Mattenenge 10
-– Johanna, Damenschneiderin, Blumpnw. la
+– Johanna, Damenschneiderin, Blumenw. 1a
 – Karl Arthur Aug., Techniker, Klaraweg 33 [34.360]
 – Karl, kaufmännischer Angestellter, Wiespnstrasse 75
 – Karl, Gemüsehändler, Kesslergasse 30
 – Klara, Bureaulistin, Nünenenweg 15
 – Klara, Kinderpflegerin, Stauffacherstr.il
-– Lina, Verkäuferin, Blumenweg la
+– Lina, Verkäuferin, Blumenweg 1a
 – Martha (Schneiter), Wwe., Geschäftsleiterin, Schwarztorstrasse 58 [23.344]
 — Mina Lea (Neuhaus), Wwe., Mühlemattstrasse 18
-– Otto. Dr. med.. Arzt, Spezialist für Beinu. rheumat. Leiden, Effingerstrasse 65 [27.586]
+– Otto. Dr. med., Arzt, Spezialist für Beinu. rheumat. Leiden, Effingerstrasse 65 [27.586]
 – Otto, Mechaniker. Länggassstrasse 41
 – Otto Roh, Mechan. Werkstätte (Effingerstrasse 65), Murtenstrasse 141a [26.095]f —Paul Fr. Ausläufer, Kramgasse 16
 – Paul W., Schneider, Muristrasse 37
@@ -18267,7 +18240,7 @@ Helff, Lina, Näherin, Spitalgasse 3
 Hell. Werner, Bankangest., Karl-Schenkstr.ll
 Heller, A. A., Pflästerermeister, Beundenfeldstrasse 35 [22.863]
 – A. M Elisabeth, Frau, Effingerstrasse 14
-– Ad A.. Sohn, Pflasterer, Parkstrasse 5
+– Ad A., Sohn, Pflasterer, Parkstrasse 5
 – Albert Willi, Monteur, Schärerstrasse 7
 – Alfred, Handlanger, Ladenwandstrasse 96
 – Edm. Theodor, Ing., Schauplatzgasse 39 [31.151]
@@ -18283,7 +18256,7 @@ Heller, A. A., Pflästerermeister, Beundenfeldstrasse 35 [22.863]
 – Viktor, kaufm. Angest., Hubelmattstr. 8
 – Walter Joh., dipl. Ing., in Fa. Walter J.
 Heller & Co., Schlossstrasse 119 [22.036]
-– Walter. Kaufmann. Sennweg 11
+– Walter, Kaufmann. Sennweg 11
 – Walter Oskar, Pflasterer, Stockerenweg 11
 – & Co., Walter J., Hoch- u. Tiefbaugesch., Schlossstrasse 119 [22.036]
 Hellman, Nils Kaufmann, Fischerweg 20
@@ -18316,7 +18289,7 @@ Hemmann, Albertine, Seminarstrasse 5
 Hemmeier, Elsa, Waldheimstrasse 10b
 – Emma. Bureaulistin, Waldheimstr. 10b
 – Guido, Dr. med., Arzt, Laupenstrasse 33
-– Jakob, Postbeamter. Waldheimstrasse 10b
+– Jakob, Postbeamter, Waldheimstrasse 10b
 Hemmer, Alb Wilh., Buchhalter, Zielweg 25
 – Ernst Friedrich (Oser), Maschinenmeister, Zielweg 25 [25.895]
 – Max Ernst (Leu), Versicherungsbeamter, Graffenriedweg 8
@@ -18334,8 +18307,6 @@ Henggeier, Ernst, Coiffeur, Länggassstr. 108
 Henggi, s. auch Hänggi
 – Alice (Heusser), Heimarbeiten der Textilwarenindustrie, Gutenbergstrasse 12
 – Fritz Walter, Coiffeur, Bühlstrasse 49
-Umänderungen, Reparaturen für alle Zentralheizungssysteme Päffli & Co»
-Beratungen, Vorschläge besorgt Ihnen jederzeit prompt u. gewissenhaft Hirschengraben 2 Tel. 24.881
 # Date: 1935-12-15 Page: 26020501/196
 Henggi, s. auch Hänggi
 – Gottfr., Kond. B. L. S., Blumensteinstr. 11
@@ -18412,7 +18383,7 @@ Herb, Alwin Schriftsetzer, Pappelweg 8
 – Arthur Rudolf, Schriftsetzer. Breitenrainstrasse 41
 – Lydia M., Bureaulistin, Breitenrainstr. 41
 – Marie (Schläfli), Wwe., Greyerzstrasse 30 [23.001]
-– Othmar Gabr.. Hilfsarbeiter, Lorrainestr. 69
+– Othmar Gabr., Hilfsarbeiter, Lorrainestr. 69
 – Rosa, Wwe., Breitenrainstrasse 41
 Herberge zur Heimat (Emanuel Haller), alkoholfreies Gasthaus, Gerechtigkeitsg. 52 i [24.135]
 Herbst, Oskar, Privatier, Jolimontstrasse 20
@@ -18464,7 +18435,7 @@ Herren, Ad. Gottfr., Spezereihdlg., Fahrweg 31
 – Erwin, Postangestellter, Berchtoldstr. 40
 – Erwin, Elektromechaniker, Myrtenweg 11, Bümpliz
 – Fr., Münzarbeiter, Landoltstrasse 65
-– Friedr.. Bauamtarbeiter. Zaunweg 21
+– Friedr., Bauamtarbeiter, Zaunweg 21
 – Friedr. E., Chauffeur, Rodtmattstrasse 83
 – Friedr. Rud., Metzger, Berchtoldstrasse 49
 – Gottfr., Ausläufer, Mindstrasse 9
@@ -18496,7 +18467,8 @@ Herren, Gottfr., Landwirt, Matzenriedstr. 73, Oberbottigen
 – Werner Adr , städt. Beamter, Bierhübeliweg 31
 – Werner Paul, Radiotelegraphist, Brunnmattstrasse 34a
 – Wilhelm, Trambilletteur. Muristrasse 97
-Herrenschwand, Th. (Walter), Oberst, Waldhöheweg 13v. Herrenschwand, Math. Ida M., Frl., Weststrasse 4
+Herrenschwand, Th. (Walter), Oberst, Waldhöheweg 13
+v. Herrenschwand, Math. Ida M., Frl., Weststrasse 4
 – Max, Dr. med., Spezialarzt für Chirurgie, Nydeckgasse 9 [22.818]
 Herrli, Ernst Hermann, Postchauffeur, Birkenweg 33
 Herrmann, s. auch Hermann
@@ -18544,15 +18516,15 @@ Herrmann & Sohn, Nischenweg 13 [23.732]
 – J. Alfr., pens. Rangierarbeiter, Waffenw. 4 [31.155]
 – J. J., Maurer, Turnweg 27a
 – Johanna, Hefterin, Viktoriastrasse 45
-– Joh. (Treuberg), Kramgasse 2 f30.655]
+– Joh. (Treuberg), Kramgasse 2 [30.655]
 – Joh. Fr., eidg. Beamter, Burkhartweg 1, Bümpliz
-– Joh. Rud., Hilfsarbeiter. Waffenweg 20
+– Joh. Rud., Hilfsarbeiter, Waffenweg 20
 – Joh. Heinr., Schlosser, Bürkiweg 19 [28.204]
 – Joh. Jak., Schlosser, Turnweg 27a
 – Joh. Ernst, Schreiner, Herrengasse 22
 – Joh., Schreiner, Militärstrasse 28a
-– K. F.. Mechaniker, Storchengässchen 5
-– Karl Jakob, pens. Friedhofarbeiter. Krippenstrasse 36
+– K. F., Mechaniker, Storchengässchen 5
+– Karl Jakob, pens. Friedhofarbeiter, Krippenstrasse 36
 – Karl Jak., Schneider, Krippenstrasse 36
 – Katharina El., Artistin, Kramgasse 44
 – Klara, Hilfsarbeiterin. Hohgantweg 5
@@ -18587,19 +18559,20 @@ Hertig, Chr. Samuel, Bahnarbeiter, Bahnstrasse 65
 – E Korb- u. Stuhlflechterei, Wylerfeldstrasse 58 [28.039]
 – Ernst Gottfr., Rodtmattstrasse 116
 – Erwin, Schriftsetzer, Bridelstrasse 94
-– Erwin E.. Coiffeur, Länggassstrasse 32a
+– Erwin E., Coiffeur, Länggassstrasse 32a
 – Frieda Hutnäherin. Wylerfeldstrasse 58
-– Friedr.. Magaziner, Freiestrasse 39
+– Friedr., Magaziner, Freiestrasse 39
 – Fritz Telephonarbeiter, Wylerringstr. 43
-– K. Fr.. Wasserleitungs-Installateur, Gerbergasse 1
+– K. Fr., Wasserleitungs-Installateur, Gerbergasse 1
 – Karl (Arm). Notar, in Fa. Haerdi & Hertig, Notariats- u. Verwaltungsbur. (Sonnenbeigrain 25 [32.063]). Spitalgasse 34 [27.133]
-– Karl. Handlanger. Altenberestrasse 20a , – Karl, Telephonarbeiter, Waffenweg 18 [25.487]
+– Karl, Handlanger, Altenberestrasse 20a
+– Karl, Telephonarbeiter, Waffenweg 18 [25.487]
 – Klara El., Bureaulistin, Bernstrasse 86, Bümpliz
 – Otto, Knecht, Postgasse 19
 – Rosa (Funkhäuser). Wwe., Bridelstr. 94
-Hertlich. Paul A., photograph. Atelier, Schanzenstrasse 6 [24.7841
+Hertlich. Paul A., photograph. Atelier, Schanzenstrasse 6 [24.784]
 – L. (Bürki), Damenschneiderin, Schanzenstrasse 6 [24.784]
-Hertsch, Arthur, Kaufmann, in Fa. Zumstein & Ciö.. Kirchenfeldstr 55 [32 620]
+Hertsch, Arthur, Kaufmann, in Fa. Zumstein & Ciö., Kirchenfeldstr 55 [32 620]
 Herwig, Heinr., Korrektor, Bottigenstr. 71, Bümpliz
 Herzan, Franz, Schneider, Dalmazirain 38
 Herzig, Ad., Pflästerermeister, Dalmaziw. 77 [33.409]
@@ -18618,15 +18591,15 @@ Herzig, Amalie Ida (Brandenberg), Wwe., Weissenbühlweg 32
 – Edgar. Stauffacher-Drogerie (Birkonw. 31), Stauffacherstrasse 6 [23.318]
 – Elise, pens Buchhalterin, Marzilistr. 36
 – Emil, Lackiermeister, Freiburgstr. 125a
-– Emma Anna, Ladentochter. Hopfenweg 37
+– Emma Anna, Ladentochter, Hopfenweg 37
 – Erwin, Abwart, Freiburgstrasse 43
 – Friedr., Freileitungsmonteur, Länggassstrasse 110
 – Fritz (Bähler), Telephonmonteur, Freiburgstrasse 125c
 – G. A. (Steinmann), Beamter der S. B. B., Freiestrasse 28
 – Hans, Schriftenmaler, Hopfenweg 37
-– Herm.. Chauffeur. Mezenerweg 7
+– Herm., Chauffeur. Mezenerweg 7
 – Herm. Rud., Instrumentenmacher, Kornhausplatz 12 [29.166]
-– Joh. All).. Bauamtarbeiter, Mezenerweg 10
+– Joh. All)., Bauamtarbeiter, Mezenerweg 10
 – Karl (Bartlome), Revisor O. Z. D., Hallerstrasse 52 [29.075]
 – Karl, gew. Laborant, Hallerstr. 52 [29.075]
 – Karl (Steiner). Ing. agr., Redaktor des
@@ -18652,7 +18625,7 @@ Herzog, Alfred. Tramangest., Thunstrasse 111
 – Hane (Leuenberger), Beamter der O. P. D., Rabbentalstrasse 41
 – Helene Gertr., Damenschneiderin, Rabbentalstrasse 41
 – Henrietta Bl., Bureauangestellte, Mattenhcfstrasae 15a
-– Jos.. Steindrucker, Kasernenstrasse 52
+– Jos., Steindrucker, Kasernenstrasse 52
 – Karl Emil, Postbureauchef, Altenbergstrasse 80a [35.480]
 – Klara. Bureaulistin. Altenbergstrasse 80a
 – Leonz, Bauunternehmer, Lagerweg 11 [22.768]
@@ -18672,7 +18645,7 @@ Herzog, Martha Rosa, Reisende Genferg. 5
 – Anna, Angestellte, Dietlerstrasse 12
 – Anna (Tschanz), Hebamme, Seidenweg 40 [29.954]
 – Anna Karol., Privat., Beaumontweg 15 [35.432]
-– Christ.. Notar, Notariats- u. Verwaltungsbureau (Elfenauweg 33 [29.493]), Chrisloffelgasse 2 (Eidg. Bank) [25.856]
+– Christ., Notar, Notariats- u. Verwaltungsbureau (Elfenauweg 33 [29.493]), Chrisloffelgasse 2 (Eidg. Bank) [25.856]
 – Dora. Telephonistin, Krippenstrasse 20
 – E., Mechaniker. Sulgenbachstrasse 46
 – E. Herm., Vertreter, Waffenweg 23
@@ -18681,14 +18654,14 @@ Herzog, Martha Rosa, Reisende Genferg. 5
 – Ernst, Hausierer, Bärengasse 29, Bümpliz
 – Ernst. Mechaniker. Stauffacherstrasse 80
 – Ernst, Reisender, Länggassstrasse 79
-– Ernst, Chef d. kommerziellen Dienstes d. S. B. B,, Falkenhöheweg 17 [36.879]
+– Ernst, Chef d. kommerziellen Dienstes d. S. B. B., Falkenhöheweg 17 [36.879]
 – Friedr., eidg. Angest., Klaraweg 3
 – Friedr., Kellner, Seidenweg 66
 – Fritz, alt Departementsaekretär S. B. B., Wabernstrasse 18 [33.051]
 – Fritz, Prokurist. Schwarzenburgstrasse 81 [45.574]
 – Gertrud, Lingere, Birkenweg 27
 – Gottfr., Buchhalter, Studerstr 66a [33.843]
-– Gottfr.. Magaziner, Waffenweg 23
+– Gottfr., Magaziner, Waffenweg 23
 – Gottfr., Schneidermstr. (Zähringerstr. 51), Neuengasse 30 [25.075]
 – Gottl., pens. Bahnarbeiter S. B. B., Krippenstrasse 18
 – Gottl. Heinr., Lithograph, Herzogstrasse 18
@@ -18697,7 +18670,7 @@ Herzog, Martha Rosa, Reisende Genferg. 5
 – Herm., gew. Buchdrucker, Steckweg 17
 – Herm. E., Schriftsetzer. Steckweg 17
 – Hermann, Steckweg 17 [82.628]
-– Huldreich, Vertreter. Bernastrasse 69
+– Huldreich, Vertreter, Bernastrasse 69
 – Jakob (Tschanz). Schlosser, Seidenweg 40
 — Joh., Buchhalter, Murtenstr. 27 [22.675]
 – Joh., pens Polizist, Birkenweg 27
@@ -18735,7 +18708,8 @@ Hess, Joh. Friedr., in Fa. Wanzenried & Hess, Breiten rainstrasse 73 [36.695]
 – Walter, Hilfsarbeiter, Brunngasse 26
 – Willi, Kondukteur S. S. B., Balmweg 33
 Hesse, Martin, Photograph, Waisenhauspl. 18
-Hesselbein, Theodor, Gärtner, Tiefenaustr. 75v. Hessen, Sibylle Marg., Privatiere, Monbijoustrasse 89 [31.282]
+Hesselbein, Theodor, Gärtner, Tiefenaustr. 75
+v. Hessen, Sibylle Marg., Privatiere, Monbijoustrasse 89 [31.282]
 Hetiich, Ernst, Kaufm., Elfenauw. 17 [26.251]
 Hetzel, Alb. (Seelhofer), Chauff., Pappelw. 11
 – Charlotte, Modistin, Pappelweg 11
@@ -18771,7 +18745,7 @@ Heumann, Leo, Rayonchef, Schillingstr. 19 [28.064]
 Heuscher, Marie Luise, Heilsarmeeoffizierin, Könizstrasse 35
 Heusser, Adolf R., Landjägerkorporal, Viktoriastrasse 98 [31.950]
 – Adolf. Maler, Weissensteinstrasse 60
-– Albert Eug.. Angestellter, Länggassstr. 70
+– Albert Eug., Angestellter, Länggassstr. 70
 – Anna Maria, Telephonistin, Optingenstr. 37 [29.363]
 – Anna (Wyss), Wwe., Hallerstrasse 20
 – Anna Maria (Rohrer), Wwe., Optingenstrasse 37 [29.368]
@@ -18800,7 +18774,8 @@ Heyer, A., Redaktor, Gryphenhübeliweg 37 [21.302]
 – Aug., Gryphenhübeliweg 37
 # Date: 1935-12-15 Page: 26020506/201
 v. Heyer, Ferd., Photograph (Greyerzstr. 48), Kramgasse 55 [26.250]
-– Karoliiie, Wwe., Greyerzstrasse 48v. Heyking, Ilse Costa E., Kindergärtnerin, Schanzeneckstrasse 13
+– Karoliiie, Wwe., Greyerzstrasse 48
+v. Heyking, Ilse Costa E., Kindergärtnerin, Schanzeneckstrasse 13
 Hickisch, Anna, Angestellte, Bühlstrasse 23
 – Johann, Schneidermeister (Zeigerweg 8), Waaghausgasse 10 [31.989]
 – Marie (Gebhard), Wwe., Messerschmiede, Motos und Velos, Schleiferei (Bühlstr. 23), Neuengasse 26, Eingang Ryffligässchen 10 [35.617]
@@ -18873,7 +18848,7 @@ Hiltbrunner, Ad., Uhren- u. Bijouteriehdlg. (Neuengasse 17). Spitalgasse 16 [31.
 – E. K., Beamter S B. B., Viktoriarain 1
 – E., Dancing, Tea-Room u. Bar Perroquet (Köniz), Laupenstrasse 2 [23.230]
 – Ernst, Chauffeur, Birkenweg 42
-– Ernst, Fabrikarbeiter. Freiburgstrasse 165
+– Ernst, Fabrikarbeiter, Freiburgstrasse 165
 – Ernst, Schuhmacher, Freiestrasse 43
 – Fr., Telegr.-Angestellter, Lorrainestr. 10
 – Gottfr., Hilfsarbeiter, Wylerringstrasse 65
@@ -18887,7 +18862,7 @@ Hiltbrunner, Ad., Uhren- u. Bijouteriehdlg. (Neuengasse 17). Spitalgasse 16 [31.
 – Ida, Einlegerin, Wylerringstrasse 65
 – Joh. Andr., Billetteur der S. S. B., Länggassstrasse 68c
 – Joh. Fr., Chauffeur-Mechaniker, Blumensteinstrasse 9
-– Joh.. Postangestellter, Länggassstrasse 83
+– Joh., Postangestellter, Länggassstrasse 83
 – K. O., Telegr.-Beamter, Viktoriarain 1
 – Lucie, Bureaulistin, Fischerweg 22
 – Lydia, Ladentochter, Effingerstrasse 101
@@ -18928,7 +18903,7 @@ Hinderling, Elisabetha Maria. Hilfsarbeiterin, Dalmaziweg 79
 – Rud., Magaziner, Dalmaziweg 79
 Hindermann, Hedwig (Tanner), Wildermettweg 46
 Hinnen, Max, Versich.-Insp., Erlachstr. 5
-Hinni, Alfr. Rob., Telephonarbeiter. Kasthoferstrasse 20
+Hinni, Alfr. Rob., Telephonarbeiter, Kasthoferstrasse 20
 – Ernst Rud., Chauff. O. T. D., Wylerstr. 97
 – Friedr. E., Seifenfabrik, Landoltstrasse 73 [28.178]
 – Fritz, Magaziner, Landoltstrasse 69
@@ -18958,7 +18933,7 @@ Hirsbrunner, Alfred, Ausläufer, Brunnmattstrasse 32
 – Blanka (Sprenger), Wwe., Effingerstr. 29 [29.275]
 – Edwin Max, Chemigr., Breitenrainstr. 59
 – Ernst, Chauffeur, Moserstrasse 10
-– Ernst (Mäusli), Bäckerei und Konditorei, . Schifflaube 22 [24.194]
+– Ernst (Mäusli), Bäckerei und Konditorei, Schifflaube 22 [24.194]
 – Ernst Oskar (Lehmann), Kaufmann, Muristrasse 12 [20.920]
 – Frieda Anna, Ladentochter, Schulweg 15
 – Friedr., Verw.-Rat b. Radio Modern A.-G., Bachstrasse 6
@@ -18985,14 +18960,12 @@ Hirsbrunner, Alfred, Ausläufer, Brunnmattstrasse 32
 – Walter Alex., Bereiter, Kasernenstr. 31
 – W., Postbeamter, Länggassstrasse 79
 – Werner Jb., Automaler, Brunnmattstr. 32
-– Willy Herm., Mechan.. Brunnmattstr. 32
+– Willy Herm., Mechan., Brunnmattstr. 32
 Hirschburger, E., Papeterie (Jabiläumsstrasse 56), Thunstrasse 2 [31.820]
-Entwürfefür alle Gebrauchszwecke Hallwag Bern
-ClichSs aller Art liefert Telephon 28.222
 # Date: 1935-12-15 Page: 26020508/203
 Hirschei, Sara, Frau, Monbijoustrasse 69 [31.458]
 – Sophie (Nordmann), Wwe., Monbijoustr. 67 [23.156]
-– Thekla, Monbijoustrasse 69 [31.4581
+– Thekla, Monbijoustrasse 69 [31.458]
 – Willy, Fürsprecher (Monbijoustrasse 67 [23.156]), Marktgasse 50 [28.135]
 Hirschen, Gasthaus, Genfergasse 1 u. Neuengasse 40 [28.370]
 Hirschi, Ad., Hilfsarbeiter, Stationsweg 23
@@ -19031,7 +19004,7 @@ Hirschi, Ad., Hilfsarbeiter, Stationsweg 23
 – Hermann. Schlosser. Bümplizstrasse 75
 – Hulda, Fabrikarbeiterin, Bümplizstr. 75
 – Ida, Fabrikarbeiterin, Stalden 6
-– Joh., Hilfsarb.. Murtenstr. 245, Bümpliz
+– Joh., Hilfsarb., Murtenstr. 245, Bümpliz
 – Johanna, Fabrikarbeiterin, Murtenstr. 245, Bümpliz
 – K., Schuhmachermstr. (Junkerngasse 14), Gerbergasse 44
 – Karl, Abwart, Seilerstrasse 23
@@ -19055,12 +19028,12 @@ Hirsig, Alb., Gipser, Lentulusstrasse 39
 – Albert, Schlosser. Martiweg 14
 – Alfr., Schreiner, Schönburgstrasse 36
 – Emil, Milchhändler, Wattenwylweg 37 [29.226]
-– Hugo W., Hilfsarbeiter, Stauffacherstr. la
+– Hugo W., Hilfsarbeiter, Stauffacherstr. 1a
 – Lina, Glätterin, Lentulusstrasse 39
 – Lina Luise (Salm), Wwe., Breitenrainpl. 37
 – Martha. Damenschneiderin. Lentulusstr. 39
 Hirsiger, A. E., Tramangest., Kasernenstr. 46
-– Arthur, Buchhalter. Thunstrasse 105
+– Arthur, Buchhalter, Thunstrasse 105
 – Daniel, Freie Strasse 40
 – Emil, Wagner, Heimstrasse 34b, Bümpliz
 – Ernst, Handlanger, Metzgergasse 17
@@ -19077,7 +19050,7 @@ Hirt, Anna M. (Hirt), Wwe., Stockerenweg 8
 – Ernst, Handlanger, Kehrgasse 43, Bümpliz
 – Ernst, Handlanger, Brunngasse 10
 – Ernst, Hilfsarbeiter, Waldheimstrasse 43
-– Ernst. Hilfsarbeiter. Mindstrasse 7
+– Ernst. Hilfsarbeiter, Mindstrasse 7
 – Ernst. Monteur, Länggassstrasse 82
 – Erwin, Mech., Feldheimweg 40, Bümpliz
 – Franz Walter, Bankangest., Monbijoustr.22
@@ -19091,16 +19064,14 @@ Hirt, Anna M. (Hirt), Wwe., Stockerenweg 8
 – Gottfr., Hilfsarb., Feldheimw. 40, Bümpliz
 – Hans, Zeichner, Gutenbergstrasse 5
 – Hans, Handlanger, Muldenstrasse 46
-Waschküchen-Anlagenfür Privat und öffentliche Gebäude in jeder gewünschten modernen Ausführung zu annehmbaren Preisen durchsfettbacher
-Qer.clitigk:itsg. 59 Telephon 2t .040
 # Date: 1935-12-15 Page: 26020509/204
 Hirt, Hans Christ., Magaziner, Breitfeldstr. 42
 – Hans, Stationsbeamter, Burgunderstr. 126, Bümpliz
 – Hermann, Polizist, Breitenrainstrasse 39
 – Jean Ch. (Goffinet), Angestellter, Wagnerstrasse 37
-– Johann Fr.. Angest., Stadtbachstr. 48
+– Johann Fr., Angest., Stadtbachstr. 48
 – Joh. Fr., Billetteur d. S. S. B., Freiburgstrasse 113
-– Joh. Gottl., Fabrikarbeiter. Schwalbenw. 32
+– Joh. Gottl., Fabrikarbeiter, Schwalbenw. 32
 – Joh., Hilfsarbeiter, Junkerngasse 48
 – Joh., Landarbeiter, Buchweg 14, Riedbach
 – Joh., gew. Milchhändler, Freiburgstr. 113
@@ -19205,7 +19176,7 @@ Hochuli, Alice, Ladentochter, Gerbergasse 46
 – Ida Elise, Kassierin, Gerbergasse 46
 – Jakob, Zimmermann, Schifflaube 2
 – Joh. Herm., Lehrer, Effingerstrasse 99
-– Joh.. Müller, Gerbergasse 46
+– Joh., Müller, Gerbergasse 46
 – Paul, Tiefbautechniker, Viktoriastrasse 51
 Hodel, Albert (Siegrist), Automechaniker, Lorrainestrasse 21
 – Anna Magdal. (Grünig), Robes, Speichergasse 35 [25.945]
@@ -19233,8 +19204,8 @@ Hodel, Albert (Siegrist), Automechaniker, Lorrainestrasse 21
 – Oskar, Schreiner, Turnweg 18
 – Sus. Kath., Zahntechnikerin, Heimstr. 14, Bümpliz
 – Walter, Bauzeichner, Wylerstrasse 73
-– Walter Wilh., Chauff.. Stöckackerstr. 83a, Bümpliz
-– Walter. Sattler, Scheibenstrasse 55
+– Walter Wilh., Chauff., Stöckackerstr. 83a, Bümpliz
+– Walter, Sattler, Scheibenstrasse 55
 – Werner Ernst, Ausläufer. Elisabethenstr. 36
 Hodler. Alfred. Messgehilfe beim Bauamt, Hopfenweg 25
 – Alfr. Hans, Sattler u. Tapezierer, Hopfenweg 25
@@ -19247,7 +19218,7 @@ Hodler, Elsa, Frau, Friedeckweg 22
 – Emmy (Bichsei), Malerin, Unterricht in
 – 0,el. Aquarell, Porzellan, Holzbrand u. Metalloplastik, Beundenfeldstr. 51 [32.834]
 – Fritz, Direktor der Steiger A.-G., Museumstrasse 10 [22.312]
-– Gottfr.. Messgehiife, Engehaldenstrasse 196
+– Gottfr., Messgehiife, Engehaldenstrasse 196
 – Hans Herm., Schlosser, Dalmazirain 44
 – Herm. Hugo, Kunstmaler, Junkerngasse 1
 – Jakob (Sarbach), Hilfsarbeiter, Murtenstrasse 133
@@ -19264,7 +19235,7 @@ Hofer, Ad., Packer, Tscharnerstrasse 25
 – Ad., Bahnarbeiter, Gäcilienstrasse 18
 – Ad., Angestellter, Bümplizstrasse 146
 – Alb. (Diibi), Druckereifaktor, Spitalackerstrasse 66
-– Alb., Elektriker, Weissensteinstrasse la
+– Alb., Elektriker, Weissensteinstrasse 1a
 – Alb., Magaziner, Fährstrasse 37a
 – Alb., pens. Beamter, Böcklinstrasse 14
 – Alb., Wagenführer S. S. B., Alleeweg 5
@@ -19302,7 +19273,7 @@ Hofer, Emil Albert, Güterarbeiter d. S. B. B., Stöckackerstrasse 56, Bümpliz
 Unfallversich.-Anstalt, Neufeldstrasse 131
 – Ernst, Buchhalter, Manuelstrasse 70
 – Ernst A., Dreher. Fröschmattw. 12a, Bümpliz
-– Ernst, Fabrikarbeiter. Bümplizstrasse 85
+– Ernst, Fabrikarbeiter, Bümplizstrasse 85
 – Ernst, Hilfsarbeiter, Marzilistrasse 35
 – Ernst, Hilfsarbeiter, Kasthoferstrasse 10
 – Ernst (Danzer), pens. Kassier, Wittigkofenweg 19 [28.937]
@@ -19321,8 +19292,8 @@ Unfallversich.-Anstalt, Neufeldstrasse 131
 – E. TJ., Heizer S. B. B., Weissensteinstr. 88
 – Ferd., Former, Murtenstrasse 155y
 – Ferdinand, Lok.-Führer S. B. B., Wachtelweg 15
-– F. R., PoMzeiwacbtmeister. Liebeggweg 13
-– Franz, Pferdewärter. Schönburgstrasse 42
+– F. R., PoMzeiwacbtmeister, Liebeggweg 13
+– Franz, Pferdewärter, Schönburgstrasse 42
 – Fr., Goldschmied, Marktgasse 29 [22.457]
 – Fr., Goldschmied, Akt.-Gesellschaft, Marktgasse 29 [22.457]
 – Fr., pens. Tramführer, Parkstrasse 50
@@ -19332,7 +19303,7 @@ Unfallversich.-Anstalt, Neufeldstrasse 131
 – Frieda, Einlegerin, Gutenbergstrasse 9
 – Friedr., Bahnarbeiter, Amthausgasse 4
 – Friedr., Bürstenfabrikant, Postgasse 28
-– Friedr.. Chauffeur, Ghutzenstrasse 8
+– Friedr., Chauffeur, Ghutzenstrasse 8
 – Friedr., techn. Assistent E. W. B., Lorystrasse 12 [22.857]
 – Friedr, Elektrotechniker, Wabernstr. 18
 – Friedr., Feinmechaniker, Rodtmattstr. 63
@@ -19380,13 +19351,13 @@ Waffenfabrik, Stockerenweg 10
 – Hans, Pächter, Bümplizstrasse 78
 – Hans, Pächter, Bümplizstrasse 78 [46.049]
 – Hans (Amaeher), Bäckermeister und Spezierer, Muristrasse 4 [21.449]
-– Hans. Postangestellter. Quartiergasse 23
+– Hans. Postangestellter, Quartiergasse 23
 – Hans, Schuhmacher, Kehrg. 20, Bümpliz
 – Hans, städt. Beamter, Wattenwylweg 22
 – Hans Rud., Maschinenmeister, Brünnenstrasse 60. Bümpliz
 – Heinr. Otto, Bauführer, Hallerstrasse 36
-– Heinrich, Bauhilfsarbeiter. Fährweg 37a
-– Herm., Dr.. in Fa. Hofer & Cie.. Aarbergergasse 12
+– Heinrich, Bauhilfsarbeiter, Fährweg 37a
+– Herm., Dr., in Fa. Hofer & Cie., Aarbergergasse 12
 – Hermann W., Goldschmied, Kanalgasse 1
 – Hermann Paul, kaufm. Angest., Effingerstrasse 69
 – Hermann, Maler, Fährstrasse 32
@@ -19397,12 +19368,12 @@ Hofer, Ida, längere, Parkstrasse 50
 – J. Fr., Pörtner, Fabrikstrasse 6
 – Jean, Schlosser, Alleeweg 5
 – Joh., kaufm Angestellter, Tscharnerstr. 25
-– Joh. Friedr.. Spediteur, Brunngasse 4
+– Joh. Friedr., Spediteur, Brunngasse 4
 – Joh., Zugführer, Bundesbahnw.il [45.685]
 – Joh., Magaziner, Sonneggring 18
 – Joh., Milchhdlg., Schloßstr. 121 [21.071]
 – Joh., Elektromonteur, Sonneggring 14
-– Joh.. Wegaufseher. Breitfeldstrasse 33
+– Joh., Wegaufseher. Breitfeldstrasse 33
 – Joh. Rud., Hilfsarbeiter, Buchdruckerw. 10, Bümpliz
 – Johanna Lydia, Bureaulistin, Bundesbahnweg 11
 – Johanna Hedw., Ladentochter, Seidenw. 85
@@ -19438,7 +19409,7 @@ Hofer, Ida, längere, Parkstrasse 50
 – Oswald, eidg. Beamter, Neufeldstrasse 101 [26.066]
 – Otto, Bäckermeister, Monbijoustrasse 69 [33.356]
 – Otto, Bahnarbeiter, Weissensteinstr. 88
-– Otto Ti.. Beamter S B. B., Beaulieurain 12
+– Otto Ti., Beamter S B. B., Beaulieurain 12
 – Otto, Hilfsarbeiter, Jurastrasse 35
 – Otto W., Schreiner, Schauplatzgasse 11
 – Paul. Beamter des schweizer. Amtes fürgeist. Eigentum, Effingerstr. 69 [28.172]
@@ -19453,7 +19424,7 @@ Hofer, Paul Erwin, Beamter S. B. B., Beaulieurain 12 [33.957]
 – Paul Rud., Techniker, Schützenweg 15
 – Peter Paul, Hilfsarbeiter, Gesellschaftsstrasse 74
 – Remo Rob., Beaulieurain 12
-– Rob,, Wirt z. Helvetia, Zähringerstr. 16 [22.209]
+– Rob., Wirt z. Helvetia, Zähringerstr. 16 [22.209]
 – Rosa, Hilfsarbeiterin, Schulweg 15
 – Rosalie, Ladentochter, Schärerstrasse 1
 – Rosalie (Leber), Wwe., Neufeldstrasse 99
@@ -19462,7 +19433,7 @@ Hofer, Paul Erwin, Beamter S. B. B., Beaulieurain 12 [33.957]
 – Rud., Schmied. Kanalgasse 1
 – Rud., Bureaulist, Neufeldstrasse 25c
 – Rud., Elektriker, Wiesenstrasse 55
-– Rud.. Portier. Aegertenstrasse 79
+– Rud., Portier. Aegertenstrasse 79
 – Sophie (Beck), Bubenbergplatz 4
 – Theodor, kaufm Angest., Rodtmattstr. 97
 – Therese, Fabrikarbeiterin, Rodtmattstr. 91
@@ -19474,14 +19445,14 @@ Hofer, Paul Erwin, Beamter S. B. B., Beaulieurain 12 [33.957]
 – Walter, Adjunkt des Kantonsbuchhalters, Emanuel-Friedlistrasse 14
 – Walter, Metalldreher, Murifeldweg 19
 – Walter, Polizist. Brunnadernstrasse 104
-– Walter. Schlosser, Murtenstrasse 153b
+– Walter, Schlosser, Murtenstrasse 153b
 – Werner, Chemigraph, Länggassstrasse 75
 – Werner Alb., Glasschleifer, Breitfeldstr. 34
 – Werner (Weiss), Feinmechaniker, Weissensteinstrasse 80
 – Werner, Trambilletteur, Willadingweg 42
 – Werner Otto, Monbijoustrasse 120
 – Werner Rudolf, Bahnarbeiter, Breitfeldstrasse 23
-– Werner Gottl.. Kanzlist. Länggassstr. 30
+– Werner Gottl., Kanzlist. Länggassstr. 30
 – Werner. Schlosser, Aehrenweg 23, Bümpliz
 – Wilhelm, Zentralheizungen u. sanitäre Anlagen (ßremgarten), Breitfeldstrasse 48 [28.717]
 – Willi., Buchbinder, Hochfeldstrasse 57
@@ -19493,8 +19464,8 @@ Hofer, Paul Erwin, Beamter S. B. B., Beaulieurain 12 [33.957]
 Lehrwerkstätten, Stockerenweg 10
 – Willy, kaufm. Angestellter, Monbijoustr. 22
 – Willy Herm., kaufm. Angest., Breitenrainstrasse 73
-– Willy Ad.. Mechaniker, Dietlerstrasse 56
-– & Cie.. Molkerei Hofer, Aarbergergasse 12 [23.846], Spitalgasse 35 [24.665] und Marktgasse 5 [25.092]
+– Willy Ad., Mechaniker, Dietlerstrasse 56
+– & Cie., Molkerei Hofer, Aarbergergasse 12 [23.846], Spitalgasse 35 [24.665] und Marktgasse 5 [25.092]
 Hoff, Ida. Frl. Dr. med., Spezialarzt für innere Krankheiten, Hallwylstrasse 44 [29.467]
 Hoffet, Cecile Agnes, Sekretärin, Stauffacherstrasse 41 [21.672]
 # Date: 1935-12-15 Page: 26020513/208
@@ -19506,7 +19477,7 @@ Hoffmann, s. auch Hofmann
 – Elise, Massage, Fuss- u. Schönheitspflege, Effingerstrasse 4 [20.939]
 – Ernst (Roth), Pfarrer, Stadthachstr. 48 [29.380]
 – Ernst Osk., Händler, Schifflauhe 40
-– Ernst, Verwaltungsbeamter. Lentulusstr. 23
+– Ernst, Verwaltungsbeamter, Lentulusstr. 23
 – Friedr (Keller), Typograph, Lorystr. 16
 – Gertrud El., Buchhalterin, Bersetweg 2
 – Grete, Atelier für Damenmoden, Viktoriastrasse 39 [31.014]
@@ -19687,7 +19658,7 @@ Hofstetter, s. auch Hostettler
 – Marie (Bögli), Wwe., Kollerweg 11 [22.958]
 – Marianna (Jakob), Altenbergstrasse 6
 – Martha. Dr. med., Spezialärztin für Lungenkrankheiten u. innere Medizin, Optingenstrasse 10 [22.140]
-– Max Alfr.. Konfiseur. Konsumstrasse 14a
+– Max Alfr., Konfiseur. Konsumstrasse 14a
 – Otto, Fabrikarbeiter, Felsenaustrasse 72
 – Otto, Kaufmann. Weststrasse 19 [29.951]
 – Paul, kaufm Angestellter, Bümplizstr. 14
@@ -19695,7 +19666,7 @@ Hofstetter, s. auch Hostettler
 – Paul, Schreiner, Kostgeberei, Bümplizstrasse 14
 – Paul. Maschinensetzer. Effingerstrasse 4a [27.367]
 – Paul Walter, Kohlenhandlung. Altenbergstrasse 6 [22.215]
-– Peter, Dr. phil.. Beamter S. B. B., Haspelweg 34 [29.035]
+– Peter, Dr. phil., Beamter S. B. B., Haspelweg 34 [29.035]
 – Rosa Emma, Angestellte, Kalcheggweg 19
 – Rosa, Fabrikarbeiterin, Wyttenbachstr. 17
 – Rud., Gärtnermeister, Seftigenstrasse 17 [25.989]
@@ -19727,7 +19698,7 @@ Hohl, Friedr. Ernst, Former, Jurastrasse 37
 Hohlenweg, Anna Regina, Ladentochter, Ladenwandstrasse 94
 Hohler, Ch. Jean, Schriftsetzer, Muristr. 73
 Hohloch, W. J., Topograph, Jubiläumsstr. 17 [28.996]
-Höhn, Walter. Instruktionsoffizier, Papiermühlestrasse 15
+Höhn, Walter, Instruktionsoffizier, Papiermühlestrasse 15
 Höinghaus, Richard, Kanonenweg 18 [20.977]
 – Richard, Zahntechniker, Kanonenweg 18
 Holder, Adele (Aebi), Damenschneiderin, Blumenbergstrasse 53
@@ -19743,7 +19714,7 @@ Holenstein, Anna (Fedier), Wwe., Buchdrukkerei u. Verlag, Ferd.-Hodlerstrasse 18
 – Paul Arn., Coiffeur, Viktoriarain 14
 Holenweg, Anna (Mosimann), Wwe., Neubrückstrasse 49
 – Friedr. Bahnvorarbeiter, Ladenwandstr. 94
-– Hs. Walter. Adjunkt der eidg. Zentralbibliothek, Sulgenbachstrasse 12
+– Hs. Walter, Adjunkt der eidg. Zentralbibliothek, Sulgenbachstrasse 12
 – Julia Marie Bureauangestellte, Neubrückstrasse 49
 – William Gottfr., Bahnarbeiter, Neubrückstrasse 49
 Holiczer, Ludwig, Schauspieler, Kreuzgasse 3
@@ -19751,17 +19722,17 @@ Holländische Gesandtschaft, Sulgenbachstr. 5 [21 098]
 de Holle, Hugo Fr., Direktor d. Zentral-Handelskammer f. Lat. Amerika (Moserstr. 2), Marktgasse 37 [28.287]
 Hollederer, Flora Marg., Angestellte, Könizstrasse 18
 – Elsa Erna, Kopistin, Könizstrasse 18
-– Klara Anna, Ladentochter. Könizstr. 18
-– Hans, Maler, Könizstrasse 4-la
+– Klara Anna, Ladentochter, Könizstr. 18
+– Hans, Maler, Könizstrasse 4-1a
 – Werner Karl, Maler, Könizstrasse 18
 Holligen, Postbureau, Weyermannsstrasse 44 [35.173]
 Holliger; Adolf Hans, Bankangest., Sandrainstrasse 94 [26.182]
 – Dora Bertha, Jägerweg 3
 – Emil, Kaufmann, Steinerstrasse 31
 – G. Hans, Postbeamter, Brunnmattstr. 69
-– G.. A.-G., Teppiche. Vorhänge. Linol.. Bettwaren, Möbelstoffe, Schwaneng. 7 [21.661]
+– G., A.-G., Teppiche. Vorhänge. Linol., Bettwaren, Möbelstoffe, Schwaneng. 7 [21.661]
 – Hanna M., Bureaulistin, Museumstr. 12
-– Joh G.. Schriftsetzer. Allmendstrasse 40
+– Joh G., Schriftsetzer. Allmendstrasse 40
 – Marie El (Gfeller), Wwe., Schlösslistr. 49
 – Roh., Postbeamter, Hochfeldstrasse 95
 – Walter, Spengler, Wylerringstrasse 11
@@ -19774,24 +19745,24 @@ Holzer, Adolf, Ausläufer, Tiefenaustrasse 112
 Holzer, Alex. Louis, Hilfsarb., Jurastr. 69
 – Anna Lucie, Bureaulistin, Militärstr. 60
 – Anna, Falzerin, Brunnhof weg 39
-– Aug.. Beamter S B. B., Elisabethenstr. 34
+– Aug., Beamter S B. B., Elisabethenstr. 34
 – Bertha, Frau, Damenschneiderin, Randweg 11
 – Bertha (Stotzer), Wwe., Breitenrainstr. 71 [20.919]
 – Charles Ferd., Motorrad-Mechaniker, Wiesenstrasse 83
 – E. (Gugger), Wwe., Freiestrasse 54
-– E. E., Postangestellter. Beundenfeldstr. 50
+– E. E., Postangestellter, Beundenfeldstr. 50
 – Elisabeth (Gosteli), Wwe., Effingerstr. 41c
 – -Emil, Maler, Brückfeldstrasse 38
 – Emil, Maschinenmeister, Effingerstr. 41c
 – Emma. Frau, Mühlemattstrasse 16
 – Emma, Angestellte, Mühlemattstrasse 16
 – Emma Fanny, Stickerin, Elisabethenstr. 34
-– Emma (Finger), Wwe.. Elisabethenstr. 34
+– Emma (Finger), Wwe., Elisabethenstr. 34
 – Ernst (Wasem), Chauffeur, Gerechtigkeitsgasse 46
 – Ernst W., Landwirt, Riedbachstrasse 354, Riedbach
 – Ernst Willy, Buchbinder, Schläflistr. 10
 – Ernst. Pferdewärter d. C. R. D., Erikaw. 7
-– Ernst Friedr.. Lehrer. Elisabethenstr 39
+– Ernst Friedr., Lehrer. Elisabethenstr 39
 – Ernst Rud., Fürsprecher, Mittelstrasse 40
 – Ferd., städt. Bausekretär u. Kassier b. d.städt. Baudirektion I, Weihergasse 15 [35 506]
 – Franz Jos., Hilfsarbeiter, Landhausweg 8
@@ -19823,8 +19794,8 @@ Holzer, Alex. Louis, Hilfsarb., Jurastr. 69
 – Rosina, Privat., Riedbachstr 346. Riedbach
 – Rud., Angest. der Amtsschreiberei, Mittelstrasse 40
 Holzer, Rud., eidg. Beamter, Spitalackerstr. 7
-– Rud.. Securitaswächter. Cäcilienstrasse 9
-– Rud.. Tapezierer. Dalmaziweg 101
+– Rud., Securitaswächter, Cäcilienstrasse 9
+– Rud., Tapezierer. Dalmaziweg 101
 – Walter, Bahnarbeiter, Quartiergasse 13
 – Walter, Postangestellter, Seidenweg 36
 – Werner,. Mechaniker, Gerbergasse 42
@@ -19834,7 +19805,7 @@ Homann, Frieda Lse. (Tschan), Wiesenstr. 83
 Homberg, Elise (Schütz), Alter Aargauerstalden 9 [31.339]
 Hornberger, A., Prof. Dr., Fürspr. (Humboldtstrasse 35 [32.155]), Amthausgasse 14 [24.901]
 – Emma, Glätterin, Belpstrasse 16
-– Gottfr.. Backwerk, Basler Schenkeli, Agent, u. Vertr., Parkstrasse 13 [36.772]
+– Gottfr., Backwerk, Basler Schenkeli, Agent, u. Vertr., Parkstrasse 13 [36.772]
 – Otto, Monteur, Mittelstrasse 64
 Homere, Ls. E. (Departout), Buchh., Sulgenrain 6
 Hond uras, Generalkonsulat, Kasinoplatz 2
@@ -19861,11 +19832,11 @@ Honegger, A., Buchbinder, Hallerstrasse 12a
 – R. Alice. Neubrückstrasse 72
 – Willi., Chauffeur, Manuelstrasse 68
 Honer, Rud. Bernh., Bureaulist, Hallerstr. 54
-Honesta, Emanuel, Bankangestellter, Melchtalstrasse 7 .
+Honesta, Emanuel, Bankangestellter, Melchtalstrasse 7
 – Rosa (Mühlemann), Wwe., Melchtalstr. 7
 Höner, Alois J., Direktor, Kursaal Schänzli, Schänzlistrasse 75
 Hönger, Fritz, Sattlermeister (Wyttenbachstrasse 37), Schläflirain 11
-– Marie. Privatiere .läeerweg 12
+– Marie. Privatiere, läeerweg 12
 Honsberger, Friedrich Ferd., Fabrikarbeiter, Felsenaustrasse 24
 – J., Zugführer der S. B. B., Neufeldstr. 153
 Honseil, Otto Willy, Architekt, Manuelstr. 74
@@ -19891,12 +19862,12 @@ Horat, Emil, Buchdruckerei, Zähringerstr 9a [31.043]
 Horb, Joh. Alfr., Gärtner, Waldheimstr. ,10a
 Hörer, Heinr., Monteur, Landoltstrasse 67
 Horger, Emil, Automechan., Hopfenweg 32
-– Emil, Pastellist, Brunngasse 46 .
+– Emil, Pastellist, Brunngasse 46
 – Wilh., Wirt z. Zimmermannia, Brunng. 19 [21.542]
 Horisberger, s. auch Horrisberger
 – A. M (Bergmann), Wwe., Neubrückstrasse 55a
 – Alfred, Kaufmann, Elisabethenstrasse 40
-– Anna (Hertig), Wwe.. Elisabethenstr. 40
+– Anna (Hertig), Wwe., Elisabethenstr. 40
 – Anna El. (Danzer), Wwe., Helvetiastr. 33
 – Dora, Bureaulistin, Spitalgasse 35
 – Friedr. E., Zollbeamter, Kalcheggweg 19
@@ -19915,7 +19886,7 @@ Horlacher, Alb., Kaufm., Südbahnhofstr. 15
 – Joh. (Fivian), Schreiner. Konsumstr.il
 – Karl (Baur), Prokurist d. Spar- & Leihkasse, Wyttenbacbstrasse 6 [27.385]
 – Karl Ed., Architekt, Wyttenbachstrasse 6
-– Lilly Bertha. Fabrikarbeiterin. Erlachstr. 5
+– Lilly Bertha, Fabrikarbeiterin, Erlachstr. 5
 – Werner, Zeichner, Terrassenweg 14
 Hörler, Joh., Mechaniker, Gutenbergstr. 11
 Horn, Helene, Bureauangest., Hallerstr. 31
@@ -19966,7 +19937,7 @@ Hosner, Joh., Packer, Friedbühlstrasse 36
 – Paul Emil, Schriftenmaler, Friedbühlstr. 36
 – Walter Ernst, Serumangesteüter, Friedbühlstrasse 36
 Hospiz z. Heimat, alkoholfr. Gasthaus, Gerechtigkeitsgasse 52 [24.135]
-Höss, Marie (Sigrist), Wwe., .Gerechtigkeitsgasse 38
+Höss, Marie (Sigrist), Wwe., Gerechtigkeitsgasse 38
 – Niklaus, Metzger, Bernstrasse 103, Bümpliz
 – O. A. N., Coiffeur und Bazar, Bernstr. 102, Bümpliz
 # Date: 1935-12-15 Page: 26020518/213
@@ -20000,7 +19971,7 @@ Hostettler, s. auch Hofstetter
 – Alfr., Kondukteur S. S. B., Sonneggring 10
 – Alfr., Sek.-Lehrer, Hubelmattstrasse 33 [28.054]
 – Alice Gertr., Bureaulistin, Herzogstr. 25
-– Anna (Käser), Wwe.. Finkenhubelweg 30 [36.160]
+– Anna (Käser), Wwe., Finkenhubelweg 30 [36.160]
 – Anna (Messer), Frau, Blumenbergstr. 5
 – Armin. Tiefdrucker. Seftigenstrasse 30
 – Arm, Einzüger b. Gaswerk, Herzogstr. 25
@@ -20009,7 +19980,7 @@ Hostettler, s. auch Hofstetter
 – Aug., Hilfsarbeiter, Bernstr. 21, Bümpliz
 – Bertha Frieda, Ladentochter, Lorystr. 14
 – Bertha, Zigarrengeschäft (Gotthelfstr. 18), Schauplatzgasse 4 [33.595]
-– Christ.. Diätbäckerei, Helvetiastrasse 27 [36.082]
+– Christ., Diätbäckerei, Helvetiastrasse 27 [36.082]
 – Christ., Handlanger, Gerbergasse 15b
 – Christ. Gottfr., Kaufmann, Effingerstr. 41c [28.475]
 – Christ., Mech.-Vorarbeiter, Rodtmattstr. 56
@@ -20050,14 +20021,14 @@ Hostettler. s. auch Hofstetter
 – Hans Christ. Emil, Fabrikarbeiter, Gesellschaftsstrasse 24
 – Hans W., Kaufmann, in Fa. Hans Hostettler Sohn & Cie., Kapellenstrasse 22 [21.543]
 – Hans (Stucki), Maurer, Fährstrasse 34
-– Hans Rud.. kaufm. Angest., Güterstr. 32
+– Hans Rud., kaufm. Angest., Güterstr. 32
 – Hans Walter, Schlosser, Zielweg 15
 – Hans Friedr., Blumenbergstrasse 5
 – Herm. Gust., Dr. phil. ehern., Simplonw. 15
 – Herm. Ad., Maler, Breitfeldstrasse 38
 – Hilda Elise. Ladentochter, Mattenhofstr. 32
 – Joh., Chauffeur, Karl-Hiltystrasse 30
-– Joh. Friedr., pens. Arbeiter. Mezenerweg 12
+– Joh. Friedr., pens. Arbeiter, Mezenerweg 12
 – Joh., Briefträg., Freiburgstr. 488,. Bümpliz
 – Joh., Dachdecker, Bremgartenstrasse 41
 – Joh., Hilfsarbeiter, Nydeckhof 29
@@ -20069,13 +20040,10 @@ Hostettler. s. auch Hofstetter
 – Klara M., Bankbeamtin, Mattenhofstr. 32
 – Klara Fanny (Benteli), Bureauangestellte, Bümplizstrasse 36
 – L. A. (Bonjour), Wwe., Stauffacherstr. 31
-Fachmännische Beratungin allen vorkommenden Fragen der Branchedurchstetthacher
-Gerechtigkeitsg.59 Telephon 21.040
 # Date: 1935-12-15 Page: 26020519/214
 Hostettler. s. auch llofstetter
 – Lily Hedw., Damenschneiderin, Tiefmattstrasse 6
-– Lina (Müller), Wwe., in Fa. Hans Hostettler Sohn & Co., Brunnadernstrasse 10
-123 9131
+– Lina (Müller), Wwe., in Fa. Hans Hostettler Sohn & Co., Brunnadernstrasse 10 [23.913]
 – Lina (Wirz), Wwe., Balmweg 18 [31.084]
 – Louis, Beamter, Stauffacherstrasse 31
 – Luise (Binggeli), Vertr. für Musikinstrumente u. ehern.-techn. Neuheiten, Neuengasse 39
@@ -20086,7 +20054,7 @@ Hostettler. s. auch llofstetter
 – Maria. Hilfsarbeiterin. Muesmattstrasse 45
 – Martha, Beamtin, Brückfeldstrasse 42
 – Otto, Chauffeur, Quartiergasse 3
-– Otto Rud., Fabrikarbeiter. Wiesenstr. 60
+– Otto Rud., Fabrikarbeiter, Wiesenstr. 60
 – Otto Wilh., Handlanger. Lorrainestr. 43
 – Paul Ami. Schriftsetzer, Stauffacherstr. 31
 – Pauline, Tapeziererin, Münzrain 4
@@ -20101,13 +20069,13 @@ Hostettler. s. auch llofstetter
 – Walter (Leuenberger), Simonstrasse 3
 – Werner (Weber), Weissenbühlweg 29b [34 431]
 – Werner, Maschinenzeichner, Wylerstr. 49
-– & Co.. Brennerei und Fruchtzuckerfabr., Weinhdlg,. Lorrainestrasse 52 [24.162]
+– & Co., Brennerei und Fruchtzuckerfabr., Weinhdlg,. Lorrainestrasse 52 [24.162]
 – & Co., G., Bau- und Brennmaterialienhandlung, Güterstrasse 32 [27.021]
 – & Sollberger. Gipser- und Malergeschäft, Muristrasse 65 [32 600]
 – Sohn & Co., Hans, Wein- u. Spirituosenhandlung. Aarbereergasse 10 [22.812]
 Hotel Giessbach A.-G., Amthausgasse 14
 « Hotel-Plan », Genossenschaft, Weyermannsstrasse 34-d [32.901]
-Hotta, Nasa-aki, japanischer Gesandter. Kirchenfeldstrasse 56 [22.389]
+Hotta, Nasa-aki, japanischer Gesandter, Kirchenfeldstrasse 56 [22.389]
 Hottenberg, Hans, Ing., Weissenbühlweg 12 [35 259]
 – Kurt, Bankangestellter, Weissenbühlweg 12
 Hottinger, Ernst, Mechaniker, Wylerstr. 95
@@ -20118,16 +20086,16 @@ Hottinger, Ernst, Mechaniker, Wylerstr. 95
 – Werner, Sattler u. Tapezierer, Kasernenstrasse 11a
 Hotz. Alfred, Handlanger, Wylerstrasse 79
 – A., Postangestellter, Karl-Staufferstr. 21
-– Aug.. Werkmeister. Felsenaustrasse 22
+– Aug., Werkmeister, Felsenaustrasse 22
 – Emil, in Fa Gebr Kuli & Hotz. Elisabethenstrasse 47 [24.311]
-– Emil Jak.. Elektriker, Elisabethenstr. 42
+– Emil Jak., Elektriker, Elisabethenstr. 42
 Hotz, E. (Schönenberger), Wwe., Sonneggring 16
 – Ernst, Elektromechan. Werkstätte (Militärstrasse 12 [34.643]), Breitfeldstrasse 48 [27.789]
 – Ernst, Stricker, Rodtmattstrasse 107
 – Ernst. Zeichner. Schillingstrasse 30
 – Franz, Photograph, Brunngasäe 50
 – Frieda M. (Harter), Belpstrasse 24
-– Friedr. W.. Hilfsarbeiter, Freiburgstr. 147
+– Friedr. W., Hilfsarbeiter, Freiburgstr. 147
 – Hans, Reklamemalerei, Talweg 3
 – Heinrich, Kaufmann. Wyttenbachstr. 29
 – Jean (Imbach), Dr., Direktor d. eidg. Handelsabteilung, Alpcnstrasse 5 [34.484]
@@ -20139,14 +20107,16 @@ Houlmann, Charles Ulysse, Kondukteur der S. B. B., Breitenrainstrasse 79
 Hourlet, Ed. (Locher), Ensingerstrasse 21 [23.347]
 – Pascale Emil, Bankangest., Seidenweg 12
 – Paul. Kaufmann, Ensingerstrasse 21
-– Pauline (Deuber). Breitenrainstrasse 27van den Hove, Catli., Privat., Länggassstr. 38v. Hoven. Ad. G.. Sattler. Kramgasse 45
-– Karl, Sattlermeister. Kramg. 45 [24.151]
-– Luise Anna. Ladentochter. Kramgasse 45
+– Pauline (Deuber). Breitenrainstrasse 27
+van den Hove, Catli., Privat., Länggassstr. 38
+v. Hoven. Ad. G., Sattler. Kramgasse 45
+– Karl, Sattlermeister, Kramg. 45 [24.151]
+– Luise Anna. Ladentochter, Kramgasse 45
 Howald, A. Marg. (Dardel), Wwe., Berchtoldstrasse 50
 – Alice Marg., Frau, städt. Angest., Berchtoldstrasse 50
 – Cecile Anna (Hunziker), Wwe. d. Professors. Sulgenauweg 10 [32.213]
 – Ernst. Ausläufer. Aarbergergasse 27
-– Ernst Jak., Bereiter. Stockerenweg 15
+– Ernst Jak., Bereiter, Stockerenweg 15
 – Ernst M., Billetteur d. S. S. B., Predigergasse 2
 – Ferd., pens. Lehrer, Kirchbühlweg 46
 – Flora Erika, Bureaulistin, Schwarztorstrasse 18 [20.258]
@@ -20159,12 +20129,12 @@ Howald, A. Marg. (Dardel), Wwe., Berchtoldstrasse 50
 – J. Cäsar, pens. Mech., Junkerngasse 53
 – J. (Sommer), Seminarlehrer, Muristr 8d [28 124]
 – Joh., Bäckermeister, Beundenfeldstr 7 [22.596]
-– Joh.. Reisender. Holligenstrasse 45
+– Joh., Reisender. Holligenstrasse 45
 – Jul. H., Kunstmaler, Belpstrasse 14
 – K. G-, Mechaniker, Krippenstrasse 22
 – L. (Ziegler), Wwe. des Amtsnotars. Bundesgasse 16 [34 627]
 – Margrit, Bureaulistin, Schwarztorstr. 18 [20.258]
-– Margr.. Kindergärtnerin. Muristrasse 8d
+– Margr., Kindergärtnerin. Muristrasse 8d
 – Max, Beamter, Schwarztorstr. 18 [20.258]
 – Max, Gold- u. Silborwarengeschäft, Naclif.von E. Schelhaas (Jubiläumsstr. 97), Spitalgasse 36 [31.410]
 # Date: 1935-12-15 Page: 26020520/215
@@ -20188,7 +20158,7 @@ Hubacher. Ad., Bauamtarbeiter, Ahornweg 5
 – Alfr., Karrer. Sägehofweg 7, Bümpliz
 – Anna G., Damenschneiderin, Wylerfeldstrasse 40
 – Elise (Fasnacht). Wwe., Tscharnerstr. 46
-– Emma (Biirki), Wwe.. Schönburgstrasse 42
+– Emma (Biirki), Wwe., Schönburgstrasse 42
 – Ernst, Gipser, Kasthoferstrasse 10
 – Ernst. Pfarrer an der Friedenskirche, Mattenhofstrasse 41 [23.808]
 – Ernst Friedr Polizist. Holligenstrasse 41
@@ -20200,8 +20170,8 @@ Hubacher. Ad., Bauamtarbeiter, Ahornweg 5
 – Fritz, pens. Tel.-Arbeiter, Kirchackorw. 3, Bümpliz
 – Fritz, Maurer, Muristrasso 55
 – Fritz. Melker. Weiermattweg 62, Bümpliz
-– Fritz, eidg. Beamter. Lorystrasse 10
-– Gottfr.. Bankangestellter. Waldheimstr. 49
+– Fritz, eidg. Beamter, Lorystrasse 10
+– Gottfr., Bankangestellter, Waldheimstr. 49
 – Gottfr., Fabrikarbeiter, Thunstrasse 113
 – Gottl., pens. eidg. Angest., Laupenstr. 5
 – Gottl., Schlosser. Mattenenge 5
@@ -20234,7 +20204,7 @@ Huber, Adele, Wwe., Damenschneiderin, Frohberweg 8
 – Albert, Fabrikarbeiter, Lentulusstrasse 49
 – Albertine, Privatlehrerin, Klösterlistutz 2 [35.220]
 – Alexander Arth., Kaufmann, Bantigerstr.14
-– Alfr., Bankangestellter. Tillierstrasse 15
+– Alfr., Bankangestellter, Tillierstrasse 15
 – Alfr., Bankangestellter, Kirchenfeldstr. 10 [35.283]
 – Alfr. (Borer), Dr. jur., Fürsprecher, Advokaturbureau (Werdtweg 7a [28.635]), Hirschengraben 5 [20.321]
 – Anna, Ladentochter, Gerechtigkeitsgasse 19
@@ -20333,7 +20303,7 @@ Huber, Karl, Kommis, Kramgasse 17
 – O. (Lang), eidg. Beamter, Friedeckweg 28
 – Ottilie, Apothekerin, Friedeckweg 28
 – Paul, Bahnbeamter, Hallerstrasse 52
-– Paul E., Fabrikarbeiter. Felsenaustr. 83
+– Paul E., Fabrikarbeiter, Felsenaustr. 83
 – Paul Max. Milchträger, Niederbottigenweg 101, Bümpliz
 – Paul, Schlosser, Wiesenstrasse 55
 – Pauline, Fabrikarbeiterin, Fährstrasse 33
@@ -20366,7 +20336,7 @@ Hubert, Margr. Adelaide, Bureaulistin, Lorrainestrasse 23
 – Max, Masch.-Schlosser, Lorrainestrasse 43
 – Otto Eugen., Elektromechan., Brunnhofw.27
 – Rud., Handlanger, Waffenweg 24
-– Sam., Walzengiess-Anstalt, Lorrainestr. 23a [22.6361
+– Sam., Walzengiess-Anstalt, Lorrainestr. 23a [22.636]
 – Vreny, Bureaul., Lorrainestr. 23 [22.636]
 Hübler, Anna, Postgehilfin, Gryphenhübeliweg 31
 – Elsa, Bureaulistin, Weissenbühlweg 29a
@@ -20387,7 +20357,7 @@ Hubmann, Ernst, Metzger, Altenbergstr. 14
 Hübner, Armin W., kauf. Angest., Ensingerstrasse 9
 – Fritz, Ingenieur, Ensingerstrasse 9
 Hübscher, Arthur Robert, Ausläufer, Gerbergasse 34
-– Emil Alb.. Maschinenmeister, Gerberg. 7a
+– Emil Alb., Maschinenmeister, Gerberg. 7a
 – Ernst, Mar.morist, Fröschmattweg 12b, Bümpliz
 – Ernst. Portier, Birkenweg 42
 – Gottfried, Spediteur, Jurastrasse 99
@@ -20411,8 +20381,8 @@ Hudec, Franz, Schneider, Sonneggring 9
 Huetiger, Bertha (Weibel), Alkoholfreies Restaurant (Monbijoustrasse 26), Lorrainestrasse 6a [31.641]
 Hufschmid, Alma, Coiffeuse, Studerstr. 60
 – D., Beamter S. B. B., Studerstrasse 60
-– Erna Bertha., Bureaulist., Länggassstr. 26
-– Flora Gertr.. Bureaulistin, Länggassstr. 26
+– Erna Bertha, Bureaulist., Länggassstr. 26
+– Flora Gertr., Bureaulistin, Länggassstr. 26
 – Fritz, Metzgermeister, Schläflirain 11
 – Fritz Ernst, Reisender. Schläflirain 11
 – Joh. Georg, gew. Maschinenführer S. B. B., Meisenweg 21 [28.763]
@@ -20422,8 +20392,7 @@ Hufschmid, Alma, Coiffeuse, Studerstr. 60
 – Rosina Karoline (Roth), Wwe., Breitfeldstrasse 1
 Hug, s. auch Haug
 – Adele, pens. Telegraphistin, Gesellschaftsstrasse 17
-– Alfr., adm. Adjunkt d. Direktors d. eidg.
-Alkoholverwaltung, Länggassstrasse 35
+– Alfr., adm. Adjunkt d. Direktors d. eidg. Alkoholverwaltung, Länggassstrasse 35
 – Alfr., Fürspr., im Advokaturbüro Dr. B.
 Lifschitz (Schwarztorstrasse 23b [25.327]), Schauplatzgasse 11 [28.455]
 – Anna Marie, Bubenbergplatz 4
@@ -20443,10 +20412,10 @@ Lifschitz (Schwarztorstrasse 23b [25.327]), Schauplatzgasse 11 [28.455]
 – Friedr., Ausläufer, Th.-Kochergasse 9
 – Friedr., Lehrer, Wattenwylweg 21 [27.503]
 – Fritz, kaufm. Angest., Seftigenstrasse 19
-– Hans, Eilgutarbeiter. Felshaldenweg 14
+– Hans, Eilgutarbeiter, Felshaldenweg 14
 – Hans, Postbeamter, Siedlungsweg 11
 – Herm. Gottfr., Schriftsetzer, Stöckackerstrasse 99a, Bümpliz
-– Herrn Reinh.. Stationsbeamter d. S. B. B., Lorystrasse 14
+– Herrn Reinh., Stationsbeamter d. S. B. B., Lorystrasse 14
 – Hilda, Verkäuferin, Gesellschaftsstr. 52
 – Jakob W., Adjunkt am städt. Amt für Berufsberatung, Effingerstrasse 95 [25.386]
 – Josefa Agnes, Fabrikarb., Grüner Weg 9
@@ -20465,14 +20434,14 @@ Hua, s. auch Hang
 Hügel, Meinrado, Beamter d. S. B. B., Gesellschaftsstrasse 84
 Hugener, Otto. Direktor der Carnis A-G., Schauplatzgasse 9 [23.893]
 Hugentobler, Anny, Neufeldstrasse 27
-– Arthur, Schriftsetzer, Weissensteinstr. la
+– Arthur, Schriftsetzer, Weissensteinstr. 1a
 – Dora Amanda, Ladentochter, Holzikofenweg 20
 – Emil (Hillam), Bureauchef u. kaufm. Adjunkt-Stellvertreter d. E.-W., Brunnadernstrasse 12
 – Gottl., Chauffeur, Martiweg 17
 – Jakob, Dr. phil., Inspektor P. T. T., Sulgeneckstrasse 36 [27.371]
 – Marg. Elis., Damenschneiderin. Neufeldstrasse 27
 – Otto (Weyer), Corsetspezialgeschäft (Steinerstrasse 31 [33.847]), Gurteng. 6 [31.929]
-– Paul A.. Klaviermacher. Neufeldstrasse 27
+– Paul A., Klaviermacher. Neufeldstrasse 27
 – Hob. Werner, Uhrmacher (Beundenfeldstrasse 7), Kramgasse 49 [34.684]
 – Robert (Boiler), Klavier-Reparaturwerkstätte, Stimmungen. Neufeldstrasse 27
 – Walter, Postangestellter, Brückenstr. 8
@@ -20490,12 +20459,12 @@ Huggler, Adolf, Krippenstrasse 24
 – Christ., Kond. B L S., Maulbeerstr. 17
 – E., Wwe., Rabbentalstrasse 73
 – Friedr., Arbeitersekretär, Muristrasse 71
-– Friedr.. Elektrotechniker, Wylerstrasse 59
+– Friedr., Elektrotechniker, Wylerstrasse 59
 – Friedr. Joh., Postbeamter, Wylerstr. 59
 – Fritz (Blaser), Kaminfeger, Rodtmattstr.106
 – Heinrich, Magaziner, Falkenweg 5
 – Josef Vikt., Zeitungsverkäufer. Bollwerk 17
-– Luise, Ladentochter. Bollwerk 17
+– Luise, Ladentochter, Bollwerk 17
 – Margaritha. Bureaulistin, Falkenweg 9
 – Max Melch., Dr. phil., Sekretär d. Kunsthalle, Privatdozent, Rabbentalstrasse 73 [33.572]
 – Peter Polizist, Eggimannstrasse 17
@@ -20544,7 +20513,7 @@ Hügi, A., Ausläufer, Ahornweg 5
 – Ida (Kurz), Wwe., Rohrweg 10
 – J. R., Vertreter, Länggassstrasse 61
 – Lina (Hostettler), Wwe., Fischerweg 8 [20.036]
-– M. Louise (Briand), Wwe.. Blumensteinstrasse 18
+– M. Louise (Briand), Wwe., Blumensteinstrasse 18
 – Martha Clara, Bureaulistin, Brückfeldstrasse 43
 – Olga, Bureaulistin, Brückfeldstrasse 43
 – Otto Fr., pens. Lok.-Führer S. B. B., Amselweg 5 [32.795]
@@ -20565,13 +20534,13 @@ Hügli, Alex., Pferdewärter, Rodtmattstr. 109
 – Anna (Walther). Wwe., Altenbergstr. 34
 – Anna M. (Hänni), Wwe., Schwarztorstr. 51
 – Bend., Hilfsarbeiter, Neubrückstrasse 171
-– Christ.. Hilfsarbeiter. Statthalterstr. 21, Bümpliz
+– Christ., Hilfsarbeiter, Statthalterstr. 21, Bümpliz
 – Christ., Packer, Gesellschaftsstrasse 38
 – Christ. Eug., Tapezierer. Altenbergstr. 34
 – Ed. Moritz, eidg. Beamter, Tiefmattstr. 9
 – Ed., Kanzlist, Wylerstrasse 6ö
 – Elisabeth. Bureaulistin, Zaunweg 16
-– Emil, Buchhalter. Wattenwylweg 22 [34.056]
+– Emil, Buchhalter, Wattenwylweg 22 [34.056]
 – Emil, Chauffeur, Effingerstrasse 41 d
 – Emma (Häusler). Beaumontweg 38
 – Emma Rosa. Modistin. Beaumontweg 38
@@ -20580,7 +20549,7 @@ Hügli, Alex., Pferdewärter, Rodtmattstr. 109
 – Ernst (Rindlisbacher), Gipser, Schwalbenweg 30
 – Ernst, Kaufmann, Morillonstrasse 2
 – Ernst, Monteur, Konsumstrasse 11
-– Frieda. Ladentochter. Beaumontweg 38
+– Frieda. Ladentochter, Beaumontweg 38
 – Fr., gew. Materialverwalter des Stadtwerkhofes, Mattenhofstrasse 9
 – Fr. E., Lok.-Führer der S. B. B., Fischermätteliweg 24
 – Friedr., Bankprokurist, Wattenwylweg 30 [28.654]
@@ -20835,7 +20804,7 @@ Huss, Alb. Eug., Angestellter, Thunstrasse 2
 – Eug., Pianist, Blumensteinstr. 7 [23.291]
 – Margarethe, Schneiderin, Muristrasse 79
 – Wilhelm, Schreinermeister, Muristr. 79
-Hüsser, Alb. Joh., Coiffeur, . Attinghausenstrasse 23
+Hüsser, Alb. Joh., Coiffeur, Attinghausenstrasse 23
 – E. R., Frl., pens. Telephonistin, Bühlstr. 41
 – Josef Franz E., Chauffeur, Junkemg. 57
 – Jos. Martin, Revisor S. B. B., Gesellschaftsstrasse 33
@@ -20844,7 +20813,7 @@ Hüssler, Joseph, Zuschneider, Schwarztorstrasse 23b
 Hutmacher, Anna Maria (Minder), Wwe., Holligenstrasse 72
 – Ernst Jak., Kramgasse 65
 – Hans (Buri), Kaufmann, Viktoriarain 3
-– Hans Herm., Techniker S. B. B.. Rossfeldstrasse 7 [29.318]
+– Hans Herm., Techniker S. B. B., Rossfeldstrasse 7 [29.318]
 – Klara Elisabeth, Bureaulistin. Randweg 8
 – Lina (Iseli), Wwe., Falkenhöheweg 15a [29.495]
 – Lina Rosa, Telegraphistin, Holligenstr. 72
@@ -20862,7 +20831,7 @@ Hutterli, Frieda Magdalena, Fabrikarbeiterin, Kasernenstrasse 34
 Huttinger, Klara (Burkhard), Wwe., Schanzenstrasse 6
 Hutzli, Alwin, Bundesbeamter, Hubelmattstrasse 58
 – Arthur, Notariatsbureau (Sulgenrain 8 [35.167]), Christoffelgasse 2 [26.099]
-– Ernst, Bahnarbeiter. Stöckackerstrasse 67, Bümpliz
+– Ernst, Bahnarbeiter, Stöckackerstrasse 67, Bümpliz
 – Frieda, Damenschneiderin, Freiburgstr. 119
 – Friedr., pens. Bahnarbeiter, Vereinsweg 6
 – Fritz, Mechaniker, Vereinsweg 6
@@ -20903,7 +20872,7 @@ Iff, Arthur, Koch, Bundesrain 8
 – Marie (Kramer), Wäscherei u. Glätterei (Metzgergasse 5), Rodtmattstrasse 91
 – Paul E., Chauffeur, Metzgergasse 5
 – Rosa, Wäscherei u. Glätterei, Belpstr. 42
-– Walter. Elektrotechniker. Brückfeldstr. 8a
+– Walter, Elektrotechniker. Brückfeldstr. 8a
 – Walter, Hilfsarbeiter, Läuferplatz 1
 – Werner, Koch, Theodor Kochergasse 5
 – Willi, Prokurist d Fa. A Weber & Co., A.-G., Bijouteriefabrik, Kalcheggweg 21 [22.996]
@@ -20997,7 +20966,7 @@ Imhof und Imhoof
 – Karl Werner. Chauffeur S. O. B., Wylerstrasse 57
 – Lina Th., Bureaulistin, Junkerngasse 20
 – Maria (Wiedemann). Wwe., Hochfeldstr. 20
-– Martha Th.. Ladentochter, Brunnhofweg 7
+– Martha Th., Ladentochter, Brunnhofweg 7
 – Max, Holz- u. Kohlenhandlung, Hopfenweg 46 [35.287]
 – Max (Rosenmund), Präsident des Verwaltungsrates der Strickerei Fischer & Co., A.-G., Elfenstrasse 17 [34.387]
 – O., Dr. med., Spezialarzt für Tropenkrankheiten u. Urologie, Luisenstr. 42 [22.531]
@@ -21023,9 +20992,9 @@ Imhoff, Ed., Sattler K. K. K., Wylerstr. 67
 – Maurice, Coiffeur, Spitalackerstrasse 69
 # Date: 1935-12-15 Page: 26020529/224
 Imhoff, Paul, Adjunkt des kant. Lehrlingsamtes, Spitalackerstrasse 69 [20.742]
-Imholz, Eug., Beamter S. B. B.. Thunstr. 23 [24.813]
+Imholz, Eug., Beamter S. B. B., Thunstr. 23 [24.813]
 – Julius Otto, Reisender, Seidenweg 24
-Immenhauser, Gottfr., Oberst, gew. Sektions- .chef der GeneralstaJbsabtlg. des Militärdep., Marienstrasse 27 [33.855]
+Immenhauser, Gottfr., Oberst, gew. Sektionschef der GeneralstaJbsabtlg. des Militärdep., Marienstrasse 27 [33.855]
 — Kurt, Dr. med. dent., Zahnarzt (Muristrasse 66 [36.671]), Zeitglockenhof, Zeitglockenlaube 6 [36.085]
 Immer, s. auch Imer
 – Arthur M. X., Kollerweg 30 [35.885]
@@ -21082,7 +21051,7 @@ Imobersteg, A. Lydia (Dummermuth), Wwe., Spezereihandlung, Mercerie u. Bonneteri
 – Jakob, Metzger, Muristrasse 91
 – Joh. Herm., pens. Postbeamter, Schanzen- jeckstrasse 25
 – Martha, Bureaulistin, Oberweg 2
-– Otto Edg.. Kommis, Muldenstrasse 11
+– Otto Edg., Kommis, Muldenstrasse 11
 – Theodor, Postbeamter, Viktoriarain 17
 Im Obersteg & Co., Hans, Reisebureau Basel, Vertreter: Karl Rotach. Theaterplatz 2
 Imperatori, Frederico, Geometer, Waisenhausplatz 27
@@ -21109,9 +21078,9 @@ Inderbitzin, Friedr. Jos., Bureauchef, Viktoriastrasse 49
 – M., Schuhmacher, Berchtoldstrasse 42
 – Rob., Versieh.-Inspektor, Stauffacherstr. 39
 Indermühle, Adelheid, Frau, Pianistin, Altenbergstrasse 120 [27.944]
-– Christ., Milch-, Butter- u. Käsehandlung, Brunnadernstrasse 71 [24.???]
-– E., Telegr.-Beamter. Weissenbühlweg 29 [31.651]
-– Ernst, Architekt (Kirchackerstr. 9, Bümpliz [46.601], Spitalgasse 34 [26.055]
+– Christ., Milch-, Butter- u. Käsehandlung, Brunnadernstrasse 71 [24.120]
+– E., Telegr.-Beamter, Weissenbühlweg 29 [31.651]
+– Ernst, Architekt (Kirchackerstr. 9, Bümpliz [46.601]), Spitalgasse 34 [26.055]
 – Ernst, Polizist, Keltenstrasse 106, Bümpliz
 – Fritz, Pianist, Altenbergstrasse 120 [27.944]
 – Henri Jules, Zollbeamter, Effingerstr. 43
@@ -21121,7 +21090,7 @@ Indermühle, Adelheid, Frau, Pianistin, Altenbergstrasse 120 [27.944]
 – R. (Barthlome), Wwe. des Architekten, Peterweg 3, Bümpliz [46.051]
 – Susanna Katharina, Lehrerin, Peterweg 3, Bümpliz
 Indinger, Fritz Werner, Hauswart, Muldenstrasse 6
-– Paul, Buchbindermeister. Gerechtigkeitsgasse 58 [35.739]
+– Paul, Buchbindermeister, Gerechtigkeitsgasse 58 [35.739]
 « Indufo », Bilder- u. Pressedienst, Genferg. 3 [23.468]
 Industrie-Abteilung des schweizer. Volkswirtschaftsdepart., Bundesgasse 8 [61]
 Industrie-Holding Co., A.-G., Glarus, Sulgeneckstrasse 37
@@ -21136,7 +21105,7 @@ Informationsdienst A.-G., Marktgasse 51 [26.091]
 Ingber, Edith B., Schneiderin. Seidenweg 3
 Inglin, Anna H., Angest., Elisabethenstr. 46
 – Dominik, Büchsenmach., Elisabethenstr. 46
-Inglin, Luise Margr,, Weissnäherin, Elisabethenstrasse 46
+Inglin, Luise Margr., Weissnäherin, Elisabethenstrasse 46
 – Maria Jos., Modistin, Elisabethenstr. 46
 Ingold, Ad., Handlanger, Lorrainestrasse 72
 – Ad., gew. Bäckermeister, Beundenfeldstr. 35 [31.148]
@@ -21158,7 +21127,7 @@ Ingold, Ad., Handlanger, Lorrainestrasse 72
 – Ida M., Damenschneiderin, Aegertenstr. 65
 – Ida Rosa (Ingold), Wwe., Gerechtigkeitsgasse 33
 – Jakob, Hilfsarbeiter, Sulgenbachstrasse 36
-– Joh., pens. Bauamtarbeiter. Kramgasse 32
+– Joh., pens. Bauamtarbeiter, Kramgasse 32
 – Joh. Jakob, Hilfsarbeiter, Kirchbergerstr.77
 – Jules Th., Wagenmaler, Weidmattweg 7, Bümpliz
 – Klara, Bureaulistin, Muristrasse 11
@@ -21168,7 +21137,7 @@ Ingold, Ad., Handlanger, Lorrainestrasse 72
 – Marianna, Bümplizstrasse 102
 – Marie (Gerber), Beundenfeldstrasse 57
 – O. E., Architekt (Monbijoustr. 12 [24.225]), Gutenbergstrasse 6 [23.643]
-– Paul, Bankbeamter. Chutzenstrasse 29
+– Paul, Bankbeamter, Chutzenstrasse 29
 – Rosalie, Schanzeneckstrasse 7
 – Rosina O., Frau, Effingerstr. 51 [31.580]
 – Sophie, Verkäuferin, Lorrainestrasse 27
@@ -21180,7 +21149,7 @@ Ingold, Ad., Handlanger, Lorrainestrasse 72
 Innere Enge. Wirtsch. (Clavadetscher, Joh.), Engestrasse [21.442]
 Innern, eidg. Dep. des, Bundeshaus Westbau [61]
 – kant. Direktion des, Münsterpl. 3 [27.211]
-Inniger, Adolf, Schuhmachermeister. Sulgeneckstrasse 4a
+Inniger, Adolf, Schuhmachermeister, Sulgeneckstrasse 4a
 – Bertha, Bureaulistin, Sulgeneckstrasse 4a
 – Christ., Architekt, Ob. Aareggweg 12 [24.599]
 # Date: 1935-12-15 Page: 26020531/226
@@ -21228,7 +21197,7 @@ Irrenanstalt Waldau, Bolligenstrasse 117 [41.161]
 Isch, Ernst Herm., gew. Beamter, Kirchenfeldstrasse 40
 – Ella (Bolliger), Wwe., Polygonweg 25
 – L. (Zbinden), Wwe. des Arztes, Kirchenfeldstrasse 40 [31.803]
-Ischer, Alfred, Kuttlermeister. Elisabethenstrasse 33
+Ischer, Alfred, Kuttlermeister, Elisabethenstrasse 33
 – Anna, Dr. phil., Sek.-Lehrerin, Sonnenbergrain 57
 – Bertha Sus., Fabrikarbeiterin, Lorrainestrasse 63
 – Eda. Krankenpflegerin, Kramgasse 6
@@ -21237,7 +21206,7 @@ Ischer, Alfred, Kuttlermeister. Elisabethenstrasse 33
 – Karl, Dr. med., gew. Arzt, Brückfeldstr. 8 [31.215]
 – Klara, Mallehrerin, Kramgasse 6
 – Martha, Lehrerin, Gerechtigkeitsgasse 42
-– Rob. Th.. Schlosser, Lorrainestrasse 63
+– Rob. Th., Schlosser, Lorrainestrasse 63
 – Rosa, Kleinkinderlehrerin, Gerechtigkeitsgasse 42
 – Sophie B., Fabrikarbeiterin, Lorrainestr. 63
 – Theophil, Dr. phil., Gymnasiallehrer, Jubiläumsstrasse 15 [36.337]
@@ -21253,13 +21222,13 @@ Iseli, Alb., Hilfsarbeiter, Aarbergergasse 13
 – Alfr. Ernst. Schriftenmaler. Brunngasse 62
 – Anna, Bureauiistin, Stöckackerstrasse 80, Bümpliz
 – Arthur Ed., Elektromechan., Köniz-str. 41
-– Arthur (Pfeiff°r). Prokurist der Allg. Plakatgesellschaft. Falkenweg 3 [27.887]
+– Arthur (Pfeiffer). Prokurist der Allg. Plakatgesellschaft. Falkenweg 3 [27.887]
 – E., Architekt, Schwarzenburgstrasse 6
 – Emil Ernst. Brunngasse 62
 – Emil Max, Postaushelfer, Südbahnhofstr. 10
 – Emilie Rosa, Kurbelstickerin, Zähringerstrasse 16c
 – Ernst. Bahnarbeiter, Cäcilienstrasse 15
-– Ernst Wilhelm. Bahnarbeiter. Könizstr. 79
+– Ernst Wilhelm. Bahnarbeiter, Könizstr. 79
 – Ernst, Bankbeamter, Thormannstrasse 58 [36.460]
 # Date: 1935-12-15 Page: 26020532/227
 Iseli, Ernst (Schindler), Bureauangestellter, Wyttenbachstrasse 28
@@ -21270,12 +21239,12 @@ Iseli, Ernst (Schindler), Bureauangestellter, Wyttenbachstrasse 28
 – Friedr., Bahnarbeiter, Dietlerstrasse 50
 – Friedr., Handlanger, Jurastrasse 6
 – Friedr. Ad., Bahnangestellter B. Z. B., Aareggweg 32
-– Friedr. Aug.. Postangestellter, Parkstr. 32
+– Friedr. Aug., Postangestellter, Parkstr. 32
 – Friedr. Karl, Apparatemonteur, Gesellschaftsstrasse 30
 – Friedr., Kaufmann, Neubrückstrasse 89
 – Friedr., Giesser, Schläflirain 5
 – Friedr. Otto, jun., Elektromonteur, Bethlehemstrasse 117, Bümpliz
-– Friedrich Otto, Hilfsarbeiter. Bethlehemstrasse 117, Bümpliz
+– Friedrich Otto, Hilfsarbeiter, Bethlehemstrasse 117, Bümpliz
 – Friedr., Lehrer, Meisenweg 20 [32.151]
 – Friedr., pens. Briefträger, Kehrgasse 24, Bümpliz
 – Fritz, Coiffeur, Neubrückstrasse 89
@@ -21287,7 +21256,7 @@ Iseli, Ernst (Schindler), Bureauangestellter, Wyttenbachstrasse 28
 – Gottfr., gew. Buchdrucker, Beaulieustr. 21 [34.871]
 – Gottfr., Mechaniker, Marzilistrasse 8d
 – -Gottlieb, Maschinenmeister, Burgunderstrasse 140, Bümpliz
-– Gustav A.. Kaufmann, Schanzeneckstr. 9 [27.020]
+– Gustav A., Kaufmann, Schanzeneckstr. 9 [27.020]
 – Hanna (Sommer), Coiffeuse (Stockerenweg 25), Kornhausplatz 10 [34.030]
 – H. (Zürcher), Kolonialwarenhdlg., Luternauweg 7 [32.226]
 – Hans, Gasarbeiter, Stöckackerstrasse 80, Bümpliz
@@ -21305,7 +21274,7 @@ Iseli, Ernst (Schindler), Bureauangestellter, Wyttenbachstrasse 28
 – Lina. Ladentochter, Murtenstrasse 37
 – Louis Oskar, kant. Angestellter, Flurstr. 29
 – Luise (Wärren), Wwe., Rabbentalstr. 41
-– M. (Liechti), Wwe.. Postgasse 46
+– M. (Liechti), Wwe., Postgasse 46
 – Marg., kaufm. Angestellte, Schwarzenburgstrasse 6
 – Margrit, Telephonistin, Freiburgstr. 345, Bümpliz
 – Marie Rosina, Ladentochter, Gesellschaftsstrasse 30
@@ -21313,18 +21282,18 @@ Iseli, Martha Marie, Lehrerin, Oberbottigenweg 40, Oberbottigen
 – Paul (Kuch), Vertreter, Bantigerstr. 39
 – Richard Hans (Grub), Beamter, Seftigenstrasse 20
 – Robert Ludwig, Chauffeur, Fröschmattweg 14, Bümpliz
-– Rob.. Konfiseur. Kesslergasse 28
+– Rob., Konfiseur. Kesslergasse 28
 – Rob. Herm., Maler, Brunngasse 62
 – Rob., Lehrmeister a. d. Spenglerabtlg. d.
 Lehrwerkstätten d. Stadt Bern, Jurastr. 27
-– Rob., Versilberungs- und Vernicklungsanstalt, Münzrain 10 [35.5101, Bureau: Marzilistrasse 15 [31.924]
+– Rob., Versilberungs- und Vernicklungsanstalt, Münzrain 10 [35.510], Bureau: Marzilistrasse 15 [31.924]
 – Rosa Ida, Bureaulistin, Siidbahnhofstr. 10
 – Rosina (Glauser), Wwe., Privatiere, Vereinsweg 18
 – Rudolf, Fabrikarbeiter, Seidenweg 20
 – Rudolf, Bahnangestellter, Hallerstr. 31
 – Walter, Angestellter, Hallerstrasse 52
 – Walter, Polisseur, Länggassstrasse 67
-– Walter. Postangestellter, Bundesbahnw. 23
+– Walter, Postangestellter, Bundesbahnw. 23
 – Werner Ernst, Schlosser, Hopfenweg 40
 – Werner PL, Goldschmied, Zähringerstr. 64
 – Werner Hilfsarbeiter, Weissensteinstr. 80
@@ -21351,7 +21320,7 @@ Isenschmid, Alfred, Hilfsarbeiter, Metzgergasse 35
 – Ernst, Schmied, Brunngasse 42
 – Ernst, Landwirt, Buchweg 6. Riedbach
 – Ernst, Landwirt, Buchweg 8, Riedbach
-– Ernst. Postbeamter. Sulgenauweg 39
+– Ernst. Postbeamter, Sulgenauweg 39
 – Ernst, Elektromonteur, Brünnackerweg 43, Bümpliz
 – Ernst. Mechaniker, Eichholzstr. 8, Bümpliz
 – Franz Herm., Chauffeur S. O. B., Mattenhofstrasse 3 [20.684]
@@ -21411,7 +21380,7 @@ Isler, Alfr. Alex., Handlanger, Kirchgassel2
 – Leonie Flora, Ladentochter, Tiefmattstr. 10
 – Max, Fachlehrer, Steinauweg 30
 Isselbächer, L., Generalvertr. d. Schaufensterkunst Bern, Monbijoustrasse 120 [33.543]
-Ita, Alfr., städt. Beamter. Schwarztorstr. 80
+Ita, Alfr., städt. Beamter, Schwarztorstr. 80
 – Emma, Bureaulistin, Engehaldestrasse 34
 – Konrad, Schriftsetzer, Landhausweg 8
 – Luise (Hofer), Finkenrain 11
@@ -21538,7 +21507,7 @@ Jaggi, s. auch Jäggi u. Jacky
 # Date: 1935-12-15 Page: 26020535/230
 Jaggi, s. auch Jäggi u. Jacky
 – Erwin, Buchhalter, Speichergasse 8
-– Friedr. E., Beamter S. B. B.. Museumstr. 14
+– Friedr. E., Beamter S. B. B., Museumstr. 14
 – Friedr., Depotarb. S. B. B., Waldlieimstr. 40
 – Fritz, mechan. Werkstätte, Abendstr. 51, Bümphz [46.185]
 – Jean (Schmid), Weinhändler, Sulgeneckstrasse 36 [20.109]
@@ -21593,9 +21562,9 @@ Jäggi, A. (Nufer), Wwe., Wäscherin, Bernstrasse 15, Bümpliz
 Jäggi, Max Th. V., Angest., Bantigerstr. 29
 – Oskar, pens. Bereiter, Militärstrasse 50
 – Otto, dipl. Buchhalter, Militärstrasse 50 [32.489]
-– Otto (Volz), gew. Sekr. der Obertelegraphendirektion, Sclianzeneckstr. 25 [36.0411
+– Otto (Volz), gew. Sekr. der Obertelegraphendirektion, Sclianzeneckstr. 25 [36.041]
 – Paul Hans, Beamter S. B. B., Pavillonweg 6
-– P. Ernst, Weichenwärter. Eggimannstr. 25
+– P. Ernst, Weichenwärter, Eggimannstr. 25
 – Paul, Bauschlosser, Eggimannstrasse 25
 – Robert, Buchhalter und Prokurist. Herzogstrasse 3
 – Robert, Landarbeiter, Schönauweg 1
@@ -21640,7 +21609,7 @@ Jakob, s. auch Jacob
 – Elisabeth (Zurhuchen), Wwe., Gerechtigkeitsgasse 18
 – Elise, Bureaulistin, Sulgenbachstrasse 21
 – Elsa, Bureaulistin, Schläflistrasse 8
-– Emil Alfred, Tramangest.. Hopfenrain lß
+– Emil Alfred, Tramangest., Hopfenrain lß
 – Emma, Bureaulistin, Schützenweg 23
 – Ernst, Dachdecker. Jurastrasse 59
 – Ernst O., Abwart, Freiburgstrasse 4
@@ -21659,7 +21628,7 @@ Jakob, s. auch Jacob
 – Hans, Handlanger, Gerbergasse 38
 – Joh. (Gugger), Aarbergergasse 46
 – Joh., Bahnarbeiter, Federweg 29
-– Joh.. Bauarbeiter, Papiermühlestrasse 11
+– Joh., Bauarbeiter, Papiermühlestrasse 11
 – Joh., Maler, Weberstrasse 25
 – Joh. (Stucki), Privatier, Seftigenstrasse 27
 – K., pens. Postangestellt., Breitenrainstr. 73
@@ -21677,7 +21646,7 @@ Jakob, s. auch Jacob
 – R., pens. Beamter d. S. B. B., Schläflistr. 8 [28.670]
 – Robert, Bankangest., Tscharnerstrasse 15
 – Rud. Ad., Vernickler, Freieckweg 2, Bümpliz
-– Rud.. Magaziner O. T. D., Tannenweg 10
+– Rud., Magaziner O. T. D., Tannenweg 10
 – Rud., Tapezierermeister, Gerechtigkeitsg. 44
 – Walter, Gewerbehalle, Möbelhandlung, Gerechtigkeitsgasse 23 [35.351]
 – Walter, Kopierer, Waffenweg 22
@@ -21707,12 +21676,12 @@ Janke, Herbert, Dr. med., Assistenzarzt, Frikartweg 26
 Jann, Alfr., Angestellter, Fichtenweg 1
 – Gertrud, Glätterei, Frohbergweg 8
 – Hans Rob., Kaufmann, Fichtenweg 1
-– J R.. Beamter S. B. B.. Fichtenweg 1
+– J R., Beamter S. B. B., Fichtenweg 1
 – M. W., Beamtin S. B. B., Frohbergweg 8
 – Marie Anna, Modistin, Frohbergweg 8
 Jansky, Rudolf, photograph. Atelier u. Handlung photographischer Artikel. Monbijoustrasse 15 [24.783]
 Jahutolo, Anna El., Coiffeuse, Schützenw. 20
-Janz, A E.. Mechaniker, Holligenstrasse 43
+Janz, A E., Mechaniker, Holligenstrasse 43
 – Hermann, Postbeamter, Aarbergergasse 50
 – Maria Lina, Pension, Effingerstrasse 25
 – Paul, Hilfsarbeiter, Brunngasse 24
@@ -21731,7 +21700,7 @@ Jaquet, Georges Arthur, Bankangestellter, Emanuel-Friedlistrasse 25
 – Paul (Rossat), Sekretär b. d. Obertelegr.-Direktion, Beundenfeldstrasse 7 [25.267]
 – Roger, Bankangestellter, Gewerbestrasse 21
 – Willy, Kaufmann, Viktoriastrasse 65
-Jaquier, Arth.. Sekretär b. d. Oberpostdirektion, Brückfeldstrasse 43
+Jaquier, Arth., Sekretär b. d. Oberpostdirektion, Brückfeldstrasse 43
 – Emil Alfr., Bauzeichner, Brückfeldstr. 43
 – Henri Francois, Stricker, Oberweg 1
 – Jules, Beamter S. B. B., Schwarztorstr. 11
@@ -21743,7 +21712,7 @@ Järmann, Emil Rob., Kaufm., Moserstr. 48
 – Hans, Spengler, Elisabethenstrasse 57
 – Joh., gew. Lehrer der Breitenrainschule, Herzogstrasse 22
 – Rudolf Samuel, Ausläufer, Elisabethenstrasse 57
-Jarnieu, Charles Jos,, Metzger, Storchengässchen 5
+Jarnieu, Charles Jos., Metzger, Storchengässchen 5
 Jaroczynsky, Alfr., Kaufmann, Karl-Schenkstrasse 9
 Jarretoui, J. F, (Lang), Schneider, Elisabethenstrasse 43
 Jasselin, Francoise, Schwarzenburgstr. 14a
@@ -21768,13 +21737,13 @@ Jaussi, Arnold Joh., Hilfsarbeiter, Seidenw. 54
 – Emil Rud., Drechsler G. W., Sandrainstr. 33
 – Emil, Hilfsarbeiter, Murifeldweg 27
 – Emil, Zahnarzt (Kirchbühlweg 18 [32.985]), Ecke Hirschengraben/Effingerstrasse 2 [34.043]
-– Ernst, Baumeister. Breitenrainstrasse 16 [22.387]
+– Ernst, Baumeister, Breitenrainstrasse 16 [22.387]
 – Ernst, Ausläufer, Militärstrasse 57
 – Frieda Gertrud, Coiffeuse, Brunnmattstrasse 55
 – Frieda, Coiffeuse, Sandrainstrasse 33
 – Fritz, Riedweg 23 [29.462]
 – Jakob. Pferdewärter, Rodtmattstrasse 85
-– Joh., Gärtnermeister. Engerain 48
+– Joh., Gärtnermeister, Engerain 48
 – Joh., Pferdewärter, Breitfeldstrasse 55
 – Martha, Emma u. Johanna, Lingeren, Gerechtigkeitsgasse 59
 – Nelly, Dr. jur., eidg. Beamte, Chutzenstrasse 39
@@ -21841,7 +21810,7 @@ Jeger, s. auch Jäger
 Jegerlehner, Arnold Ernst, Techniker. Waldhöheweg 14 [22.923]
 – Ernst Walter, Heizer, Hotelgasse 3
 – Franz Ad., Kaufmann, Wildermettweg 49
-– Friedr.. Melker, Neubrückstrasse 59
+– Friedr., Melker, Neubrückstrasse 59
 – Joh., Güterarbeiter, Aehrenweg 30, Bümpliz
 – Marie (Gurtner), Wwe., Waldhöheweg 14
 – Otto, Magaziner b. Konsum, Brunnhofw. 4
@@ -21858,7 +21827,7 @@ Jenk, Friedr. Joh., Mechaniker. Lorrainestrasse 67
 – Joh., Installateur, Landoltstrasse 73
 – Otto P., Ausläufer, Lorrainestrasse 32
 – Rosa (Gfeller), Wwe., Landoltstrasse 73
-– Walter Rud.. Coiffeur, Lorrainestrasse 32
+– Walter Rud., Coiffeur, Lorrainestrasse 32
 Jenke, Fritz, Lehrer der Keramik, Altenbergstrasse 37
 Jenne, Chr. F. (Imhoff), Vertreter, Breitenrainplatz 40a [34.763]
 – Fritz E., Kommis, Breitenrainplatz 40a
@@ -21880,11 +21849,11 @@ Jenni und Jenny
 – Bertha A., Falzerin, Keltenstr. 93, Bümpliz
 – Bertha (Bachmann), Wwe., Seidenweg 6
 – Chr., Milchhändler, Quartierg.il [32.536]
-– Christ.. Schlosser, Wylerstrasse 43
+– Christ., Schlosser, Wylerstrasse 43
 – Ella (Weiss), Angestellte, Zielweg 5
 – Emil Fr., Bankbeamter, Beaulieustrasse 7
 – Emil Jak., Mechaniker, Sulgenbachstr. 41
-– Emma (Nydegger), Damenschneiderin, Könizstrasse 4-la
+– Emma (Nydegger), Damenschneiderin, Könizstrasse 4-1a
 – Emma (Merz), Wildermettweg 46
 – Ernst, Hilfsarbeiter, Rütlistrasse 13
 – Ernst, Kaufmann. Greyerzstrasse 28
@@ -21962,7 +21931,7 @@ Jenni und Jenny
 – R. Luise, Glätterei Hallerstrasse 36
 – - Robert Maximilian, Schauspieler, Hopfenweg 21
 – Rosa, Hebamme, Schanzenstrasse 23
-– Rosa Bertha. Damenschneiderin, Rodtmattstrasse 66
+– Rosa Bertha, Damenschneiderin, Rodtmattstrasse 66
 – Rosa Gertr., Ladentochter, Gesellschaftsstrasse 78
 – Rosa (Schär), Privatiers, Hallerstrasse 56 [32.802]
 Jenni und Jenny
@@ -21977,9 +21946,9 @@ Jenni und Jenny
 – Ulrich, Lok.-Führer. Bundesbahnweg 15
 – Walter, Hilfsarbeiter, Sulgeneckstrasse 54d
 – Werner, Postangestellter, Murtenstr. 129
-– Xaver, Spinnereihilfsmeister. Felsenaustrasse 24
+– Xaver, Spinnereihilfsmeister, Felsenaustrasse 24
 – ’s Söhne, Bauspenglerei, Aarbergerg. 28, Eingang Sternengässchen [33.942]
-– & Co.. Import, Bollwerk 21 [28.235]
+– & Co., Import, Bollwerk 21 [28.235]
 Jensen, N. P. Chr., Schreiner, Zähringerstr. 51
 Jent, Elisabeth, Frl., Effingerstrasse 56
 – E. (Jäggi), Priv., Effingerstr. 56 [31.198]
@@ -21994,14 +21963,14 @@ Jenzer, Alfred (Willi), Bäckerei-Konditorei, Neubrückstrasse 71 [24.155]
 – Bertha, Kindergärtnerin, Gryphenhübeliweg 45
 – Christ. (Eicher), städt. Liegenschaftsverwalter, Willadingweg 21 [36.517]
 – Elisa. Brunnhofweg 20
-– Ernst, Angest. S. B. B.. Eggimannstrasse 17
+– Ernst, Angest. S. B. B., Eggimannstrasse 17
 – Ernst. Autowagner, Sandrainstrasse 73
 – Hans (Zaugg), Schmied, Lentulusstr. 65
 – Helene. Bureauangeslellte, Gartenstr 13
 – Herm., Herren-Maßschneiderei, Neubrückstrasse 71
 – Ida, Ladentochter, Willadingweg 21
 – Jak. (Herzig), in Fa. Ramseyer, Streun & Co., DaLmaziweg 57
-– Jakob. Stationechef S. S. B.. Cäcilienstr. 15
+– Jakob. Stationechef S. S. B., Cäcilienstr. 15
 – Johanna Martha, Sek.-Lehrerin, Werdtw. 4
 – Joh. Friedr., Mechan., Murtenstr. 155m
 – Karl, Schmied, Schreinerweg 15
@@ -22036,7 +22005,7 @@ Jobin, Alb. A., eidg. Beamter, Ensingerstr 38 [26.259]
 Joder, Bertha, Verkäuferin, Brünnackerw. 15, Bümpliz
 – Christ., pens. Schlosser, Breiteweg 13
 – Elise (Studer), Wwe., Burgfeldweg 8
-– Ernst. Bauamtarbeiter. Könizstrasse 51
+– Ernst, Bauamtarbeiter, Könizstrasse 51
 – Friedr., Lok.-Führer, Waldheimstrasse 10b
 – Hans Rud., Mechaniker, Brünnackerw. 15, Bümpliz
 – Hermine, Photographin. Randweg 13
@@ -22053,7 +22022,7 @@ Johner, Emil, Schriftsetzer, Dalmazirain 44
 – Hans Adrian, Steinerstrasse 47
 – Joh., Angestellter, Kasthoferstrasse 8
 – Johannes. Chauffeur, Bümplizstrasse 171
-– Martha Lina (v. Grüningen), Wwe.. Steinerstrasse 47 [22.507]
+– Martha Lina (v. Grüningen), Wwe., Steinerstrasse 47 [22.507]
 – Paulina El., Missionarin. Schönauweg 1
 – Roger E., Kaufmann. Friedheimweg 51
 – Theod. Gust., Arzt, Freiburgstrasse 18
@@ -22067,17 +22036,17 @@ Joho, Emma Gertr., Fabrikarbeiterin, Tscharnerstrasse 3
 Jöhr, August Alfred, Handlanger, Murtenstrasse 153d
 – F. H., Dekorateur, Monbijoustrasse 120
 – Hans, Beatusstrasse 17 [34.153]
-– Hans W.. kaufm Angest., Beatusstr. 17
+– Hans W., kaufm Angest., Beatusstr. 17
 – Ida Morgr., Beatusstrasse 17
 – Martha Rosa, Hilfsarbeiter, Stalden 3
-– Rob. Joh.. Masch-Schlosser, Murtenstr.l53c
+– Rob. Joh., Masch-Schlosser, Murtenstr.l53c
 – Rosa M. E., Ladentochter, Museumstr. 12
 – Rosa, Lehrerin, Neufeldstr. 155 [24.798]
 Jolimont, Pension, Reichenbachstrasse 39 [32.202]
 Jolles, Ida (Hegnauer), Wwe., Kirchenfeldstrasse 4 [31.099]
 Jomini, Pierre, Ingenieur, Seftigenstrasse 64
 Jonasch, Walter, Tapezierer und Dekorateur (Parkstrasse 35, Wabern), Mühlemattstr. 66 [28.910]
-Jones, Francis M.. Schänzlistrasse 65
+Jones, Francis M., Schänzlistrasse 65
 – Lois A. Schänzlistrasse 65
 de Jong van Beck en Donk, B., Dr., Schanzenbergstrasse 11
 Jonquiere, Martha, Frl., Privatiere, Lilienweg 18 [33.870]
@@ -22095,31 +22064,31 @@ Jordan, Alice Ang., Beamtin S. B. B., Brückfeldstrasse 10a
 – Eug. TI., Coiffeur, Kyburgstrasse 10
 – Gertrud. Kirchenfeldstrasse 8
 – Hulda, Bureaulistin, Raineggweg 3
-– Luise (Bächler). Wwe.. Brückfeldstr. 10a
+– Luise (Bächler). Wwe., Brückfeldstr. 10a
 Jordi, Albert, Gepäckarbeiter d. S. B. B., Fichtenweg 3a
 – Alb. Rud., Bureaulist, Fischerweg 19
 – Alfr., städt. Beamter, Weingartstrasse 45
 – Eduard. Sektionschef der Generalstabsabteilung, Laubeckstrasse 28 [20.256]
 – Elisabeth (Aebi), Wwe., Schwarztorstr. 67
 – Emil, kant. Angestellter, Viktoriastrasse 47
-– Emil (Feiler). Bureauchef S. B. B,, Viktoriastrasse 47
+– Emil (Feiler). Bureauchef S. B. B., Viktoriastrasse 47
 – Emma, Rosenweg 15
 – Emma (Schwab), Wwe. des Notars. Rabbentalstrasse 77 [22.919]
 – Ernst. Elektromechaniker, Eschenweg 15
 – Ernst Ottilio, Masch.-Techniker, Fichtenweg 3a
 # Date: 1935-12-15 Page: 26020541/236
 Jordi, Erwin (Debucquoy), Angestellter, Landoltstrasse 83
-– Fanny El.. Ladentochter, Belpstrasse 16
+– Fanny El., Ladentochter, Belpstrasse 16
 – Franz (Nebel), Beamter S. B. B., Brunnadernstrasse 98 [21.696]
 – Friedr., Schreiner, Kirchbergerstrasse 2
-– Friedr.. Handlanger, Sandrainstrasse 78
+– Friedr., Handlanger, Sandrainstrasse 78
 – Fritz (Dähler), Baumeister, in Fa. Gebr.
 J. & F. Jordi, Neuhäuserweg 1 [22.048]
 – Fritz, Kaufmann, Weidmattweg 7, Bümpliz
 – Gerhard, Notar, in Fa. Jordi & Co., Rabbentalstrasse 77 [22.919]
 – Gottfr., Pferdewärter, Breitfeldstrasse 35a
 – Gottlieb, Buchbinder, Willadingweg 25
-– H.. Münzarbeiter. Tscharnerstrasse 27
+– H., Münzarbeiter, Tscharnerstrasse 27
 – Hans, Architekt, Falkenweg 21 [36.412]
 – Hans Rudolf, Techniker, Seftigenstr. 53
 – Hedwig Gertr., Bureaulistin, Brückenstr. 10
@@ -22424,17 +22393,16 @@ Jung, E., Angestellter der kant. Stempelverwaltung, Beundenfeldstrasse 37
 – Werner Otto (Zwinger), Ingenieur, Frohbergweg 5
 Jungen, Christian, Prediger, Laupenstr. 13
 – Fr., gew. Postfaktor, Siedlungsweg 17
-– Fritz (Fuchs), Prokurist der Fa. Worbla
-A.-G., Schläflirain 1
-– Herm.. Kupferstecher, W 7 olfstr. 3 [20.883]
+– Fritz (Fuchs), Prokurist der Fa. Worbla A.-G., Schläflirain 1
+– Herm., Kupferstecher, W 7 olfstr. 3 [20.883]
 – Johann Sam., pens. Beamter, Tillierstr. 3
 Junger, Anna, gew. Arbeitslehrerin, Laupenstrasse 33 [35.567]
 Jungi, Elise, Bureaulistin, Elisabethenstr. 27
 – Ernst. Giesser. Strandweg 68
 – Ernst. Schriftsetzer, Greyerzstrasse 27
 – Frieda Luise. Beamtin S. B. B., Fischermätteliweg 23
-– Fritz, eidg Beamter, Sandrainstrasse 83 [24.207]
-Jungi, Gottfr. [21.904] (Nikles), Treuhand- und Revisionsbureau, Buchführung und Expertisen (Beundenfeldstrasse 2 [132.2541), Bürgerhaus. Neuengasse 20
+– Fritz, eidg. Beamter, Sandrainstrasse 83 [24.207]
+Jungi, Gottfr. [21.904] (Nikles), Treuhand- und Revisionsbureau, Buchführung und Expertisen (Beundenfeldstrasse 2 [32.254], Bürgerhaus. Neuengasse 20
 – Hans. Lehrer, Cedernstrasse 8, Bümpliz
 – Karl Albert. Schlosser. Weissenbühlw. 35a
 – Robert, Wäscher, Holligenstrasse 92
@@ -22467,11 +22435,11 @@ Junker, siehe auch Juncker
 – Ferd., Buchhalter, Waldheimstrasse 43
 – Frieda (Sclimid), Wwe., Siedlungsweg 23
 – Fritz (Schneider), Bäckermeister, Pestalozzistrasse 1 [22.650]
-– Gottfr., Zimmermeister. Militärstrasse 26 [22.529]
+– Gottfr., Zimmermeister, Militärstrasse 26 [22.529]
 – Hermann, Ghemigraph, Herzogstrasse 15
 – Herm., Polizeikorporal, Herzogstrasse 15
 – J. A., Modellschreiner, Waldheimstrasse 43
-– Joh., pens. Bahnarbeiter. Lentulusrain 7
+– Joh., pens. Bahnarbeiter, Lentulusrain 7
 – Joh., Gasarbeiter, Stöckackerstrasse 97, Bümpliz
 – Joh., Buchbinder, Bridelstrasse 6
 – Joh. V., eidg Beamter, Kirchbühlweg 19
@@ -22483,11 +22451,11 @@ Junker, siehe auch Juncker
 – & Co., Max, Berufskleiderfabrikat., Mühlemattstrasse 14a [24.427]
 Junod, Andre. Revisor der Oberpostkontrolle, Gryphenhübeliweg 19
 – Charles Henri, Techniker S. B. B., Blumenbergstrasse 37
-– Louis M. H.. eidg. Beamter, Südbahnhofstrasse 17
-– Maur.. Beamter d. internat. Bureaus des
+– Louis M. H., eidg. Beamter, Südbahnhofstrasse 17
+– Maur., Beamter d. internat. Bureaus des
 Weltpostvereins, Südbahnhofstrasse 17 [33.687]
 Jura, Hotel, Bubenbergplatz 5 [23.884]
-Juri, Alf:-. G F.. Postbeamter. Falkenplatz 5
+Juri, Alf:-. G F., Postbeamter, Falkenplatz 5
 Juri, Emma. Ladentochter, Weissenbühlw. 2
 – Gertrud, Modistin, Sonneggweg 15
 – Julius, Reisender. Sonneggweg 15 [45.088]
@@ -22498,7 +22466,7 @@ Justiz- u Polizeidepartement, eidg., Bundeshaus-Westbau, Depart-Vorsteher [61]
 Jüstrich, Emil, Just-Bürsten, Schwarztorstrasse 80 [34.784]
 Jutzeler, Hans, Kaufmann, Belpstrasse 49
 Jutzi, Christ. (Schlegel), Frohbergweg 5
-– Chr.. Bahnarheiter. Kehrgasse 33. Bümpliz
+– Chr., Bahnarheiter, Kehrgasse 33. Bümpliz
 – Elise Rosa, Vorsteherin. Monbijoustr. 69
 – Emma M., Schneiderin, Scheuermattw. 12
 – Friedr. Gottl., Schlosser, Scheibenstr. 32
@@ -22508,7 +22476,6 @@ Jutzi, Christ. (Schlegel), Frohbergweg 5
 – Hedwig, Bureaulistin, Frohbergweg 5
 – Joh., Hilfsarbeiter, Breitfeldstrasse 56
 – Johanna, Damenschneiderin, Kehrgasse 33, Bümpliz
-Buchdruck-Clichesein- und mehrfarbig Hallwag Bernliefert gut und preiswert Telephon 28.222
 # Date: 1935-12-15 Page: 26020545/240
 Jutzi, Margaretha, Ladentochter, Thunstr. 90
 – Marie (Brönnimann), Wwe., Metzgerei, Thunstrasse 90 [33.592]
@@ -22526,7 +22493,7 @@ Juvet, E., Beamter der Oberpostdirektion, Denzlerstrasse 6.
 – Nora Bluette, Angestellte K. T. D., Denzlerstrasse 6
 Ka-We-De [20.175]
 Kunsteisbahn und Wellenbad Dählhölzli-Bern A.-G., Jubiläumsstrasse 95 (Wintersaison November—März, Sommersaison Mai—September)
-Kaar, Jos., Schuhmachermstr.. Metzgerg. 34
+Kaar, Jos., Schuhmachermstr., Metzgerg. 34
 Kaatz, Ewald, Chemigraph, Rodtmattstr. 54
 Kabes, Emil Lucien, Kaufmann, Zaunweg 22
 Käch, Albert, Maler- und Gipsergeschäft (Bierhübeliweg 1 [33.179]), Sulgenrain 16
@@ -22573,7 +22540,7 @@ Kähr, s. auch Kehr
 Kaiser, s. auch Kayser u. Keiser
 – Alice, Damenschneiderin, Jolimontstr. 14
 – Alice, Frau, Kirchenfeldstrasse 30 [23.632]
-– Bertha Louise, Thunstrasse .95
+– Bertha Louise, Thunstrasse 95
 – Bruno, Dr., Kaufmann, Fabrikstrasse 1 [31.063]
 – E., Telegraphistin, Lagerweg 2 [22.886]
 – Edmund Fabrikation von Schuhschäften, Wattenwylweg 9 [35.631]
@@ -22602,10 +22569,7 @@ Krankheiten, Röntgendiagnostik (Thunstrasse 95 [24.959]), Ghristoffelgasse 4 [3
 – Sus. (Luder), Wwe., Fabrikstr. 1 [31.063]
 – Tino, Kirchenfeldstrasse 30
 – Willi, Schlosser, Jolimontstrasse 14
-– Gebr., .Marktgasse 41
-Das moderne Badzimmermacht Ihnen sicher
-Freude. Lassen Sie sichberaten durchstettbacher
-Gerechtigkeitsg. 59 Telephon 21.040
+– Gebr., Marktgasse 41
 # Date: 1935-12-15 Page: 26020546/241
 Kaiser, s. auch Kayser u. Keiser
 – ’s Kaffeegeschäft, Spitalgasse 24 [36.256]; Länggassstrasse 30 und Breitenrainpl. 31
@@ -22626,7 +22590,7 @@ Kälin, Anton, Apotheker, Spitalackerstr. 25
 – Margr. Marie, Lehrerin, Beatusstrasse 19
 – Walter, Typograph, Frikartweg 14
 – & Burri, Neon-Service, Melchtalstrasse 15 [36.248]
-Kalten, Joh Adolf, Telegr.-Beamter. Bühlpl. 1
+Kalten, Joh Adolf, Telegr.-Beamter, Bühlpl. 1
 Kalmus, Leopold Fr., Farbenätzer, Gutenbergstrasse 12
 Kalnins, K., Sekretär der lettischen Gesandtschaft, Ob Dufourstrasse 45
 Kalt, Anna (Wenger), Wwe., Breitenrainpl. 31 [32.495]
@@ -22684,7 +22648,7 @@ Kammermann, Ad. Rud., Bauarbeiter, Postgasse 46
 – Margaretha, Krankenschwester, Blumenbergstrasse 5
 – Martha, Frau, Kramgasse 60
 – Max, Metzger, Scheibenstrasse 41
-– Otto Herm., Hilfsarbeiter. Metzgergasse 34
+– Otto Herm., Hilfsarbeiter, Metzgergasse 34
 – Rud., Handelslehrer am städt. Gymnasium, Lerberstrasse 17 [34.855]
 – Therese, Lehrerin, Fellenbergstrasse 15
 Kämpf, s. auch Kempf
@@ -22702,7 +22666,7 @@ Kämpf, s. auch Kempf
 # Date: 1935-12-15 Page: 26020547/242
 Kämpf, s. auch Kempf
 – Helene, Bureaul., Brüekfeldstr. 10a [33.807]
-– Herm., Postangestellter. Gesellschaftsstr. 18
+– Herm., Postangestellter, Gesellschaftsstr. 18
 – Ida Al., Längere, Schönburgstrasse 40
 – Jak. R., Maschinenmstr., Schönburgstr. 40
 – Jb., pens. Pferdewärter, Schönburgstr. 40
@@ -22727,7 +22691,8 @@ Kämpfer, Anna, gew. Telegraphistin, Bubenbergstrasse 18
 – Rosa (Lüdi), Lingere, Lentulusstrasse 38
 – Rosalie, Bureaua,ngest., Bubenbergstr. 18
 — Rud., Angestellter, Mittelstrasse 12
-– Walter Werner, Mechaniker, Mezenerweg 8v. Känel und Känel
+– Walter Werner, Mechaniker, Mezenerweg 8
+v. Känel und Känel
 – A. Henri Jak., Chauffeur, Mühlemattstr. 16
 – Adolf Rob., Postbeamter, Aarbergerg. 58
 – Alex., Handlanger, Scheibenstrasse 20
@@ -22790,7 +22755,7 @@ v. Känel und Känel
 Kanifz, Jakob, Generaldirektor, Th.-Kochergasse 5
 Kannengieser, Theo, Leiter der « La Suisse», Sub-Direktion (Jubiläumsstr. 57 [36.508]), Bahnhofplatz 1 [29.511]
 Kantonalbank von Bern, Bundesplatz 8 [22.701]
-– Zweigbüro Breitenrain, Breitenrainplatz 36 [22.659
+– Zweigbüro Breitenrain, Breitenrainplatz 36 [22.659]
 – Zweigbüro Eigerplatz, Eigerpl. 12 [22.629]
 – Zweigbüro Länggasse, Länggassstr. 29-Ecke Bühlstrasse [23.320]
 – Zweigbüro Bümpliz [46.602J
@@ -22812,10 +22777,9 @@ Känzig, Alfr., Bauamtarbeiter, Jurastrasse 9
 Kanziger, Bertha, Verkäuferin, Länggassstrasse 25
 – Gottfr., Mechaniker, Birkenweg 16
 – Gottfr., Modellschreiner, Hallerstrasse 28
-– Hans, Dipl. Ingenieur, Experte beim eidg.
-Amt für geistiges Eigentum, Viktoriastr. 53
+– Hans, Dipl. Ingenieur, Experte beim eidg. Amt für geistiges Eigentum, Viktoriastr. 53
 – Hans Alb., Mechaniker, Bridelstrasse 4
-– Joh., Bauamtarbeiter, Weissensteinstr. la
+– Joh., Bauamtarbeiter, Weissensteinstr. 1a
 – Marie Rosa (Paul), Wwe., Bridelstr. 4
 – Walter, Ingenieur, Gryphenhübeliweg 8 [34.614]
 Kapfer, Adolf, gew. Bäcker, Bühlstrasse 59
@@ -22843,7 +22807,7 @@ Kappeier, Anna, Bureaulistin, Lenzweg 8
 – Ernst Werner, Maler, Breitfeldstrasse 54
 – Ernst J., Maschinenmeister, Tiefenaustrasse 112
 – Ernst, Pianist, Klavier-Unterricht, Sulgenheimweg 17 [34.723]
-– Frz. Herm.. Dr. jur., eidg. Beamter, Engestrasse 49 [22.776]
+– Frz. Herm., Dr. jur., eidg. Beamter, Engestrasse 49 [22.776]
 – Friedr., Hilfsarbeiter, Rodtmattstrasse 87
 Kappeier, Gottfr., Bankangest., Belpstr. 11
 – Gottfr., Gipser- u. Malermeister, Breitfeldstrasse 54 [27.644]
@@ -22855,7 +22819,7 @@ Kappeier, Gottfr., Bankangest., Belpstr. 11
 – Joh. Samuel, Hilfsarbeiter, Ladenwandstrasse 96
 – Johann, Gipser- und Malermeister, Stauffacherstrasse 29 [35.563]
 – Joh. Otto, Zollbeamter, Ensingerstrasse 23
-– Joseph, Billetteur S. S. B.. Muristrasse 50
+– Joseph, Billetteur S. S. B., Muristrasse 50
 – Karl, Beamter K.K.K., Lenzweg 8 [24.248]
 – Karl C., Chauffeur. Rodtmattstrasse 116
 – Karl (Arnold), Kaufmann, Seftigenstr. 53 [29.442]
@@ -22883,7 +22847,7 @@ Karlen, Anna Kath., Gehilfin, Bubenbergstr. 4
 – Hs., Handlanger, Eymattstr. 164, Bümpliz
 – Hedwig Rosa, Bankangest., Moserstr. 8
 – Jakob, Mechaniker, Wiesenstrasse 29
-– J. F., Fabrikarbeiter. Rodtmattstrasse 69
+– J. F., Fabrikarbeiter, Rodtmattstrasse 69
 – Joh., Telephonarbeiter, Länggassstr. 63
 – Lina, Damenschneiderin, Wiesenstrasse 34
 – Luise Emma, Frl., Moserstrasse 8
@@ -22971,17 +22935,17 @@ Gebr. A. & P., Käsermann, Schwarztorstrasse 79 [29.564]
 – Lina (Jakob), Stockerenweg 9
 – M. Klara, Lebensmittelhandlung, Aegertenstrasse 49 [23.539]
 – Walter, mech. Werkstätte u. Vernicklungsanstalt (Effingerstr. 92 [26.229]), Schwarztorstrasse 77 [36.870]
-– Gebr.. A. & P., Fabrikation von Kühlern u. Autospenglerei, Schwarztorstr-. 79 [29.564]
+– Gebr., A. & P., Fabrikation von Kühlern u. Autospenglerei, Schwarztorstr-. 79 [29.564]
 Kasernen-Kantine, Papiermühlestrasse 15 [23.321]
 Kasernen-Verwaltung, Papiermühlestr. 15 [24.611]
 Käseunion, Schweiz. [24.951] Monbijoustrasse 47
 Käslin, Rob. Alfr., Mech., Spitalackerstr. 59
-– Louise (Merker), Wwe.. Bubenbergstr. 33 [29.064]
+– Louise (Merker), Wwe., Bubenbergstr. 33 [29.064]
 Käsmeier, Jak., Schneidermeister (Lentulusrain 22 [22.598]), Effingerstr. 13 [21.051]
 – Johanna Kath., Bureaulistin, Lentulusrain 22
 Kaspar, Arnold Gottl. (Droz), Beamter der S. B. B., Kyburgstrasse 9
 – Bertha, Krankenpflegerin, Riedweg 11
-– Bruno, Grubenarbeiter. Bümplizstrasse 3
+– Bruno, Grubenarbeiter, Bümplizstrasse 3
 – Ernst, Coiffeur, Fährstrasse 8 [34.267]
 – Ernst. Spengler-Installateur, Elisabethenstrasse 45
 – Frieda, Ladentochter, Jubiläumsstrasse 88
@@ -23102,7 +23066,7 @@ Kaufmann, Johannes, Coiffeur, Bümplizstr. 75
 – Rene Alb., Gipser, Eggimannstrasse 26
 – Rosalie, Bureaulistin, Schwanengasse 9
 – Rosina, Weissnäherin, Sulgenbachslr. 45
-– Rosina (Ramseyer), Wwe.. Hopfenweg 13
+– Rosina (Ramseyer), Wwe., Hopfenweg 13
 – Rud., Chauffeur, Freiburgstrasse 370
 – Rud., Hilfsarbeiter, Sulgenauweg 15
 – Rud., Kohlenarbeiter, Bümplizstrasse 75
@@ -23118,12 +23082,12 @@ Handel u. Industrie, Marienstr. 29 [24.930]
 – Willi, Maschinenmstr., Weissensteinstr. 112
 – Willi (Gautschi), Antiquariat, Kesslerg. 23
 – Xaver, Verwaltungsgehilfe O. P. D., Wyttenbachstrasse 14
-– & Co.. J., Mercerie, Bonneterie, Waaghausgasse 3—7 [25.922]
+– & Co., J., Mercerie, Bonneterie, Waaghausgasse 3—7 [25.922]
 Kaufmännischer Verein, Vereinshaus Herrengasse 36, Vereinssekretariat [22.647], Schulsekretariat und Stellenvermittlung [22.888], Restaurant [23.447]
 Kaupe, Vilma. Sekretärin, Ob. Dufourstr. 45
 Kauz, A., Unternehmer, Schönburgstrasse 32
 – Ernst (Birbaum), Hilfsarbeiter, Altenbergstrasse 14
-– Fr., Kaminfegermeister, Breitenrainstr. 18 [32.5331
+– Fr., Kaminfegermeister, Breitenrainstr. 18 [32.533]
 – Hedw. Margr., Verkäuferin, Marktgasse 3
 – Joh., Hausierer, Unt. Aareggweg 5
 – Joh. Friedr., jun., Kaminfeger, Breitenrainstrasse 18
@@ -23194,8 +23158,7 @@ Kellenberger, Alfr., eidg. Beamter, Giessereiweg 9 [23.034]
 – Hanna (Kleist). Wwe. d. Bankverwalters, Gryphenhübeliweg 49 [29.697]
 – Louise Erna, Verkäuferin, Beundenfeldstrasse 3 [20.772]
 Keller, Adolf, Landwirt, Schosshaldenstr. 38
-– A. J. (Notz), Ingen, d. Bern. Kraftwerke
-A.-G., Kniislihubelweg 11 [45.068]
+– A. J. (Notz), Ingen, d. Bern. Kraftwerke A.-G., Kniislihubelweg 11 [45.068]
 – A. M. Klara, Muldenstrasse 37
 – Ad., Maschinenmeister, Brünnenstr. 104, Bümpliz
 – Adolf, Zimmermann, Hirschengraben 10
@@ -23211,7 +23174,7 @@ A.-G., Kniislihubelweg 11 [45.068]
 – Alice, Bureau listin, Zähringerstrasse 24
 – Anna, Frl., Mezenerweg 8
 – Anna Lse., Kunstmalerin, Marienstrasse 14 [35.612]
-– Anna (Flückiger), Wwe.. Schützenmattstrasse 12 [32.098]
+– Anna (Flückiger), Wwe., Schützenmattstrasse 12 [32.098]
 – Arnold Wilh., Angestellter, Wyttenbachstrasse 11
 – Aug., Festangestellter, Alleeweg 8
 – Aug., pens. Versich.-Beamter, Hch.-Wildstrasse 16
@@ -23236,7 +23199,7 @@ Keller, Elisabeth, Handweberin S. W. B., Junkerngasse 15 [22.631]
 – Emil, Gymn.-Lehrer, Klaraweg 9 [36.449]
 – Emil, Hilfsarb., Bottigenstr. 67, Bümpliz
 – Emil, Ingenieur, in Fa Keller & Cie., Schützenmattstrasse 12 [32.098]
-– Emil Ferd., Postbeamter. Viktoriastrasse 35
+– Emil Ferd., Postbeamter, Viktoriastrasse 35
 – Emil (Kaiser), gew. Kaufmann, Manuelstrasse 68 [29.319]
 – Ernst. Junkerngasse 43
 – Ernst Robert, Sonneggweg 7
@@ -23301,14 +23264,14 @@ Keller, Gotthelf, Milchträger, Rehhagstr. 10, Bümpliz
 – Hermann, Beamter, Fischerweg 17
 – Hermann, Spezereihdlg., Militärstrasse 44 [32.797]
 – Hermann Arthur, in Fa. Gottfr. Keller & Söhne, Fischerweg 15 [20.243]
-– Hugo, Gesanglehrer a.. d. Knabensekundarschule II, Zwyssigstrasse 19 [36.451]
+– Hugo, Gesanglehrer a., d. Knabensekundarschule II, Zwyssigstrasse 19 [36.451]
 – Ida Friederike Kath., Stalden 22
 – Ida (Bohner), Wwe., Heckenweg 3
 – Ida M., Telephonistin, Ob. Aareggweg 30
 – Ida Rosa (Gramm), Kornhausplatz 5
 – J. L. B., Privatiere, Altenbergstrasse 53 [23.497]
 – Jacques (Michel), Personalchef, Schwarztorstrasse 18 [34.472]
-— Jacques, Photographie und Malerei (Manuelstrasse 105 [34.7651), Herzogstr. 2 [32.778]
+— Jacques, Photographie und Malerei (Manuelstrasse 105 [34.765]), Herzogstr. 2 [32.778]
 – Jakob, eidg. Beamter, Falkenhöheweg 14
 – Jakob, Beamter, Allmendstrasse 2
 – Jakob, Vertreter, Gerechtigkeitsgasse 20
@@ -23324,8 +23287,7 @@ Keller, Manuelstrasse 101 [32.805]
 – Karl Aug., Chemiker, Rosenw. 20 [26.159]
 – Karl Ernst, Möbelschr., Ob. Aareggweg 30
 – Karl Alb., Techniker, Sulgenrain 8 [25.686]
-– Karl, Ingenieur, in Fa. Keller & Cie., Ob.
-Aareggweg 30 [34.801]
+– Karl, Ingenieur, in Fa. Keller & Cie., Ob. Aareggweg 30 [34.801]
 Keller, Katharina (Dolder), Näherin, Effingerstrasse 97
 – Klara, Aufräumerin, Weissensteinstr. 61
 – Klara Joh. (Stucki), Wwe., Tiefmattstr. 12
@@ -23342,7 +23304,7 @@ Keller, Katharina (Dolder), Näherin, Effingerstrasse 97
 – Marie, Bureaulistin, Seilerstrasse 2
 – Marianne J., Aerztin, Gartenstrasse 13
 – Martha F. M., Bureaulist., Hch.-Wildstr. 16
-– Martha (Locher), Wwe.. Waschfrau, Willadingweg 42
+– Martha (Locher), Wwe., Waschfrau, Willadingweg 42
 – Matthias, Fuhrmann, Weissensteinstr. 61
 – Max, Generalagentur der «Zürich», Allgem.
 Unfall- und Haftpflicht-Versich. (Sulgenrain 10 [33.984]), Zeughausg. 29 [29.859]
@@ -23355,10 +23317,9 @@ Eisenbahndepartement, Gewerbestrasse 33
 – Otto, Schmied, Stockerenweg 20
 – Otto, gew. Wirt, Wylerstr. 55 [28.359]
 – Paul Alfr., Kaufmann, Aegertenstrasse 63
-– Paul, Dr. med., Zahnarzt, neue Zahnklinik (Schanzenbergstr. 11 [27.241], Marktg. 19 [22.532]
+– Paul, Dr. med., Zahnarzt, neue Zahnklinik (Schanzenbergstr. 11 [27.241]), Marktg. 19 [22.532]
 – Paul Rud., eidg. Beamter, Egghölzliw. 50 [28.384]
-– Paul (Umiker), Fürsprecher [Münsingen
-81.117], Waisenhausplatz 4 [21.933]
+– Paul (Umiker), Fürsprecher (Münsingen [81.117]), Waisenhausplatz 4 [21.933]
 – Paul (Mühlethaler), in Fa. Gottfr. Keller & Söhne, Neufeldstrasse 128 [23.651]
 – Rene, Ingenieur, Speichergasse 8 [35.869]
 – Robert Otto, Bureaulist, Magazinweg 8
@@ -23376,7 +23337,7 @@ Eisenbahndepartement, Gewerbestrasse 33
 Keller, Theodor gen. Josef, Herren- u. Damensalon (Optingenstrasse 46 [24.140]) Kornhaus [22.676]
 – Ulrich, Bahnarbeiter, Marktgasse 27
 – Walter, Beamter S. B. B., Fischerweg 18
-– Walter Rolf, Angestellter. Beaumontweg 17
+– Walter Rolf, Angestellter, Beaumontweg 17
 – Walter, Ingenieur, Aehistrasse 7 [36.625]
 – Walter Rob., Kommis, Bubenbergstr. 16a
 – Walter, Lehrer, Viktoriastrasse 41 [29.360]
@@ -23401,7 +23362,7 @@ Kellerhals, Alfred, Masch.-Techn., Seidenw. 24
 – Otto, Sektionschef, Habsburgstr. 14 [20.087]
 – Rud., Fürsprecher, Präs, der kant. Rekurskommission, Effingerstrasse 65 [28.009]
 Kellersberger, Armin, gew. Adjunkt bei der
-O. P. D.. Schanzeneckstrasse 15
+O. P. D., Schanzeneckstrasse 15
 Kellner, Alexis, Karosserie-Fachmann. Lerberstrasse 14 [21.073]
 Keltz, Alb., Coiffeurgeschäft, Bümplizstr. 130 [46.273]
 – Robert, Coiffeur, Bümplizstrasse 130
@@ -23444,7 +23405,8 @@ Kernen, Ernst Joh. Jak., Kaufmann, Hallerstrasse 54 [28.585]
 – Rudolf, Hilfsarbeiter, Brunnhofweg 23
 Kerwand, Maurice Louis, kaufm. Angestellter, Chutzenstrasse 17
 Keser, Karl Aug., Sekretär, Elfenstrasse 18a [28.108]
-– Gustav, Taucher, Freiburgstrasse 69von Kessel, Albrecht, Sekr. der deutschen Gesandtschaft, Hotel Beau-Site
+– Gustav, Taucher, Freiburgstrasse 69
+von Kessel, Albrecht, Sekr. der deutschen Gesandtschaft, Hotel Beau-Site
 Kesselring, Gottl., Maschinenmonteur, Rodtmattstrasse 77
 – Irma (Riotte), Wwe., Sulgeneckstrasse 8 [28.911]
 – Math., Bureaulistin, Wylerstrasse 71
@@ -23457,7 +23419,6 @@ Kessi, Franz Ernst, Angest., Freiestrasse 57
 Kessler, Alois Ernst, Magaziner, Gerechtigkeitsgasse 49
 – Arthur, Elektr.-Monteur, Kasernenstr. 41
 – Camille Wolfgang, Musiklehrer, Gurteng. 4
-Umbauten erfordern den Rat des er- Gebr. Keller, Architektenfahrenen u. gewissenhaften Architekten s P it a igasse 20 Tel. 23.204
 # Date: 1935-12-15 Page: 26020555/250
 Kessler, Christ. (Stäheli), Rev.-Bureauchef b.der O. P. D., Wabernstrasse 22 [24.133]
 – Emil, Angestellter, Gotthelfstrasse 20
@@ -23476,25 +23437,25 @@ Keusen, A. (Maurer), Zigarrenhdlg. (Gesellschaftsstrasse 41), Länggassstr. 30 [
 – Ad., Buchdrucker, Thunstrasse 17
 – Anna Elis. (Gerber), Wwe., Privatiere, Gesellschaftsstrasse 41
 – Ernst, Coiffeurgeschäft für Herren und Damen (Gesellschaftsstrasse 41), Schauplatzgasse 4 [36.652]
-– Ernst Fritz. Hilfsarbeiter. Länggassstr. 57
+– Ernst Fritz. Hilfsarbeiter, Länggassstr. 57
 – Ernst, Schweinemästerei, Forsthausweg 14
 – Fr., Gärtner, Brunnmattstrasse 67
-– Friedr.. Postangest.. Gesellschaftsstr. 16
+– Friedr., Postangest., Gesellschaftsstr. 16
 – Fritz. Kondukteur der S B. B., Länggassstrasse 94
 – Gottl., Abwart, Gutenbergstrasse 4
 – Hans, Vermessungstechniker, Länggassstrasse 99
 – Hermann. Koch. Greyerzstrasse 49
-– Joh.. Höheweg 13
+– Joh., Höheweg 13
 – Karl, Magaziner, Laubeckstrasse 194
 – Lina (Glaus). Spezereihandlung (Höheweg 13), Muristrasse 69
 – Marie Luise, Freiburgstrasse 45
 – Otto. Bureaulist. Gesellschaftsstrasse 41
 – Werner, Packer, Laubeckstrasse 194
 – Familie, Kolonialwarenhandlung, verlängerte Laubeckstrasse 194 [21.722]
-Keust, Hans Bernh., Vertreter. Berehtoldstrasse 5 [28.037]
+Keust, Hans Bernh., Vertreter, Berehtoldstrasse 5 [28.037]
 Khalatbary, A., Sekr. der iranischen Gesandtschaft, Seminarstrasse 30
 Kiefer, Hans (Gosteli), Bohrer. Scheibenstrasse 19a
-– Mathilde El.. Angestellte. Lilienweg 17
+– Mathilde El., Angestellte. Lilienweg 17
 – Th., Lokomotivführer, Lilienweg 17
 Kieffer, Gaston, Techniker b. eidg. Amt für
 Wasserwirtschaft. Lorbeerstr. 4, Bümpliz
@@ -23525,13 +23486,13 @@ Kiener, Ad., Fabrikarbeiter, Sidlerstrasse 5
 – Ernst, Handlanger, Gerbergasse 30
 – Ernst Albert, Schulinspektor, Daxeihoferstrasse 1 [27.250]
 – Frieda, Einlegerin, Ulmenweg 9
-– Friedr., Bauamtarbeit., Weissensteinstr. la
+– Friedr., Bauamtarbeit., Weissensteinstr. 1a
 – Friedr., Handlanger, Freiburgstrasse 52
 – Friedr., Postangest., Kehrg. 29, Bümpliz
 – Friedr., Reparateur, Belpstrasse 47
 – Friedr., Schreiner, Holligenstrasse 43
 – Fritz, Quartieraufseher des 4. Bezirks, Kirchenfeldstrasse 29 [20.456]
-– Fritz, Cafe Kiener-Ziegler, Gerechtigkeitsgasse 16 r24.791]
+– Fritz, Cafe Kiener-Ziegler, Gerechtigkeitsgasse 16 [24.791]
 – Fritz, Steigerweg 15 [22.748]
 – Gottfr., Artist, Gerbergasse 30
 – Gottfr., pens. Gasarbeiter, Ulmenweg 9
@@ -23580,7 +23541,7 @@ Kiesinger, Alb., Herrenkleidergeschäft, Aarbergergasse 36
 – Wilh., Autofahrschule, Sickingerstrasse 3 [22.397]
 Kihm, Herm. Ernst, Beamter S. B. B., Brückfeldstrasse 41
 Kilchenmann, Bertha Hanna, Bureaulistin, Parkstrasse 13 [27.378]
-– Bertha (Schönmann), Wwe.. Parkstr. 13
+– Bertha (Schönmann), Wwe., Parkstr. 13
 — Charles H., in Fa. Boivin, Kilchenmann & Co., Viktoriarain 17 [25.670]
 – Ghr., Sanitätspolizist, Spitalgasse 14 [33.902]
 – Eduard, Dr. phil., Privatdozent, Gymnasiallehrer, Effingerstrasse 37
@@ -23588,7 +23549,7 @@ Kilchenmann, Bertha Hanna, Bureaulistin, Parkstrasse 13 [27.378]
 – Ernst, Lokomotivführer, Lentulusstrasse 44
 – Franz, Schriftsetzer, Armandweg 11
 – Friedr., Hilfsarbeiter, Schärerstrasse 21
-– Friedr.. in Fa Kilchenmann & Finger, Schwarzenburgstrasse 14a
+– Friedr., in Fa Kilchenmann & Finger, Schwarzenburgstrasse 14a
 – Hermann, Alkoholfreies Restaurant zum Lamm, Metzgergasse 70
 – Joh., Landwirt, Wabernstrasse 49
 – K., eidg. Beamter, Wyttenbachstrasse 32 [28.467]
@@ -23611,12 +23572,12 @@ Kilchör, Alice E. H., Fabrikarbeiterin, Mühlemattstrasse 36
 – Joh., Zugführer B. L. S., Mittelstrasse 40
 Kilgus, David Fr., Zimmermann, Weidgasse 7, Bümpliz
 – Johanna L., Damenschneiderin, Mattenenge 15
-– K. P.. Schmied-Vorarbeiter, Mattenenge 15
-Kilian, A. K., Frl.. Privatiere, Zeughausg. 31
+– K. P., Schmied-Vorarbeiter, Mattenenge 15
+Kilian, A. K., Frl., Privatiere, Zeughausg. 31
 – Frieda. Kunststopferin, Effingerstrasse 53
 Kimche, Max, Dr. jur., Rechtsanwalt (Gutenbergstrasse 12), Spitalgasse 35 [33.421]
 Kinder- und Frauenschutz, Sekretariat und Rechtsauskunftstelle: Dr. Zehnder, Fürspr., Marktgasse 17 [34.666]
-Kindergarten, städt., Neufeldstr. 8 [27.9491
+Kindergarten, städt., Neufeldstr. 8 [27.949]
 – Breitfeld, Wylerfeld 23 [24.474]
 Kindprheim Sonnenblick, Haspelweg 42 [21.285]
 Kinder-Krippen: Fricktreppe 13 [32.981], Altenbergstr. 9 [32.565], Murifeld, Mindstrasse 3 [33 627], Lorrainestr. 80 [32.625], Wylerringstr. 52 [32.936], Länggassstr. 6 [24.638], Mattenhofstr. 40 [33.606], Krippenstrasse 28 (Ausserholligen) [22.948], Bümpliz [46.025]
@@ -23665,19 +23626,19 @@ Kipfer, Adolf, in Fa. L. Fankhauser & Cie., Seidenweg 34
 – Fr., Spezereihandlg., Stöckackerstrasse 61, Bümpliz [46.167]
 – Friedr., Mechaniker, Bümplizstrasse 19
 – Fritz, internationaler Möbeltransp., Zeughausgasse 22, Lagerhaus Ostermundigen [22.033]
-— Fritz, kaufm. Angest,, Florastrasse 19
+— Fritz, kaufm. Angest., Florastrasse 19
 – Gertrud (Stämpfli), Lehrerin, Erlenweg 10 [31.631]
 – Hans Fritz, Maler, Postgasse 28
 – Hans O., kaufm. Angest., Zeughausgasse 22
-– Herm. Otto, Angestellter. Muristrasse 93
+– Herm. Otto, Angestellter, Muristrasse 93
 – Ida (König), Wwe., Rabbentalstrasse 45
 – Jakob, Wasserleitungsunternehmer (Bremgarten [33.379]), Stockerenweg 1 [32.748]
-– Jakob, pens. Bauamtarbeiter. Wylerringstrasse 52a
+– Jakob, pens. Bauamtarbeiter, Wylerringstrasse 52a
 – Jakob (Blaser), Handlang., Waldheimstr. 45
 – Joh., Angest der städt. Brandwache, Steigerweg 16 [29.158]
 – Joh., Giesser. Bümplizstrasse 19
 – Joh., Handlanger, Ladenwandstrasse 88
-– Karl Friedr.. Schriftsetzer, Laupenstr. 12d
+– Karl Friedr., Schriftsetzer, Laupenstr. 12d
 – Karl, pens Bronzeür, Laupenstrasse 12d
 – Margr., Bureaulistin, Haspelweg 40
 – Margaretha Lina, Damenschneiderin, Bümplizstrasse 19
@@ -23701,7 +23662,7 @@ Kirchhof er, Anna Maria, Frau, Länggassstrasse 99
 – Hans, Hilfsarbeiter, Wachtelweg 11
 – Hermine. Glätterin, Freiburgstrasse 18
 – Ida Rosa, Telephonistin, Alpeneckstr. 7
-– Ida, Ladentochter. Wachtelweg 11
+– Ida, Ladentochter, Wachtelweg 11
 – Jean A., Lehrer, Effingerstrasse 50
 – Jean Rene, Mechaniker, Lentulusrain 18
 – Lina, Ladentochter, Wachtelweg 11
@@ -23733,7 +23694,7 @@ Kirtsch, Anna, ungarische Gesandtschafts-Kanzleisekretärin, Feldeggweg 1 [26.06
 Kislig und Kisslig
 – Alfred, Dachdecker, Stöckackerstrasse 108, Bümpliz
 – Chr., Händler, Rehhagstr. 13, Bümpliz
-– Ernst. Fabrikarbeiter. Breiteweg 6
+– Ernst. Fabrikarbeiter, Breiteweg 6
 – Ernst, Hilfsarbeiter, Pestalozzistrasse 34
 – Ernst, Malerei, Gipserei, Glasschilder (Hotelgasse 14/Kasinoplatz [33.858]), Thunstrasse 4
 # Date: 1935-12-15 Page: 26020558/253
@@ -23767,7 +23728,7 @@ Kissling, Albrecht Ad., Karrer, Gerbergasse 38
 – Arnold, Hilfsarbeiter, Stöckackerweg 78, Bümpliz
 – Friedr., Schuhmacher, Effingerstrasse 88
 – Hans, Konstrukteur, Waldhöheweg 7a [32.159]
-– Herm., Beamter d S. B. B.. Schulweg 2a
+– Herm., Beamter d S. B. B., Schulweg 2a
 – Hermine Anna, Verkäuferin, Kirchenfeldstrasse 39
 – Ida, Jurastrasse 4
 – J. (Furrer), Agenturen, Kirchenfeldstr. 39 [36.387]
@@ -23806,7 +23767,7 @@ Kläfiger, Erhard, Angestellter, Mühlemattstrasse 58
 – Hs. Ed., Hilfsarbeiter, Mühlemattstr. 58
 – K. Walter, Mühlemattstrasse 58
 – Kurt, Chauffeur, Schwarzenburgstrasse 8
-– Walter Wilh., Bahnarb.. Mühlemattstr. 58
+– Walter Wilh., Bahnarb., Mühlemattstr. 58
 Kläger, Hedwig Olga, Verkäuferin, Felsenaustrasse 26
 – J. J., Schlosser, Felsenaustrasse 26
 Klaiber, Fr. Wilh., eidg. Beamter, Morillonstrasse 30 [26.318]
@@ -23900,8 +23861,8 @@ Kleeb, Anna Marie (Isler), Wwe., Genferg. 7
 – Helene, Angestellte, Kesslergasse 17
 – Lisette, Glätterin, Armandweg 14
 – Martha, Knabenschneiderin, Armandw. 14
-Kleefeld, Ferd. M., Schreibmaschinen u. Bureauartikel (Frohbergweg 11), Spitalg. 30f33.980]
-– Ferd. Max, kaufm. Angest., Frohbergw.il
+Kleefeld, Ferd. M., Schreibmaschinen u. Bureauartikel (Frohbergweg 11), Spitalg. 30 [33.980]
+– Ferd. Max, kaufm. Angest., Frohbergw. il
 Klein, Anna (Flühmann), Wwe., Eggimannstrasse 20
 – Arnold Max, Kommis, Junkemgasse 3
 – Emil, Korb- u. Sesselflechter, Altenbergstrasse 36a
@@ -23909,7 +23870,7 @@ Klein, Anna (Flühmann), Wwe., Eggimannstrasse 20
 – Fritz Rob., Hilfsarbeiter, Mühleplatz 2
 – Hans Otto, Monteur, Eggimannstrasse 20
 – Margaretha, Serviertocht., Storchengässli 5
-– Richard Jos.. Angestellter, Hopfenweg 44
+– Richard Jos., Angestellter, Hopfenweg 44
 – Walter, Elektro-Ing., Optingenstrasse 29
 Kleiner, Alfred, Fabrikarbeiter, Läuferplatz 6
 – Dori, Bureaulistin, Monbijoustrassse 121
@@ -24040,11 +24001,11 @@ Knapp, Ad., Oberfeueraufseher. Bantigerstrasse 33 [32.225]
 – Else, Ladentochter, Breitfeldstrasse 3
 Knaus, Anna, Frl., Assistentin am tellur.
 Observatorium, Sidlerstrasse 5
-Knecht, Alfr., Einzüger, Talweg la
+Knecht, Alfr., Einzüger, Talweg 1a
 – Arnold, pens. Pferdewärter, Breitenrainstrasse 37
 – Edwin, Sattler- u. Tapezierermstr. (Tscharnerstrasse 3), Murtenstrasse 43
 – Emma Bertha, Filialleiterin, Militärstr. 39
-– Ernst Wilh.. in Fa. Knecht-Flückiger & Co., Effingerstrasse 39
+– Ernst Wilh., in Fa. Knecht-Flückiger & Co., Effingerstrasse 39
 – F. A. (Liechti), Berchtoldstrasse 38
 – H. (Straub), Kaufm., Breitenrainplatz 40c
 – Hans, March.-Tailleur, Monbijoustrasse 27 [35.404]
@@ -24066,7 +24027,7 @@ Kneubühl, Aline, Damenschneid., Neubrückstrasse 171
 – Ernst, Gärtner, Sandrainstrasse 7
 — Friedrich, Gärtner, Kirchbergerstrasse 1
 – Gottfr., pens. Bahnarbeiter, Jurastrasse 15t— Gottfr., Polizist, Flurstrasse 33
-— Gottfr., Spezereihandlung, Hopfenweg 18 [36.5031
+— Gottfr., Spezereihandlung, Hopfenweg 18 [36.503]
 — Hans, Schlosser, Beundenfeldstrasse 41
 — Ida, Kinderpflegerin, Marienstrasse 11
 — Paul Christ., Bureaulist, Beundenfeldstrasse 41
@@ -24088,7 +24049,7 @@ Kneubühler, Bertha Anna, Ladentochter, Länggassstrasse 29
 – Olga, Bureaulistin, Holzikofenweg 31
 – Otto, Zeichner E. W. B., Balderstrasse 23
 – Samuel, Kohlenarbeiter, Mittelstrasse 32
-Kneuss, Andre Jules, Bankbeamter. Tscharnerstrasse 7
+Kneuss, Andre Jules, Bankbeamter, Tscharnerstrasse 7
 – Karl Ulysfje, Kommis, Mittelstrasse 23
 – Gottfried, Giesser, Muldenstrasse 55
 – Gottfried, W., Ausläufer, Engehaldestr. 73
@@ -24115,7 +24076,7 @@ Knobelspiess, Friedr. O., Konditor, Waldheimstrasse 40
 Knoblauch, Jak. Rud., Angest., Wagnerstr. 35
 – Paul, Beamter S. B. B., Hauensteinweg 34 [45.482]
 Knoblich, Elsa, Damenschneiderin, Elisabethenstrasse 19
-– G. M Herm.. Konditor, Standstrasse 17
+– G. M Herm., Konditor, Standstrasse 17
 – Paul Herm., Photograph, Standstrasse 17
 # Date: 1935-12-15 Page: 26020562/257
 Knoll, Alois Rieh., kaufm. Angest., Tscharnerstrasse 43
@@ -24129,7 +24090,8 @@ Knoerr, Carl (Gallenschütz), Kaufmann, Effingerstrasse 91 [21.669]
 – Rosalie, Frl., Wabernstrasse 38 [28.250]
 Knörri, Ad., Zimmermann, Standstrasse 32
 – A. M. (Pamseyer), Wwe., Lentulusstr. 50 [21.558]
-— Gottfr., Maurer, Nydeckgasse 17v. Knorring, Helge, I. Sekr. der finn. Gesandtschaft, Sommerlust, Wabern
+— Gottfr., Maurer, Nydeckgasse 17
+v. Knorring, Helge, I. Sekr. der finn. Gesandtschaft, Sommerlust, Wabern
 Knuchel, Ernst, Hausierer, Metzgergasse 44
 – Ernst, Direktor des Buchhaltungsbureau Rita, Friedheimweg 49 [32.013]
 – E., & Iseli, Inseraten-Vermittlungsbüro «Royal», Genfergasse 3 [32.013]
@@ -24137,7 +24099,7 @@ Knuchel, Ernst, Hausierer, Metzgergasse 44
 – Friedr., Maurer, Jurastrasse 51
 — Hans Rud., Angestellter, Klaraweg 31
 – Herm. N., eidg. Beamter, Lentulusstr. 42
-– Herm.. Depotarbeiter S. S. B.. Bahnhöheweg 36, Bümpliz
+– Herm., Depotarbeiter S. S. B., Bahnhöheweg 36, Bümpliz
 – Jak., Hilfsarb., Engehaldenstr. 73 [24.718]
 – Jak., Maurer, Engehaldenstr. 73 [24.718]
 – Joh., gew. Geschäftsführer. Werdtweg 19 [35.523]
@@ -24145,16 +24107,17 @@ Knuchel, Ernst, Hausierer, Metzgergasse 44
 — Max Hermann, Gärtner, Bahnhöheweg 36, Bümpliz
 – Maximilian W., Dr. med., Spezialarzt fürinnere Krankheiten F. M. H., besonders
 Lungenkrankheiten, Hallerstr. 2 [28.785]
-– Paul, Revisor, Stapfenackerstr. 40, Bümplizt —Rud., Früchte- u. Gemüsehandlg. en gros (Rodtmattstr. 93), Kesslergasse 2 [25.396]
+– Paul, Revisor, Stapfenackerstr. 40, Bümpliz
+— Rud., Früchte- u. Gemüsehandlg. en gros (Rodtmattstr. 93), Kesslergasse 2 [25.396]
 – Rudolf, Zigarrengeschäft (Schanzeneckstrasse 19), Zeitglockenlaube 4
-– Walter (Stucki), Länggass-Apotheke (Neu» brückstrasse 80 [32.705), Länggassstr. 28
-? [22.322]
+– Walter (Stucki), Länggass-Apotheke (Neubrückstrasse 80 [32.705]), Länggassstr. 28 [22.322]
 – Walter Otto, Magaziner, Mattenenge 18
 – Walter, Reitlehrer im eidgen. Remonten-Depot, Klaraweg 31
-– Walter, Gehilfe, Gesellschaftsstrasse 90l —Walter. Spengler, Engehaldenstrasse 73
+– Walter, Gehilfe, Gesellschaftsstrasse 90l
+— Walter, Spengler, Engehaldenstrasse 73
 – & Vogt, Pension Berna, Schanzeneckstr. 17 [22.065]
 Knüsel, Alh. Leo, Schulabwart, Brünnenstrasse 40. Bümpliz
-. — Geschwister. Blumengeschäft (Köniz-Gartenstadt [45.234]), Mühlemattstrasse 66 [21.178]
+— Geschwister, Blumengeschäft (Köniz-Gartenstadt [45.234]), Mühlemattstrasse 66 [21.178]
 Knüsli, Konrad, pens. Beamter der S. B. B., Stauffacherstrasse 5
 – Max C., Kommis, Viktoriastrasse 45
 Oskar Konrad, kfm. Angest., Sennweg 17
@@ -24167,7 +24130,7 @@ Knutti, Alfred, Pferdewärter, Allmendstr. 50
 «KOBAG», Kollektiv-Bau- und Ablösungs-Genossenschaft, Basel, Geschäftsstelle fürden Kanton Bern, Neuengasse 39 [28.011]
 Kobel, Adolf, Hausierer, Murtenstrasse 24
 – Adolf, jun., Handlanger, Murtenstrasse 24
-– Chr., Rangiermeister S. B. B.. Stöckackerstrasse 96, Bümpliz
+– Chr., Rangiermeister S. B. B., Stöckackerstrasse 96, Bümpliz
 – Chr., Schlosser, Stöckackerstr. 96, Bümpliz
 – Elisabeth (Rindlisbacher), Wwe., Elisabethenstrasse 26
 – Ernst. Heizer, Altenbergstrasse 35
@@ -24181,7 +24144,7 @@ Kobel, Adolf, Hausierer, Murtenstrasse 24
 – Fritz, Emil, Maurer, Brunngasse 8
 – Hans (Hänni), Bäckerei und Kaffeestube, Gerechtigkeitsgasse 1 [21.486]
 – Hans, Chauffeur, Lentulusstrasse 30
-– Hans, Hilfsarbeiter. Brunnhofweg 26
+– Hans, Hilfsarbeiter, Brunnhofweg 26
 – Hedw., Aushilfe, Stöckackerstr. 81, Bümpliz
 – Hermann, Hilfsarbeiter, Stöckackerstr. 96, Bümpliz
 – Hermann, Prokurist, Könizstrasse 71
@@ -24189,7 +24152,7 @@ Kobel, Adolf, Hausierer, Murtenstrasse 24
 – Joh., Angestellter, Weissensteinstrasse 74
 – Joh., Bahnarbeiter, Bahnstrasse 57
 – Joh., Coiffeur, Stöckackerstr. 81, Bümpliz
-– Joh., Giessereiarheiter. Fischermätteliw. 2
+– Joh., Giessereiarheiter, Fischermätteliw. 2
 – Joh., Handlanger, Murtenstrasse 30
 – Jos., Bauunternehmer. Stöckackerstr. 97, Bümpliz [46.086]
 – Karl, Angestellter, Jennerweg 7
@@ -24197,7 +24160,7 @@ Kobel, Adolf, Hausierer, Murtenstrasse 24
 – Kurt Emil, Prov.-Reisender, Forstweg 71
 – Nikl., Aufseher, Könizstrasse 71
 – Nikl., Maurer, Stöckackerstr. 81, Bümpliz
-– Rosa (Frey), Wwe.. Kunststein- u. Steinhauergeschäft (Könizstrasse 71 [33.667]), Weissensteinstrasse 31 [21.095]
+– Rosa (Frey), Wwe., Kunststein- u. Steinhauergeschäft (Könizstrasse 71 [33.667]), Weissensteinstrasse 31 [21.095]
 – Rudolf, Kaufmann, Könizstrasse 71
 – Rud., Zementer, Freiburgstr. 354, Bümpliz
 – Rud., Hilfsarbeiter, Altenbergstrasse 37
@@ -24269,7 +24232,7 @@ Kocher, Alb., Dr. med., Privatdozent für Chirurgie, Laupenstrasse 25 [21.210], 
 – Emil, Gasarbeiter, Tannenweg 21
 – Emil (Jenni), Stadtmissionar, Berchtoldstrasse 29
 – Ernst Ad., Ausläufer, Waffenweg 23
-– Ernst, Radio-Grammophongesch. (Tiefenaustrasse 56 [27.488], Spitalgasse 36b, Eingang v. Werdt-Passage [27.588]
+– Ernst, Radio-Grammophongesch. (Tiefenaustrasse 56 [27.488]), Spitalgasse 36b, Eingang v. Werdt-Passage [27.588]
 – Ernst, Steindrucker, Lentulusrain 26
 – Friedr., Elektrotechn., Mittelstr. 60 [32.006]
 – Friedr., Maschinist, Tiefenaustrasse 56
@@ -24428,7 +24391,7 @@ Köhler, s. auch Koller
 — Paul (Gasche), Maler, Wachtelweg 13
 – Paul, Mechaniker, Spitalackerstrasse 72
 – Paul Emil, Pförtner, Freiburgstrasse 18i— Paul, Prokurist, Muldenstrasse 29
-– R.. Wwe., Angestellte, Elisabethenstr. 35
+– R., Wwe., Angestellte, Elisabethenstr. 35
 — Roger G. Arth. (Clerc), Photograph, Murtenstrasse 137i
 — Roland Hubert, Radiotechn., Steinerstr. 39
 – Rosa, Damenschneiderin, Alleeweg 35
@@ -24521,7 +24484,7 @@ Koka, Fr., Schneider, Tannenweg 15
 Kolarik, Anton, Schlosser, Flurstrasse 5
 Kolatschewsky, Valerius, Dr. phil., Gymnasiallehrer, Scheuermattweg 6 [36.826]
 Kolb, A., Bureauangestellter, Rosenweg 13
-– Adolf Phil.. Mechaniker. Flurstrasse 14
+– Adolf Phil., Mechaniker. Flurstrasse 14
 – Denise F., Bureaulistin, Brunnadernstr. 32a
 – Emil, pens. Bankbeamter, Länggassstr. 68b
 – Emilia Pauline, Manglerin, Murifeldw. 62
@@ -24581,8 +24544,8 @@ König, s. auch Küng
 – Anna Augusta, Damenschneiderin, Gutenbergstrasse 19
 – Anna (Wild), Wwe., Marktkrämerin, Aarbergergasse 50
 – Bertha, Frau, Denzlerstrasse 8
-– Bertha. Lingerie. Engeriedweg 11 [27.5471
-– Dora, Pflegerin, Marienstrasse 31 [31.4321
+– Bertha, Lingerie, Engeriedweg 11 [27.547]
+– Dora, Pflegerin, Marienstrasse 31 [31.432]
 – Eduard (Koller), Dr. med., Arzt, Moserstrasse 42 [32.070]
 – Emil, Coiffeur, Beundenfeldstrasse 57
 – Emil, Dr. phil., gew Direktor des eidg. Amtes für Mass und Gewicht, Jubiläumsstr. 41 [25.028]
@@ -24593,7 +24556,7 @@ König, s. auch Küng
 – Erich Ed., Ingenieur, Moserstrasse 42
 – Ernst, Rütlistrasse [21.566]
 – Ernst Alb., Pächter, Stegenw. 21, Bümpliz
-– Erwin August,, Elektromonteur, Pestalozzistrasse 38
+– Erwin August., Elektromonteur, Pestalozzistrasse 38
 – Frieda, Hilfsarbeiterin, Blockweg 11
 – Fritz, Dr, med., Spezialarzt f. Geburtshilfeu. Frauenkrankheiten, Laupenstrasse 41 [23.950]
 – Fritz, Schuhmacher, Mattenenge 5
@@ -24634,7 +24597,7 @@ König, siehe auch Küng
 – Werner, Chauffeur S. O. B., Blockweg 11
 – Werner, Metzgermstr. (Blumensteinstr. 9), Gewerbestrasse 18 [24.556]
 – Willy (Schlupp), Dr. jur., Privatdoz., Vize-Direktor S. M. V. G., Scheuermattweg 14 [20.636]
-– & Bielser, Motorräder, Velos, Nähmasch., Beundenfeldstr. 21 [22.1001; Nähmasch.-Filiale: Hirschengraben 2 [22.200]
+– & Bielser, Motorräder, Velos, Nähmasch., Beundenfeldstr. 21 [22.100]; Nähmasch.-Filiale: Hirschengraben 2 [22.200]
 Königs, Waiter, Oberstlt., Kavallerie-Instr., Humboldtstrasse 33 [29.965]
 Könitzer, E. (Niederhäuser), Wwe. des Reg.-Rates, Hallwylstrasse 42 [31.906]
 – Gottfr. (Oswald), Hilfsarb., Rodtmattstr. 101
@@ -24655,7 +24618,7 @@ Konrad, s. auch Conrad
 – Viktor Emil, Kaufmann, Freiburgstr. 125
 – Werner Heinr., Musiker, Güterstrasse 44
 Konservatorium für Musik, Kirchgasse 24 [28.277]
-Konsulatskanzlei von Albanien, Neueng. 20 [23.2321
+Konsulatskanzlei von Albanien, Neueng. 20 [23.232]
 – von Argentinien, Seidenweg 32 [28.619]
 – von Belgien, Hotellaube 8 [21.644]
 – des Britischen Reiches. Bundesplatz 2 [24.108]
@@ -24676,7 +24639,7 @@ Konsulatskanzlei von Albanien, Neueng. 20 [23.2321
 – von Oesterreich, Laupenstrasse 5
 – von Paraguay, Marktgasse 37 [28.287]
 – von Polen, Elfenstrasse 20 [21.013]
-– von Portugal, Amthausgasse 6 . [23.032]
+– von Portugal, Amthausgasse 6 [23.032]
 – von Schweden, Monbijoustr. 32 [31.675]
 – von Spanien, Kasinoplatz 2 [21.638]
 – der Türkei, Bubenbergplatz 8 [21.616]
@@ -24737,7 +24700,7 @@ Kormann, Fr., Landwirt, Matzenriedstr. 161, Oberbottigen
 – Hans, Landwirt, Matzenriedstrasse 161, Oberbottigen
 – Hans, Landwirt, Rosshäusernstrasse 72, Bümpliz
 – Hedw. El., Bureaulistin, Münsterplatz 1
-– K. Friedr.. gew. Schlossermeister, Aarbergergasse 61
+– K. Friedr., gew. Schlossermeister, Aarbergergasse 61
 – Marg., Schneiderin, Marzilistrasse 12a
 – Maria (Stauffer), Wwe., Brünnenstr. 121, Bümpliz
 – Martha, Ladentochter, Breitfeldstrasse 52
@@ -24748,9 +24711,9 @@ Kormann, Fr., Landwirt, Matzenriedstr. 161, Oberbottigen
 – Walter, Schlosser, Kehrgasse 10, Bümpliz
 – Werner, Architekturbureau. Brünnenstrasse (121 [46.2301), H5, Bümpliz [46.230]
 – Werner, Hilfsarb., Kehrgasse 10, Bümpliz
-.— Willy Paul, Elektromech., Schreinerweg 23
+— Willy Paul, Elektromech., Schreinerweg 23
 Kornag A.-G., Liegenschaftenhandel, Zeughausgasse 9
-Körner, C. H.. Ing., Schwarztorstrasse 18 [33.557]
+Körner, C. H., Ing., Schwarztorstrasse 18 [33.557]
 – Dora Renate, Modistin, Schwarztorstr. 18
 – Emma, Modistin (Schwarztorstrasse 18 [33.557]), Marktgasse 31 [34.182]
 Kornfein, Friedr. Ignaz, Commis, Effingerstrasse 9
@@ -24816,7 +24779,7 @@ Krähenbühl, s. auch Kreienbühl
 – Friedr., Hilfsarbeiter, Freiburgstrasse 75
 – Friedr., Magaziner, Frohbergweg 8
 – Friedr. (Klossner), Polizeigefreiter, Herzogstrasse 15
-– Friedr., Postangestellter. Blumenweg 1
+– Friedr., Postangestellter, Blumenweg 1
 – Friedr., Telegr.-Angestellter, Muristr. 73
 Krähenbühl, s. auch Kreienbühl
 – Friedr., Zimmermeister, Jurastrasse 5 [34.752]
@@ -24827,7 +24790,7 @@ Krähenbühl, s. auch Kreienbühl
 – Gertrud A., Bureaulistin, Simplonweg 29
 – Gertrud Margr., Bureaulistin, Eigerweg 7
 – Gertrud, Verkäuferin, Bubenbergstrasse 5
-– Gottfr., Postangestellter. Bubenbergstr. 5
+– Gottfr., Postangestellter, Bubenbergstr. 5
 – Gottfr., Thuustrasse 22
 – — Gottl. Gottfr., Packer, Breitenrainstr. 33
 – Gottl., Zimmermann, Bierhübeliweg 31
@@ -24844,9 +24807,9 @@ Krähenbühl, s. auch Kreienbühl
 – Herm. Frz., Elektriker. Landweg 8
 – Huldreich Edm., Angestellter, Herzogstr. 15
 – Ida, Bureaulistin, Thunstrasse 22
-– Jakob, Bahnarbeiter. Muldenstrasse 55
+– Jakob, Bahnarbeiter, Muldenstrasse 55
 – Joh. Friedr., Käfiggässchen 32
-– Joh., Bahnarbeiter. Blockweg 5
+– Joh., Bahnarbeiter, Blockweg 5
 – Johann, Bautechniker, Kasthoferstrasse 12
 – Joh., Wagenmaler, Simplonweg 29
 – Johanna, Bureaulistin, Rütlistrasse 14
@@ -24909,7 +24872,8 @@ Kramer, Anna (Stöcker), Wwe., Thunstr. 11
 – Simone Lina, Ladentochter, Zeigerweg 5
 – W. Rud., Beamter der eidg. Finanzkontrolle, Optingenstrasse 44 [32.295]
 Kramis, Alfr., Pfarrer, Luisenstr. 6 [21.218]
-– Rosa Margaretha, kaufm. Angest., Luisenstrasse 6v. Kranichfeld, Glementina El., Bureaulistin, Schwanengasse 7
+– Rosa Margaretha, kaufm. Angest., Luisenstrasse 6
+v. Kranichfeld, Glementina El., Bureaulistin, Schwanengasse 7
 – Ed., Kanzleisekretär, Viktoriastrasse 55
 Krankenanstalt Tiefenau, städt., Tiefenaustrasse 116 [20.473]
 Krankenhilfe Bern und Umgebung. Meldestelle: Frl. Messmer, Olga, Masseuse, Effingerstrasse 49 [32.842]
@@ -25040,11 +25004,10 @@ Krebs, Adolf, Bahnarbeiter, Morgenstrasse 6, Bümpliz
 – F. A. (Gmünder), Coiffeurgeschäft, Waaghausgasse 6 [35.396]
 – Fr., Beamter der Direktion der soz. Fürsorge, Ostermundigenstrasse 20 [27.263]
 – Franz, Angestellter, Brünnenstrasse 77, Bümpliz
-Der zuverlässige Fahrplanfür Bern, in die nähere und weitere Umgebung istder Touristen - Fahrplan ( Verlag Hallwag, Bern), der Ihnen auch interessante Aufschlüsse Uber genussreiche Touren gibt.
 # Date: 1935-12-15 Page: 26020572/267
 Krebs, Frieda, Kassierin, Neuengasse 16
 – Frieda A., Ladentochter, Mittelstrasse 64
-– Friedr. (Wüest), Alkoholfreies Restaurantz. Gutenberg, Monbijoustrasse 26 [21.653]
+– Friedr. (Wüest), Alkoholfreies Restaurant z. Gutenberg, Monbijoustrasse 26 [21.653]
 – Friedr., Badaufseher, Morillonstrasse 30
 – Friedr. Rob., Goldschmied, Wagnerstr. 29
 – Friedr. Ernst, kfm. Angest., Morillonstr. 30
@@ -25061,7 +25024,7 @@ Krebs, Frieda, Kassierin, Neuengasse 16
 – Gottfr., Beamter, Stauffacherstrasse 31
 – Gottfr., Beamter, Freiburgstr. 472, Bümpliz [46.605]
 – Gottfr., Schneider, Murifeldweg 81
-– Gottl., Fabrikarbeiter. Hochfeldstrasse 59
+– Gottl., Fabrikarbeiter, Hochfeldstrasse 59
 – Hans, Hilfsarbeiter, Lerchenweg 35
 – Hans, kaufm. Angest., Optingenstrasse 35
 – Hans, Kaufm., Kirchbühlweg 41 [32.660]
@@ -25069,10 +25032,10 @@ Krebs, Frieda, Kassierin, Neuengasse 16
 – Hans, Schlosser S. B. B., Federweg 29a
 – Hedw. Rosa, Bureaulistin, Polygonweg 13
 – Hedw. Alice, Bureaulistin, Ostermundigenstrasse 20
-– Hermann. Postbeamter. Tillierstrasse 34
+– Hermann. Postbeamter, Tillierstrasse 34
 – Ida B., Schneiderin, Tiefmattstrasse 10
 – Joh., Bureauangestellter, Bantigerstr. 18
-– Joh. Friedr., Hilfsarbeiter. Freiburgstr. 48
+– Joh. Friedr., Hilfsarbeiter, Freiburgstr. 48
 – Joh. Friedr., Tramangest., Seelibühlweg 15
 – Johanna Emma. Buchhalterin-Kass., Tiefmattstrasse 10
 – Karl, Biskuitfabr., Wabernstr. 91 [32.436]
@@ -25133,7 +25096,7 @@ Kreis, E. Otto, Masch.-Zeichner, Muristr. 89
 – Fritz, Bücherrevisor und Organisator (Monbijoustrasse 39 [28.026]), Hirschengraben 6 [24.906]
 – Fritz Walter, kaufm. Angest., Belpstr. 34
 – Klara Adelheid, Tapeziererin, Belpstr. 34
-– Konrad, eidg. Beamter. Brückfeldstr. 39
+– Konrad, eidg. Beamter, Brückfeldstr. 39
 – Otto, Musikdirektor, Gryphenhübeliweg 49 [32.425]
 – Paul, Milchträger, Belpstrasse 34
 Kreisforstamt VIII, Bern, Herrengasse 3 [27.211]
@@ -25144,7 +25107,7 @@ Kreispostdirektion, Dienstgebäude, Bollw. 10 [62]
 Krell, Martha Gertrud, Bureaulistin, Brunnhofweg 22
 – Otto, Handelsangestellter, Vennerweg 4
 Krematorium, Bremgartenfriedhof
-Kremer, Eug., Konzertmeister. Wabernstr. 5 [27.382]
+Kremer, Eug., Konzertmeister, Wabernstr. 5 [27.382]
 # Date: 1935-12-15 Page: 26020573/268
 Krenger, Chr., Dachdecker, Scheuerrain 6
 – Elisabeth. Telephonistin. Thunstrasse 2
@@ -25204,7 +25167,8 @@ Krisenabgabeverwaltung, Kant., Herreng. 15 [27.249]
 Kriesi, Walter, Polizist, Fellenbergstrasse 21
 Kriminalkammer d. Obergerichts, Ferdinand-Hodlerstrasse 7 [23.365]
 Krippen, s. Kinderkrippen
-Krneta, Ozren, Dr., T. J. Agentura, Handelsund Kreditvermittlung mit Jugoslawien, Aegertenstrasse 1 [22.8021v. Krogh, Anna El. A. (Gercke), Steinerstr. 33
+Krneta, Ozren, Dr., T. J. Agentura, Handels- und Kreditvermittlung mit Jugoslawien, Aegertenstrasse 1 [22.802]
+v. Krogh, Anna El. A. (Gercke), Steinerstr. 33
 Kroik, Chaida. Bureaulistin, Monbijoustr. 11
 – M. (Persitz), Angestellter, Monbijoustr.il
 Krompholz, Eduard, Kaufmann, Humboldtstrasse 7 [23.991]
@@ -25248,13 +25212,14 @@ Kropf, Marie Luise (Bühler), Wwe., Weissensteinstrasse 118 [29.539]
 – Rudolf (Jarretout), Zivilstandsbeamter, Florastrasse 22 [33.925]
 – Wilh., Vertreter, Karl-Schenkstrasse 5
 Kropfli, Alice, Ablagehalterin der K. G. B., Zielweg 29
-– Ed. (Lüthi), Bankbeamter. Scheibenstr. 15
+– Ed. (Lüthi), Bankbeamter, Scheibenstr. 15
 – Th., Oberlehrer der Primarschule Innere Stadt, Zielweg 29
 – W. (Hufschmid), Bücherexperte der kant.
 Rekurskommission, Thunstrasse 92
 Kröpfli, Adolf, Informationsbüro (Fiscliermätteliweg 21), Speichergasse 29
 – Marie (Käsermann), Privat., Höheweg 13
-Krüppel, Karl, Schäfer, Spitalackerstr. 16v. Krüdener, Ellen, Angestellte, Bubenbergstrasse 10
+Krüppel, Karl, Schäfer, Spitalackerstr. 16
+v. Krüdener, Ellen, Angestellte, Bubenbergstrasse 10
 Krug, Emil Bernh., Coiffeur, Herren- und Damensalon, Thunstrasse 6 [36.140]
 Krüger, Karl Jos., Wirt z. Rathaus, Rathausplatz 5 [36.183]
 Krüger, Raymond, Masseur, Zentralbad, Gurtengasse 4 [22.038]
@@ -25294,7 +25259,7 @@ Krütli, Fr., Graveur in Fa. Bücher & Krütli, Beatusstrasse 4
 «Kubag», Kohlen u. Brennholz A.-G. Bern, Neuengasse 39 [21.852]
 Kubick, Johanna (Käser), Wwe., Gutenbergstrasse 7 [29.183]
 – Pauline, Wwe., Wiesenstrasse 62
-Kühler, Charlotte Bertha. Helvetiastrasse 29
+Kühler, Charlotte Bertha, Helvetiastrasse 29
 – Christ. (Begert), Kolonialwarenhandlung, Tscharnerstrasse 47 [22.637]
 – Herm., Postbeamter, Melchthalstrasse 15
 – Hieron., Elektromechaniker, Randweg 9
@@ -25372,7 +25337,7 @@ Kuert, s. auch Kurt und Kurth
 – Johann Gottlieb, Wein- und Liqueurhandlung, Murtenstrasse 34a
 Kuert, s. auch Kurt und Kurth
 – Walter, Tapezierermeister, Muesmattstr. 45 [36.945]
-Küffer, E. (Dätwyler), Pension, Bollwerk 29 [22.1971
+Küffer, E. (Dätwyler), Pension, Bollwerk 29 [22.197]
 – Ernst, Handlanger, Freiburgstrasse 346, Bümpliz
 – Felix, eidg. Beamter, Waldheimstr. 49
 – Georg, Seminarlehrer, Florastrasse 17 [22.692]
@@ -25444,7 +25409,7 @@ Kuhn, Gottl., Werkmeister, Rodtmattstr 31
 – M. Gertrud (Gfeller), Wwe., Hubelmattstrasse 23
 – Marie (v. Jenner), Wwe., Kirchenfeldstrasse 24
 – Martha E. A., in Fa. M. & P. Kuhn, Monbijnustrasse 35
-– Matthäus J. (Kipfer), pens. Konsumangestellter. Alleeweg 32
+– Matthäus J. (Kipfer), pens. Konsumangestellter, Alleeweg 32
 – Maurice H., kaufm. Angest., Belpstrasse 51 [33.696]
 – Max (Humbel). Beamter d. eidg. Alkoholverwaltung. Kirchenfeldstr. 24 [29.959]
 – Max, Möbel- und Dekorationsgeschäft, Sulgenbachstrasse 46 [27.839]
@@ -25459,11 +25424,10 @@ Kuhn, Gottl., Werkmeister, Rodtmattstr 31
 – Robert, Fabrikarbeiter, Rodtmattstr. 67
 – Rosa, Beamtin, Florastrasse 23 [36.298]
 – Rud., Mag.-Gehilfe S. B. B., Gesellschaftsstrasse 84
-Kuhn, Theodor (Buchmann), Ing. des eidg.
-Amtes f. Wasserwirtschaft, Helvetiastr. 27 [31.600]
+Kuhn, Theodor (Buchmann), Ing. des eidg. Amtes f. Wasserwirtschaft, Helvetiastr. 27 [31.600]
 – Walter, Ingenieur, Direktor des Gaswerks, Sandrainstrasse 17 [23.519]
 – Walter Friedr., Monteur, Lerchenweg 33
-– Wenzel, Angestellter. Allmendstrasse 39
+– Wenzel, Angestellter, Allmendstrasse 39
 – Werner Oswald, Maler, Waffenweg 22
 – Willy Karl, kaufm. Angest., Herzogstr. 3
 Kühn, K. J. Rosa, Krankenpflegerin, Archivstrasse 8
@@ -25510,7 +25474,7 @@ Kuli, A. E. Ida, Wyttenbachstrasse 29
 – Emil, Patissier, Neuengasse 16
 # Date: 1935-12-15 Page: 26020577/272
 Kuli, Ernst Traug., Dr., Beamter, Alexanderweg 2 [26.325]
-– Fritz. Buchbindermeister. Mezenerweg 2
+– Fritz. Buchbindermeister, Mezenerweg 2
 – Hedwig, Atelier für Maßschneiderei. Greyerzstrasse 33
 – Hedwig Dora, Bureaulistin, Aegertenstr. 46
 – Herm. Emil, Lok.-Führer d. S. B. B., Bollwerk 35
@@ -25619,7 +25583,7 @@ Küng, s. auch König
 – Emil, Kondukteur S. B. B., Bühlstrasse 14
 – Ernst, Installateur, Eggimannstrasse 23
 – Ernst, Beamter O. T. D., Hochfeldstr. 11
-– Friedr., Malermeister. Brunngasse 50
+– Friedr., Malermeister, Brunngasse 50
 – Friedr., Schlosser, Wiesenstrasse 67
 – Fritz, Hilfsarbeiter, Eggimannstrasse 23
 – Fritz, Pferdewärter, Wiesenstrasse 67
@@ -25715,7 +25679,7 @@ Kunz, s. auch Kuentz
 – Franz Adolf, Dienstchef, Beundenfeldstr. 18
 – Frieda, Verkäuferin, Werkgasse 32, Bümpliz
 – Fr., Bundesweibel, Hallerstrasse 62
-– Friedr. Arnold. Hausmeister im Bundeshaus, Theodor-Kochergasse 9 . [61.848]
+– Friedr. Arnold. Hausmeister im Bundeshaus, Theodor-Kochergasse 9 [61.848]
 – —Friedr., Kohlenhändler. Bümplizstrasse 88
 – Friedr., gewes. Metzgermeister, Weissensteinstrasse 22a [23.728]
 – Friedr., photograph. Artikel (Läuferpl. 8), Kramgasse 30 [28.875]
@@ -25724,7 +25688,7 @@ Kunz, s. auch Kuentz
 – Fritz, Einleger, Freiburgstr. 372, Bümpliz
 – Fritz, Magaziner, Federweg 27
 – Fritz, Heizer, Waffenweg 27
-– Fritz, Hufschmiedmeister. Flurstrasse 16
+– Fritz, Hufschmiedmeister, Flurstrasse 16
 – Fritz, Metzgerei, Wursterei, Weissensteinstrassc 22a [23.728]
 – Fritz (Lehmann), Restaurant, Seidenweg 5 [23.736]
 – Fritz (Scheidegger), Pflästerer, Weissensteinstrasse 68
@@ -25829,7 +25793,7 @@ Künzi, s. auch Küenzi
 – Hedwig Alb., Schule für tänz. Gymnastik, Gerechtigkeitsgasse 72 [29.476]
 – Ida, Angestellte, Aegertenstrasse 69
 – J G., pens Bezirkspolizist. Mittelstr. 21
-– Joh., Bankbeamter. Sulgenbachstrasse 14
+– Joh., Bankbeamter, Sulgenbachstrasse 14
 – Julie, Schneiderin, Aegertenstrasse 69
 – Karl Friedr., jun., Schreiner. Breitenrainstrasse 10
 – Karl Friedr., in Fa. Künzi & Gyger, Breitenrainstrasse 10
@@ -25847,7 +25811,7 @@ Künzi, s. auch Küenzi
 – Rud., Kolonialwarenhdlg., Schmiedweg 7
 – Rudolf. Schuhmacher, Altenbergstrasse 30
 – Rud., Spengler u. Inst., Gerechtigkeitsg. 5
-– S. E.. Aegertenstrasse 69
+– S. E., Aegertenstrasse 69
 – Theodor, Schriftsetzer, Gerbergasse 15
 Künzi, s. auch Küenzi
 – W., Velo-Klinik (Hallerstr. 612 r, Boiligen), Thunstrasse 4 [26.098]
@@ -25892,7 +25856,7 @@ Künzli, s auch Künzle
 – Rosine (Trachsel), Wwe., Heckenweg 15
 – Walter, Beamter d. S. B. B., Gesellschaftsstrasse 22 [29.297]
 – Walter (Hiirlimann), Rest. Circus Knie, Optingenstrasse 43 [29.605]
-– Walter. Pension zur Universität, Fischerweg 16 [34.814]
+– Walter, Pension zur Universität, Fischerweg 16 [34.814]
 – Werner, Hilfsarbeiter, Th.-Kochergasse 4
 – Gebr., Photographie, Chutzenstrasse 30 [36.705]
 Kuoch, Otto, Dr., Zahnarzt, Monbijoustr. 10 [22.881]
@@ -25912,14 +25876,14 @@ Küpfer, s. auch Kipfer
 – Ernst, Viktoriastrasse 89
 – Ernst, Magaziner, Distelweg 7
 – Ernst A., Steinhauer, Schifflaube 42
-– Friedr., Bankbeamter. Spitalackerstr. 64
+– Friedr., Bankbeamter, Spitalackerstr. 64
 – Friedr., Dachdecker, Brunnmattstrasse 32
 – Friedr., gew. Fabrikant, Bubenbergstr. 3 [32.765]
 – Fritz, Ausläufer, Kesslergasse 23
 – Fritz (Mauch), Beamter S. B. B., Bubenbergstrasse 3
 – Fritz, Briefträger, Gesellschaftsstrasse 35
 – Fritz Joh., Schmied, Steckweg 15
-– Gottl. Ed. (Ramo), Prokurist, Tscharnerstrasse 41 . [28.824]
+– Gottl. Ed. (Ramo), Prokurist, Tscharnerstrasse 41 [28.824]
 – H. J., Postangestellter, Breitenrainstr. 81
 – Herm. Paul, Postchauffeur, Hallerstr. 23
 – Hans, Dachdeckermeister, Aehrenweg 32, Bümpliz [46.162]
@@ -25961,8 +25925,7 @@ Küpfer, siehe auch Kipfer
 – Walter, Schlosser, Badgasse 41
 – Willi., Molkereitechniker, Aarbergerg. 49
 Kupferschmid, Chr. Karl, Koch, Freiestr. 58
-Kupferschmid, E. 28.728
-Aoito-Fournituren und Ersatzteile, Erlachstrasse 7
+Kupferschmid, E. 📞 28.728 Auto-Fournituren und Ersatzteile, Erlachstrasse 7
 – Erika, Bureaulistin, Neufeldstrasse 15
 – Fritz, Hilfsarbeiter, Seidenweg 29
 – Fritz, Maurer, Schauplatzgasse 5
@@ -26109,7 +26072,7 @@ Labriola, Alberto, ehern. Diplomat, Thunstr. 22 [32.019]
 Lachat, Alb. G., Metzger, Stalden 4
 – Hermine, Pestalozzistrasse 30
 – Jos. Emil, Mechaniker, Gerechtigkeitsg. 52
-– Maria,, Ladentochter, Kramgasse 74
+– Maria., Ladentochter, Kramgasse 74
 ; — R. (Mühlethaler), Wwe., Marzilistrasse 24
 Lächler, Walter, Postbeamter, Neufeldstr. 105
 Lack, Emil, Schlossermstr. (Wattenwylw. 21 [36.288]), Postgasshalde 21 [35.997]
@@ -26146,7 +26109,7 @@ Läderach, G. A., Laborant im Frauenspital, Weissensteinstrasso 20
 – Gottl., Tramangestellter, Murifeldweg 63
 – Hans, Autotransporte, Schifflaube 2 [27.334]
 – Hans, Mechaniker, Lentulusrain 6
-– Hans Friedr., Pferdewärter. Bantigerstrasse 26
+– Hans Friedr., Pferdewärter, Bantigerstrasse 26
 – Hans, Wagenführer der S. S. B., Murifeldweg 11
 – Hans. Zugführer, Freie Strasse 61
 – Hedwig Frieda, Weissnäherin, Holligenstrasse 70
@@ -26155,7 +26118,7 @@ Läderach, G. A., Laborant im Frauenspital, Weissensteinstrasso 20
 Central (Bümplizstr. 177 [46.127]), Ryffligässchen 4 [24.636]
 – Jakob, Schreiner, Forsthausweg 15
 – Jeanne, Frau, Fabrikarbeiterin, Badg. 49
-– Joh. E., Bauamtarbeiter. Wylerringstr. 41
+– Joh. E., Bauamtarbeiter, Wylerringstr. 41
 – Joh., Handlanger, Gerbergasse 12
 – Joh., in Fa Läderach & Mosimann, Beundenfeldstrasse 56
 – Joh. (Bottelini), Maler, Militärstrasse 45
@@ -26203,7 +26166,7 @@ Lambert, Hilda Hedwig, Kinderpflegerin, Mindstrasse 3
 – Mina (Kulli), Wwe., Burgernzielweg 6 [28.609]
 Lamblin, Zel (Knuchel), Uhrenmacher und Uhrenhandlung, Monbijoustr. 67 [29.206]
 Lamborot, Charlotte Math., Damenschneiderin, Sulgeneckstrasse 22
-– Dora M . Lingere, Sulgeneckstrasse 22
+– Dora M., Lingere, Sulgeneckstrasse 22
 – Emilie Fr., Tapeziererin, Sulgeneckstr. 22
 – Louis, Hauswart E. W. B., Sulgeneckstr. 22
 – Melitta C., Damenschneiderin, Sulgeneckstrasse 22
@@ -26236,7 +26199,7 @@ Landjäger-Hauptwache, Ferd.-Hodlerstr. 7 (Amthaus) [21.342]
 Landis, Rosa Elisab., Privat., Waldhöhew. 29
 Landolf, Alfr. (Kupferschmied), orthopädische Werkstatt, Seilerstrasse 2 [29.975]
 – Franz, Chemigraph, Lentulusstrasse 43
-– Gottl.. Redaktor am «Bund». Muldenstr. 1 [36.376]
+– Gottl., Redaktor am «Bund». Muldenstr. 1 [36.376]
 Landolt, Emil (Riiedi), Inspektor in der eidg. Steuerverwaltung, Kirchbühlweg 51
 – Ernst, Konfiserie-Schachtel-Fabrikation, Mühlemattstrasse 14a
 – Fritz H. R., eidg. Beamter, Friedensstr. 3 [33.175]
@@ -26468,7 +26431,7 @@ Lanzendörfer, Ambrosius,. Plattenleger, Zähringerstrasse 40
 Lanzrein, Emma. Sekretärin, Luternauweg 6
 Lapaire, Leon Jos. L., Graphiker, Könizstr. 43
 Lapp, Jean Arthur, Malermeister, Fabrikstrasse 36
-– Walter. Nähmaschinen- u. Velohandlung u. Reparaturwerkst. (Laubockstr.196 [34.041]), Kramgasse 5 u. Kirchgasse 4 [22.018]
+– Walter, Nähmaschinen- u. Velohandlung u. Reparaturwerkst. (Laubockstr.196 [34.041]), Kramgasse 5 u. Kirchgasse 4 [22.018]
 Lappe, Moritz K. Th. (Böhler), Apotheker, Länggassttrasse 8
 Lardelli, Ant., Zollbeamter, Länggassstr. 12
 Lardon, Rene Paul, Bankangestellter, Gutenbergstrasse 5
@@ -26489,7 +26452,7 @@ Lauber, s auch Lauper
 – Emanuel, Bankbeamter, Weingartstr. 47
 – Hanny. Angestellte, Steinerstrasse 4
 – Joh., Zimmermann. Simonstrasse 15
-– Max, Briefmarkenhandlung (Steinerstr. 4 [34.277]), Spitalgasse 18 . [33.441]
+– Max, Briefmarkenhandlung (Steinerstr. 4 [34.277]), Spitalgasse 18 [33.441]
 – Susanna. Heilsarmeeoffizierin, Muristr. 6
 – Walter, Postangestellter, Dalmaziweg 83
 Laubis, Elsa, Bureauangestellte, Gartenstr. 8
@@ -26503,7 +26466,7 @@ Laubscher, Arnold, Händler, Sulgenbachstr. 36
 – Fritz (Guggisberg), Angest., Seftigenstr. 77 [24.667]
 – Hilda Pauline, Coiffeuse, Elisabethenstr. 20
 – Mathilde, Beamtin der schweizer. Landesbibliothek, Bubenbergstrasse 2
-– Walter. Schlosser, Scheibenstrasse 55
+– Walter, Schlosser, Scheibenstrasse 55
 Läuchli, Rosa, Fabrikarbeiterin, Tunnelweg 7
 – Wilh., pens. Fabrikaufseher, Tunnelweg 7
 Lauchnauer, Emma, Heilsarmeeoffizierin, Malerweg 2
@@ -26544,7 +26507,7 @@ Lauper, s auch Lauber
 – Ernst, Portier der Waffenfabrik, Stauffacherstrasse 61
 – Ernst, Schmied, Murtenstrasse 153d
 – Fritz, Kaufmann. Genossenweg 5
-– Fritz, kaufm. Angestellter. Forstweg 65
+– Fritz, kaufm. Angestellter, Forstweg 65
 – Gertrud. Bureaulistin, Neubrückstrasse 83
 – Gottfr., Gemüsehändler, Ahornweg 5
 – Hans, kant Angestellter, Dalmazirain 22
@@ -26571,7 +26534,7 @@ Laurenz, Bernh. (Eschbach), Coiffeur-Fachlehrer, Gartenstrasse 10 [34.188]
 Lauri, Hans. Photohaus (Brunnadernrain 30 [36.649]), Waisenhausplatz 4 [34.444]
 – Jakob, Photograph, Brunnadernrain 30
 Laurösch, Ludw., Maschinenmeister, Wabernstrassp 79
-Lautenschlager, Karl Jos., Kommis, Donnerbühlweg la
+Lautenschlager, Karl Jos., Kommis, Donnerbühlweg 1a
 Lauterbrunnen-Mürren-Bergbahn A.-G., Domizil: Spar- und Leihkasse, Bundesplatz 4
 Lauterburg, A., Sohn, A.-G., Au Bon Marchä, Mercerie. Nouv. Ling., Spitalg. 3 [27.511]
 – -A., Dr. med., Arzt, Falkenhöbeweg 20 [24.766]
@@ -26608,7 +26571,7 @@ Lebensmittel-Aktiengesellschaft Bern, vorm.
 Joh Sommer & Cie., Zollikofen [47.125] Filialen: Waisenhausplatz 9 und Waaghausgasse 10 [21.124], Spitalg. 40 [22.951], Gerechtigkeitsgasse 42, Belpstrasse 36, Seftigenstrasse 28 [36.884], Zieglerstr. 26 [33.049], Cäcilienstrasse 21, Gesellschaftsstrasse 19d, Seidenweg 2 [23.185], Brückfeldstrasse 25 [23.169], Freiestr 38 [34.054], Militärstrasse 39 [32.849], Moserstrasse 16 [31.259], Flurstrasse 17, Kyburgstrasse 13, Lorrainestr. 19, Scheibenstr. 36 [21.989], Luisenstr. 16 [33.418], Anshelmstrasse 18 [36.466], Klaraweg 18 [21.929], Gryphenhübeliweg 31 [22.108], Steigerweg 17, Schönbergrain 6, Thunstrasse 103 [36.495], Nelkenw 17, Brunnadernstr 63a [24.357], Gerbergasse 43, Marzilistr.-Brückenstrasser [36.504,; Freiburgstrasse 60, Bethlehem, Murtenstrasse 222; Bümpliz: Bümplizstrasse 180, Lorbeerstrasse 11, Bernstr. 21, Reichenbachstrasse 63
 Lebensmittelkontrolle der städt. Polizeidirektion, Predigergasse 6 [20.470]
 Leber J. (Utz), Jungfraustrasse 44 [33.610]
-– Jakob, Bankangestellter. Hochfeldstr. 105
+– Jakob, Bankangestellter, Hochfeldstr. 105
 – Luise (Wyser), Wwe., Thormannstrasse 50 [31.896]
 Lebet, A., Dr. med., Adjunkt des Oberfeldarztes, Hallerstrasse 50 [31.406]
 – Jeanne A. R., Gymnastiklehrerin, Hallerstrasse 50
@@ -26690,7 +26653,7 @@ Lehmann, s. auch Leemann
 – Albert. Melker, Tiefenaustrasse 98
 – Albr., Schuhmachermeister, Breitenrainstrasse 23
 – Alex., Bankangestellter, Niggelerstrasse 7
-– Alex., Fuhrhalter. Sandrainstr. 18 [35.871]
+– Alex., Fuhrhalter, Sandrainstr. 18 [35.871]
 – Alex., Kaufm., Scheuermattw. 10 [25.649]
 – Alex., Maschinenschlosser, Lorrainestr. 64
 – Alex., Zaunmacher. Eggimannstrasse 17
@@ -26825,7 +26788,7 @@ Lehmann, s. auch Leemann
 – Gottl., Sattler, Freieckweg 6, Bümpliz
 – Gottl. (Steffen), Spengler, Seidenweg 19
 – Gottl. (Blum), Strassenmeister, Stadtbachstrasse 8 [34.525]
-– Gottl., Versich.-Beamter. Lentulusstr. 40
+– Gottl., Versich.-Beamter, Lentulusstr. 40
 – Gottl. (Scheidegger), Rest. Holligen, Freiburgstrasse 68 [23.091], Autoabbruch-Unternehmung, Freiburgstrasse 66
 – Gottl., Zimmermann, Stauffacherstrasse 3
 – Grittli, Fabrikarbeiterin, Junkerngasse 23
@@ -26873,7 +26836,7 @@ Lehmann, s. auch Leemann
 – Johanna Elise, Angestellte, Muesmattstr. 33
 Lehmann, s. auch Leemann
 – Julia Anna. Beaulieustrasse 47
-– . Julia, Bureaulistin, Berchtoldstrasse 25
+– Julia, Bureaulistin, Berchtoldstrasse 25
 – Julia, Rotkreuzschwester, Niesenweg 3
 – K. Otto, Beundenfeldstrasse 32 [27.802]
 – Karl’s Wwe., Akzidenzdruckerei (Schärerstrasse 5), Brunngasse 17 [27.876]
@@ -26943,7 +26906,7 @@ Lehmann, s. auch Leemann
 – Rud., Mechaniker, Beundenfeldstrasse 41
 – Rud Joh Tramapgest., Kasthoferstr. 4
 – Rud., Schlosser. Länggassstrasse 92
-– Rud. Alfr., Eilgutarbeiter. Weissensteinstrasse 114
+– Rud. Alfr., Eilgutarbeiter, Weissensteinstrasse 114
 – Rud. Alb., Polierer, Schützenweg 5
 – Ruth B., Ladentochter, Schönburgstrasse 5
 – Sam., Landwirt. Niederriedweg 41, Oberbottigen
@@ -26955,13 +26918,13 @@ Lehmann, s. auch Leemann
 – Walter Hans Kondukteur S. B. B., Gesellschaftsstrasse 31
 – W. Paul, Buchdrucker, in Fa. Lehmann & Pulver, Buchdruckerei, Brunnadernstr. 8 [28.906]
 – Walter G., Bureaulist, Fischerweg 21
-– Walter Ad., eidg Beamter. Kyburgstr 6 [31.847]
+– Walter Ad., eidg Beamter, Kyburgstr 6 [31.847]
 – Walter Eug., Einleger. Altenbergstr. 14
 – Walter, Elektriker, Birkenweg 29
 – Walter, Hilfsarbeiter, Zaunweg 24
-– Walter. Kondukteur S. B. B., Aebistr. 10
-– Walter. Mechaniker, Allmendstrasse 42
-– Walter. Mechaniker, Wiesenstrasse 42
+– Walter, Kondukteur S. B. B., Aebistr. 10
+– Walter, Mechaniker, Allmendstrasse 42
+– Walter, Mechaniker, Wiesenstrasse 42
 – Walter Herm., Mechaniker, Feldheimw. 40, Bümpliz
 – Walter Adolf, Schlosser, Lorrainestr. 68
 – Werner, Dr., Chemiker, Kirchbühlweg 46
@@ -26977,7 +26940,7 @@ Lehmann, s. auch Leemann
 Lehmann, s. auch Leemann
 – Willy, Hilfsarbeiter, Breitenrainplatz 29
 – Willy, Landarbeit., Thormannmätteliweg 19
-– & Cie., vorm. Altorfer, Lehmann & Cie., Zofingen. Zentralheizungsfabr . sanit Einricht., Tankanl., Blumenbergstr.16 [21.564]
+– & Cie., vorm. Altorfer, Lehmann & Cie., Zofingen. Zentralheizungsfabr., sanit Einricht., Tankanl., Blumenbergstr.16 [21.564]
 – & Jenni, mech. Schlosserei, Friedheimweg 24 [31.938]
 – & Pulfer, Buchdruckerei, vorm. Jul. Lehmanns Wwe., Gerechtigkeitsg. 79 [31.772]
 – & Söhne, A., Fuhrhalterei. Sandrainstr. 18
@@ -27006,7 +26969,7 @@ Lehrlingsamt, kant., Kramg 1 [23.154]
 Lehrlingskommissionen der Stadt Bern, gewerbliche. Sekretariat, Kramg. 1 [27.344]
 Lehrlingskommission für den kaufmänn. Beruf, Gemeinde Bern, Sekretär. (W. Küng), Herrengasse 36 [22.888]
 Lehrmittelverlag, staatl., Speichergasse 14-13 [22.237]
-Lehrwerkstätten (für Schreiner, Mechaniker, Schlosser u Spengler) Direktion u. Werkstätten: Lorrainestrasse 3 [28 1671
+Lehrwerkstätten (für Schreiner, Mechaniker, Schlosser u Spengler) Direktion u. Werkstätten: Lorrainestrasse 3 [28.167]
 Leibacher, Ernst, eidg. Beamt., Seftigenstr. 20
 Leiber, Ad., Offiziersbedient., Kasernenstr. 11
 Leibfarth, Friedr., Privatier, Bernastrasse 34
@@ -27058,7 +27021,7 @@ Leimgruber, Edm., pens. Wagenvisiteur der S. B. B., Hallerstrasse 29
 Leinen und Stickereien A.-G., Kramgasse 16 [24.660]
 Leinenhaus Bern 21.180
 Luchsinger & Co., Fahr, und Handel in Weisswaren, Spezialität: Brautaussteuern. Speichergasse 8. Privat: Eichholzstrasse 30, Wabern [35.786]f-einenweberei Bern A.-G., Bubenbergplatz 7 [27.831], Fabrik: Wylerringstrasse 46/48 [23.401]
-Leinenweberei Langenthal A.-G., Karl-Schenk-Haus, Spitalgasse 4 . [29.494]
+Leinenweberei Langenthal A.-G., Karl-Schenk-Haus, Spitalgasse 4 [29.494]
 Leiser, A. Gottl., Postbeamter, Freiestrasse 33
 – Alfred, Hilfsarbeiter, Metzgergasse 58
 – Anna Frieda, Ladentochter, Hochfeldstrasse 101
@@ -27190,11 +27153,9 @@ Lerchmüller, Hedwig Math., Verkäuferin, Murtenstrasse 3
 Lerf, Walter, Hilfsarbeiter, Flurstrasse 24
 – Willi Oskar, Bankbeamter, Schanzeneckstrasse 19
 Lergier, Gertr. M., Angest., Giessereiweg 9
-– Herm. E., Geschäftsführer, Sulgenauw. 24 [25.3061
+– Herm. E., Geschäftsführer, Sulgenauw. 24 [25.306]
 – Karl Otto, Hilfsarbeiter, Kyburgstrasse 13
 – Mina, Blumen- u. Pflanzengeschäft (Giessereiweg 9 [33.644]), Ryffligässchen 3 [23.405], Fil. Kramgasse 26 [31.552]
-Das moderne Badzimmermacht Ihnen sicher
-Freude. Lassen Sie sichberaten durch Gerechtigkeitsg.59 Telephon 21.040
 # Date: 1935-12-15 Page: 26020595/290
 Lergier, Walter Max, Polizist, Lorystrasse 4
 – William L. (Lehmann), Küchenchef, Muristrasse 93
@@ -27262,7 +27223,8 @@ Leuba, Amelie Charlotte (de Hillern), Beundenfeldstrasse 43 [25.374]
 – Lucette Sus., eidg. Beamtin, Falkenplatz 18 [22.774]
 – Marcel Aug., Coiffeur, Lorrainestrasse 6a
 – William Cäsar, Kaufmann, Spitalgasse 35
-Leuch, A. Rieh., städt. Beamter, Badgasse 21von Leuchsenring, Emilie Albertine, Privat., Finkenrain 15
+Leuch, A. Rieh., städt. Beamter, Badgasse 21
+von Leuchsenring, Emilie Albertine, Privat., Finkenrain 15
 Leuenberg, Erna, Schäftemacherin, Felshaldenweg 27
 – Ernst, Hilfsarbeiter, Marktgasse 18
 – Gottlieb Rudolf. Dachdecker. Flurstr. 17
@@ -27338,10 +27300,10 @@ Leuenberger, Emil, Buchbinderei (Seidenweg 6), Bühlstrasse 25 [35.602]
 – Fritz, Stanzer, Federweg 27
 – Fritz (Näf), Tramkondukteur, Mindstr. 3
 – Fritz, Tramkontrolleur, Rossfeldstrasse 21
-– Gottfr., Fabrikarbeiter. Felsenaustr 20
+– Gottfr., Fabrikarbeiter, Felsenaustr 20
 – Gottfr., Hilfsarbeiter, Weissensteinstr. 80
 – Gottfr Masch -Schlosser. Tunnelweg 6
-– Gottfr. pens. Oberpferdewärter. Rodtmattstrasse 90
+– Gottfr. pens. Oberpferdewärter, Rodtmattstrasse 90
 – Gottfr (Spycher), Fabrikation u. Vertriebdes Hosenträgers « Raedi», Wyttenbachstrasse 37
 – Gottfr Paul, Zahntechniker, Watten wylweg 10
 – Gottl. Friedr., Telephonarbeiter, Vennerw. 3
@@ -27378,7 +27340,7 @@ Leuenberger, Hans Gottl., Beamter d. P. T. T., Bürgieastrasse 20 [25.243]
 – J. J., pens. Postangest., Lorrainestr. 10
 – Jak., Schneider, Altenbergstrasse 98
 – Jakob, Dr. jur., Vorsteher des kant. Jugendamtes (Anshelmstrasse 4 [33.948]), Kramgasse 1 [29.621]
-– Jakob, Gasarbeiter. Brunnmattstrasse 43
+– Jakob, Gasarbeiter, Brunnmattstrasse 43
 – Jakob, Hilfsarbeiter, Rodtmattstrasse 81
 – Jakob, Hilfsarbeiter, Freiburgstrasse 149
 – Jacques, Maler, Altenbergstrasse 98
@@ -27592,7 +27554,6 @@ Liechti, Alb., Zahntechniker (Wiesenstr. 10), Laupenstrasse 1 [22.7781
 – Friedr., Telephonmonteur, Gerechtigkeitsgasse 15
 – Fritz, Handlanger, Buchweg 2, Riedbach
 – Fritz, Hotel-Restaurant Wächter, Genfergasse 2/4 [23.932]
-Auch Sie werden mit unserer guten Ware Schneider&RindlisbaclierllUIIIUll und prompten Bedienung zufrieden seinl Christoffelgasse 4 - Tel. 21.191
 # Date: 1935-12-15 Page: 26020599/294
 Liechti, Fritz (Bigler), Metzgermeister, Morillonstrasse 10 [26.373]
 – Fritz, Schlosser, Gutenbergstrasse 4
@@ -27601,7 +27562,7 @@ Liechti, Fritz (Bigler), Metzgermeister, Morillonstrasse 10 [26.373]
 – Gertrud, Verkäuferin, Hallerstrasse 55
 – Goltfr., Bauamtarbeiter, Forstweg 69
 – Gottfr., Bauamtarbeiter, Muesmattstr. 35
-– Gottfi Buchhalter. Forsthauswe? 4
+– Gottfi Buchhalter, Forsthauswe? 4
 – Gottfr. Ernst. Kaufmann. Wyttenbachstr. 11
 – Gottfr., Kontroll. d. S. S. B., Forsthausw. 4
 – Gottl., Elektromonteur, üptingenstrasse 42
@@ -27610,7 +27571,7 @@ Liechti, Fritz (Bigler), Metzgermeister, Morillonstrasse 10 [26.373]
 – Hans, Chauffeur, Rodtmattstrasse 108
 – Hans, Mechaniker, Wachtelweg 19
 – Hans Alb., Schlosser, Burgfeldweg 10
-– Hans. Versieh.-Angestellter. Moserstr. 15
+– Hans. Versieh.-Angestellter, Moserstr. 15
 – Hedwig, Bankangest., Stöckackerstr. 83a, Bümpliz
 – Hedwig, Fabrikarbeiterin, Forstweg 69
 – Hedwig (Eichenberger), Wwe., Pension, Aarbergergasse 46 [28.265]
@@ -27621,11 +27582,11 @@ Liechti, Fritz (Bigler), Metzgermeister, Morillonstrasse 10 [26.373]
 – J. (Rohr), Agentur für Getreide, Luisenstrasse 19 [21.908]
 – Jak., Magaziner, Gesellschaftsstrasse 30
 – Jakob, Schokoladen- u. Lebkuchenhändler, Brunnhofweg 5
-– Joh Bahnwärter. Kyburgstrasse 9
+– Joh Bahnwärter, Kyburgstrasse 9
 – Joh. Friedr., Hilfsarbeiter, Gerbergasse 42
 – Joh. Paul, Chauffeur, Federweg 29
 – Joh., Kaufmann, Herrengasse 21
-– Joh. K., Nachtwächter. Bremgartenstr. 61
+– Joh. K., Nachtwächter, Bremgartenstr. 61
 – Joh. F., Typograph, Hallerstrasse 55
 – Joh., Vertreter, Viktoriarain 8 [27.942]
 – Johannes. Fabrikarbeiter Mühlemattstr 36
@@ -27675,7 +27636,7 @@ Liechti, Marie, Frl., Spitalackerstrasse 63
 – Theodor. Ingenieur b. Stadtbauamt, Florastrasse 8 [24.985]
 – Finch Maschinist, Wylerfeldstrassp 6
 – Walter Oskar, Angestellter, Kapellenstr. 7
-– Walter. Ingenieur. Moserstrasse 52
+– Walter, Ingenieur. Moserstrasse 52
 – Walter, Hilfsarbeiter, Seidenweg 21
 – Walter kaufm Angest Gutenbergstr 4
 – Walter, Placierungsbureau Servier, Marktgasse 16
@@ -27826,7 +27787,7 @@ Linder, Eduard (Sommer), Elektrotechniker, Heinrich-Wildstrasse 10
 – —Traugott, Zimmermann, Militärstrasse 42a
 — Verena (Zbinden), Wäscherei u. Glätterei, Läuferplatz 1 [29.279]
 — Walter Max, in Fa. Rud. Linder & Sohn, Standstrasse 31
-– Werner, Hilfsarbeiter. Mittelstrasse 19
+– Werner, Hilfsarbeiter, Mittelstrasse 19
 — Werner Fritz, Tapezierer, Schwarzenburgstrasse 14a
 Lindgreen, Karl, Spengler, Wylerringstr. 9
 – Charles Otto, Hutmacher, Wylerringstr. 9
@@ -27896,8 +27857,7 @@ Lipmann, Anna, Reisende, Wyttenbachstr. 14
 – Jonasch, Prov.-Reisender, Wyttenbachstrasse 14
 Lipp, August, kaufm. Angest., Mittelstr. 64
 Lippmann, Josef, Verwaltungsrat d. Leinenweberei Bern A.-G., Effingerstrasse 39 [34.094]
-– Jules, Verw.-Rat der Leinenweberei Bern
-A.-G., Effingerstrasse 31 [27.038]
+– Jules, Verw.-Rat der Leinenweberei Bern A.-G., Effingerstrasse 31 [27.038]
 – Sophie (Weil), Wwe., Gutenbergstrasse 9 [34.266]
 – Sarah, Frau, Länggassstrasse 25
 Lippuner, Andreas (Müller), Reisender, Falkenplatz 3
@@ -27912,7 +27872,7 @@ Lirgg, Ernst E. (Tenger), Reisender, Postg. 18
 – Friedr., Bauamtarbeiter, Brunnhofweg 21
 – Gertrud. Brunnhofweg 21
 – Marg., Fabrikarbeiterin, Brunnhofweg 21
-– Walter. Sattler u. Tapezierer, Brunnhofweg 21
+– Walter, Sattler u. Tapezierer, Brunnhofweg 21
 Lischetti, Wald. Ant., Handlanger, Zwiebelngässchen 16
 Lithographenbund, Sekretariat, Beaumontweg 19 [31.808]
 Litzelmann, Viktor C. J., städt. Beamter, Monbijoustrasse 16
@@ -27933,7 +27893,7 @@ Lobsiger, Ad., Chauffeur, Burgfeldweg 18
 – Alex., Kohlenarbeiter, Bümplizstrasse 60
 – Alex., Schlosser. Flurstrasse 5
 – Bendicht, Schriftsetzer, Brunnmattstr. 21
-– Ernst, Hilfsarbeiter. Stalden 6
+– Ernst, Hilfsarbeiter, Stalden 6
 – Ernst Rud., kant. Angest., Hallerstr. 39
 – Ernst P., Mechaniker, Flurstrasse 5
 – Ernst, Pferdewärter, Bahnhöheweg 44, Bümpliz
@@ -27948,7 +27908,7 @@ Lobsiger, Ad., Chauffeur, Burgfeldweg 18
 – Margr Emma, Telephonistin, Flurstr. 5
 – Paul Gotth., Metzgermeister, in Fa. Lobsiger-Mathys, Humboldtstrasse 7 [23.415]
 – Walter Herm., Chauffeur, Zähringerstr. 57
-– Walter Ad., Hilfsarbeiter. Burgfeldweg 18
+– Walter Ad., Hilfsarbeiter, Burgfeldweg 18
 – Walter Adolf, Metzgermeister, in Fa. Lobsiger-Mathys, Spitalgasse 31 [36.214]
 – Werner, Elektromonteur, Breiteweg 12
 Lochau, Herm. H. G., Photograph, Viktoriastrasse 89
@@ -27982,7 +27942,7 @@ Locher, Jak., Kaminfegermstr., Bürkiweg 11 [36.592]
 – Joh., pens. Abwart, Scheibenstrasse 19a
 – Joh., Maler, Länggassstrasse 57
 – Joh., Schuhmacher. Amselweg 11
-– Johannes. Pferdewärter. Gruberstrasse 8
+– Johannes. Pferdewärter, Gruberstrasse 8
 – Karl, kaufm. Angest., Viktoriastrasse 43
 – Karl Gottlxeb, Buchh.-Kassier, Brückenstrasse 9 [36.670]
 – Karl Roh., Chauffeur. Tscharnerstrasse 21
@@ -28018,7 +27978,7 @@ Löffel, Alfred, Zimmermann, Rosshäusernstrasse 50, Riedbach
 – Hermann Aug., Zimmermann, Mattenhofstrasse 10
 – Hermann, Angestellter, Schärerstrasse 1
 – Jean (Brosi), lic. rer. pol., Rechnungsführer der kant. Unterrichtsdirektion, Hochfeldstrasse 104
-— Joh., Pächter. Weissensteinstr. 70 [32.517]
+— Joh., Pächter, Weissensteinstr. 70 [32.517]
 – Johann Friedr., Schreinermeister, Rehhagstrasse 2. Bümpliz
 – Karl, Bahnangest., Riedernstr. 92, Bümpliz
 – Karl W., Metzger, Wylerstrasse 55
@@ -28073,20 +28033,20 @@ Loosli, Adolf, Bankangest., Giessereiweg 9
 – Ernst, Fabrikarbeiter, Seidenweg 53
 – Ernst, Hausierer, Nydeckhof 25
 # Date: 1935-12-15 Page: 26020604/299
-Loosli, Fricclr., Lok.-Fiihrer S. B. B., Bundesbahnweg 33
-– Friedr.. Hilfsarbeiter, Freiburgstrasse 188, Bürapliz
-– Friedr,, Marbrier, Freiburgstr. 188, Bümpliz
-– Friedr,, Magaziner, Platanenweg 3
+Loosli, Friedr., Lok.-Fiihrer S. B. B., Bundesbahnweg 33
+– Friedr., Hilfsarbeiter, Freiburgstrasse 188, Bürapliz
+– Friedr., Marbrier, Freiburgstr. 188, Bümpliz
+– Friedr., Magaziner, Platanenweg 3
 – Friedr., Schlosser, Freiestrasse 50
 – Friedr., Schreiner, Weissensteinstrasso 12
 – Fritz, Fabrikarbeiter, Freiburgstrasse 347, Bümpliz
-– Fritz Albert, Fürsprecher (Viktoriastr. 43 [28 1831), Bollwerk 19 [22.6621
+– Fritz Albert, Fürsprecher (Viktoriastr. 43 [28 1831]), Bollwerk 19 [22.662]
 – Fritz, Hilfsarbeiter, Gerechtigkeitsgasse 43
 – Fritz Reisender. Hochfeldweg 17
 – Fritz. Schriftsetzer, Schreinerweg 23
-– Gottl., Fabrikarbeiter. Felsenaustrasse 86
+– Gottl., Fabrikarbeiter, Felsenaustrasse 86
 – Gottl., Fabrikarbeiter, Friedheimweg 12
-– Gottl.. Schlossermeister (Schreinerweg 23), Waldheimstrasse 46 [35.270]
+– Gottl., Schlossermeister (Schreinerweg 23), Waldheimstrasse 46 [35.270]
 – Hs. Adolf, Handlanger, Seidenweg 53
 – Hans, Koch. Wangenstrasse 7. Bümpliz
 – Hans Alfred, Dr. med., Arzt, Friedeckw. 22 [28.422]
@@ -28094,11 +28054,11 @@ Loosli, Fricclr., Lok.-Fiihrer S. B. B., Bundesbahnweg 33
 – Irma Johanna, Kopistin, Gesellschaftsstrasse 42
 – Jakob Friedr., Handlanger, Waffenweg 27
 – Joh., Alteisenhändler. Gerechtigkeitsg. 52
-– Joh.. Fabrikarbeiter. Felsenaustrasse 86
-– Joh.. Packer. Waffenweg 27
+– Joh., Fabrikarbeiter, Felsenaustrasse 86
+– Joh., Packer. Waffenweg 27
 – Joh. Gottfr., Schlosser, Waldheimstr. 46
 – Joh., Wirt, Aarbergergasse 55 [22.099]
-– Karl Rud.. Hilfsarbeiter, Wangenatrasse 7, Bümpliz
+– Karl Rud., Hilfsarbeiter, Wangenatrasse 7, Bümpliz
 – Klara, Fabrikarbeiterin, Felsenaustr. 86
 – Magdalena (Gurtner), Milchproduktengeschäft, Effingerstrasse 88
 – Marie El., Bureaulistin. Kursaalstrasse 11
@@ -28117,7 +28077,7 @@ Lopez Olivän, Julio, spanischer Gesandter, Brunnadernstrasse 43 [23.612]
 Löpfe, Felix Emil, Zeichner, Burgunderstr. 55, Bümpliz
 – Pankraz, Architekt, Laupenstrasse 53 [29.400]
 Löpthien, Christiane Martha, Bureaulistin, Mattenhofstrasse 30
-– Peter, Bedarfsartikel für Bäckereien. Konditoreien und Hotels etc., Mattenhofstr. 30 [34.8301
+– Peter, Bedarfsartikel für Bäckereien. Konditoreien und Hotels etc., Mattenhofstr. 30 [34.830]
 – Pierre Felix, kaufm. Angest., Mattenhofstrasse 30
 Lora, Romilda. Fabrikarbeiterin, Breitfeldstrasse 63
 Lorenz, Josef M. L., Schlosser, Hoclifeldstr. 3
@@ -28126,17 +28086,17 @@ Lorenzetti, Amilcare, Maler, Tiefenaustr. 91
 – Maria, Frau, Pension, Aarbergergasse 46
 Loretan, Bertha, Bureaulistin, Hochfeldstr. 7
 – E. (Bürgi), pens. dipl. Ing. der E. T. H., Elfenauweg 15 [35.588]
-– Edelbert. Bahnarbeiter S. S. B.. Kramg 48
+– Edelbert. Bahnarbeiter S. S. B., Kramg 48
 – Fritz, Chauffeur S. O. B., Hochfeldstr. 106
 – Rene (Zemp), Dr. med., prakt. Arzt u. Spezialarzt für innere Krankheiten. Optingenstrasse 29 [24.936]
 Loretz, Hermann, Dreher, Standstrasse 32
-Lorllleux & Cie.. Gh., Fabrik von Buch- und Steindruckfarben, Walzenmasse, Firnissenetc., Fabrik: Schützenmattstr. 12 [31.297], Bureau: Hotelgasse 1 [24.828]
+Lorllleux & Cie., Gh., Fabrik von Buch- und Steindruckfarben, Walzenmasse, Firnissenetc., Fabrik: Schützenmattstr. 12 [31.297], Bureau: Hotelgasse 1 [24.828]
 Lorraineschulhaus. Lorrainestrasse 33de Loriol, Alcide Charles, Schuhmacher, Blumensteinstrasse 3
 Lörtscher, Ad., Parkettleger, Lorrainestr. 22
 – Adolf (Eggler), Beamter d. Schweiz. Bundesanwahschaft, Steinerstr 28 [31.254]
-– Adolf, jun . Bodenleger, Lorrainestrasse 22
+– Adolf, jun., Bodenleger, Lorrainestrasse 22
 – Alb., Beamter S B B, Lötschbergweg 3
-– Albert Arth.. Schriftsetzer, Lötschbergw. 3
+– Albert Arth., Schriftsetzer, Lötschbergw. 3
 – Arnold Marcel, Vertreter, Thunstrasse 39 [28.597]
 – Christ., Handlanger, Lorrainestrasse 28
 – Flora (Ramseyer), Kunst-Stopferei, Thunstrasse 39 [28.597]
@@ -28158,13 +28118,13 @@ Lörtscher, Ad., Parkettleger, Lorrainestr. 22
 – Joh. Jak., Fabrikarbeiter, Mattenhofstr. 9
 – Joh., Monteur. Bümplizstrasse 13
 – K. Aug., Mechaniker, Berchtoldstrasse 39
-– Lorde E., Ladentochter. Schulweg 5
-– Luise, Placierungsbureau « Helvetia »,, Spitslgasse 55 [23.617]
+– Lorde E., Ladentochter, Schulweg 5
+– Luise, Placierungsbureau « Helvetia »., Spitslgasse 55 [23.617]
 – Margr., Einlegerin, Lorrainestrasse 22
 – Maria (Kirchliofer), Wwe., Bollwerk 31 [20.574]
 – Marie (Ledermann), Damenfrisiersalon (Berchtoldstrasse 39). Marktg. 35 [24.281]
 – Otto, kant. Armeninspektor, Blumensteinstrasse 1
-– Paul Jak.. Spengler. Breitenrainstr. 81
+– Paul Jak., Spengler. Breitenrainstr. 81
 – Walter, Beamter S. B. B., Brünigweg 28
 # Date: 1935-12-15 Page: 26020605/300
 Lörtscher, Walter (Burkhalter), Maschinenschlosser, Attinghausenstrasse 27
@@ -28184,11 +28144,11 @@ Zeitung», Grüner Weg 11
 – Walter, Mechaniker, Graffenriedweg 4
 Lorysoital, Freiburgstrasse 41g [65.335]
 Losenegger, Alfred Chr., Fahrdienstarbeiter, Murtenstrasse 137
-– Emma. Ladentochter. Aarbergergasse 10
+– Emma. Ladentochter, Aarbergergasse 10
 – Ernst Walter, Handlanger, Rodtmattstr. 92
 – Friedr., Kalkulator, Allmendstrasse 48
 – Friedr., Kioskhalter, Breiteweg 6
-– Friedr.. pens. Pferdewärter, Breiteweg 14
+– Friedr., pens. Pferdewärter, Breiteweg 14
 – Gottl., Angest. d. E W. B., Gruberstr. 20
 – Hans, Billetteur, Alleeweg 35
 – Joh., Maurer, Quartierhof 1
@@ -28199,7 +28159,7 @@ Losinger, E. (v. Ernst), Ing., Daxelhoferstr.20 [24.450]
 Los-Zentrale A.-G., v. Werdt-Passage [33.587]
 Lotmar, Fritz (Seelig), Dr. med., Nervenarzt, Hallwylstrasse 48 [20.936]
 – Helene Ruth, Dr. phil., Hilfsassistentin, Hallwylstrasse 48
-– Walter, Dr.. Physiker, Hallwylstrasse 48
+– Walter, Dr., Physiker, Hallwylstrasse 48
 Lötscher, Elise (Möri), Blumenbergstrasse 14
 – Franz F. (Jost), Hilfsarbeiter, Federweg 25
 – Herm., Portier, Murifeldweg 22
@@ -28218,7 +28178,7 @@ Lotz, Elisabeth Sophie (Rognon), Wwe., Sulgeneckstrasse 25 [29.324]
 Louis, Ad. Ed., Architekt, in Fa. Gebr. Louis, Viktoriarain 5
 – Anna Maria, Frau, Waisenhausplatz 2 [33.632]
 – Ernst Al. (Kämpf), Kraftwagenführer S.
-0. B.. Seftigenstrasse 36
+0. B., Seftigenstrasse 36
 – Georg Friedr., Notar, Moserstrasse 16 [26.031]
 – Hans, Architekt, in Fa. Gebr. Louis, Brunnmattstrasse 72
 – Eedy, Bureaulistin, Moserstrasse 16
@@ -28237,7 +28197,7 @@ Löw Schuhverkauf A.-G., Marktgasse 4 [23.373]
 Löwe, Maria, Bureaulistin, Eichmattweg 5
 – Walter Ch. J., Versicherungsbeamter, Eichmattweg 5
 Löwenberg, S., Schneider, Simonstrasse 21
-Löwenthal. H.. Dipl. Optiker, Frikartweg 6
+Löwenthal. H., Dipl. Optiker, Frikartweg 6
 Lubin Uhren-A.-G., Allmendstrasse 33
 Lubini, Luigi, Führergehilfe, Muesmattstr. 26
 Lucek, Erna, Verkäuferin, Fichtenweg 3
@@ -28259,7 +28219,7 @@ Luder, A., pens. Zeughausverwalter, Schläflistrasse 4 [32.739]
 – Anna Elisab. (Lössi), Wwe., Bantigerstr.26
 # Date: 1935-12-15 Page: 26020606/301
 Luder, Arnold, Ausläufer, Berchtoldstr. 21
-– Emil, Postangestellter. Herzogstrasse 26
+– Emil, Postangestellter, Herzogstrasse 26
 – Ernst (Schwarz), Malermeister, Bernastrasse 41 [36.581]
 – Ernst, Sekretär d. O. P. D., Müslinweg 18
 – Ernst, Schriftsetzer, Moserstrasse 8
@@ -28267,7 +28227,7 @@ Luder, Arnold, Ausläufer, Berchtoldstr. 21
 – Felix. Maschinenmeister, Berchtoldstr. 21
 – Frieda Anna, Bureaulistin. Freiburgstr. 69
 – Friedrich Ernst, Bahnarbeiter, Seidenweg 47
-– Friedr.. Bureaulist, Monbijoustrasse 22
+– Friedr., Bureaulist, Monbijoustrasse 22
 – Gertrud, Haushaltungslehrerin, Hochfeldstrasse 111
 – Hans, Notar, Sekr., Fischerweg 6 [27.818]
 – Hans Ernst (Feuz), Reisender, Länggassstrasse 45
@@ -28292,12 +28252,12 @@ Luder, Arnold, Ausläufer, Berchtoldstr. 21
 – Willi, Angestellter, Berchtoldstrasse 21
 Ludi, Alb., Versich.-Inspektor, Schwarztorstrasse 23 [27.087]
 – Joh. Alb., Belpstrasse 47
-– Konrad, dipl. Elektrotechn.. Belpstrasse 47
+– Konrad, dipl. Elektrotechn., Belpstrasse 47
 – Konrad, Elektrotechniker, Belpstrasse 47
 Lüdi, Alfred, Schuhmachermeister (Gesellschaftsstrasse 70), Länggassstrasse 40a [23.585]
 – Aline, Ladentochter, Grabenpromenade 3
 – Arth. Max, kaufm. Angest., Effingerstr. 6
-– A. (Wiedmer), Seifenprodukte, Tscharnerstrasse 7 . [29.438]
+– A. (Wiedmer), Seifenprodukte, Tscharnerstrasse 7 [29.438]
 – Berta, Wabernstrasse 79
 – Chr. Fr., Kutscher, Tscharnerstrasse 7
 – Elise (Rufener), Wwe., Florastrasse 7
@@ -28325,7 +28285,7 @@ Lüdi, Hedwig Elsa (Müller), Turnlehrerin, Gesellschaftsstrasse 84
 – Werner, Bankangest., Spitalackerstr. 17
 Lüdin, Fritz, gew. Prokurist, Neufeldstr. 126
 – Paul, Geometer beim kant. Wasserrechtsamt, Neubrückstrasse 104 [27.805]
-Ludwig, Eduard Peter. Buchhändler, Egghölzliweg 57
+Ludwig, Eduard Peter, Buchhändler, Egghölzliweg 57
 – Emil, Telegraphist, Wylerstrasse 81
 – Emilie (Maurer), Wwe., Fellenbergstr. 8
 – Emilie (Studer), Wwe., Bogenschützenstr. 6
@@ -28355,7 +28315,7 @@ Luginbühi, Alb. Joh., Fabrikarbeiter, Brunnhofweg 21
 # Date: 1935-12-15 Page: 26020607/302
 Luginbühl, Anna El. (Wyssmann), Wwe., Schmiedweg 7
 – Bertha, Ladentochter, Scheibenstrasse 39
-– Bertha. Kinderfräulein, Gutenbergstr. 23
+– Bertha, Kinderfräulein, Gutenbergstr. 23
 – Bertha Agnes (L’Eplatenier), Wwe., Rodtmattstrasse 65
 – Christ. (Müller), Hausierer, Altenbergstr. 19
 – Christ. (Kilchenmann). Zentralweg 29
@@ -28364,7 +28324,7 @@ Luginbühl, Anna El. (Wyssmann), Wwe., Schmiedweg 7
 – Ed. (Beguelin), Sekundarlehrer, Schwarztcrstrasse 22 [20.671]
 – Egon, Elektromonteur, Blockweg 11
 – Elise, Postgasse 56
-– Emma (Schwarzentrub), Wwe.. Viktoriastrasse 91
+– Emma (Schwarzentrub), Wwe., Viktoriastrasse 91
 – Ernst Rud., Kaufmann, Tiefenaustrasse 39
 – Ernst, Kondukteur S. B. B., Neufeldstr. 27
 – Ernst, Metallhandlung, Tiefenaustrasse 39 [23.694]
@@ -28387,7 +28347,7 @@ Luginbühl, Anna El. (Wyssmann), Wwe., Schmiedweg 7
 – Gottfr., Dachdeckermeister (Postgasse 22 [36.044]), Schosshaldenstrasse 18
 – Gottfr., Fabrikarbeiter, Zaunweg 16
 – Gottfr., Pferdewärter, Werkgasse 17, Bümpliz
-– Gottfr., Postangestellter. Könizstrasse 79
+– Gottfr., Postangestellter, Könizstrasse 79
 – H., Radioreparaturen, Brunnmattstr. 46 [20.922]
 – Hans, Bäckerei-Konditorei, Breitenrainplatz 37 [22 509], Filiale und Tea-Room, Sohärerstrasse 23 [23.109]
 – Hans Albert, Hilfsarbeiter, Steckweg 11
@@ -28403,9 +28363,9 @@ Luginbühl, Anna El. (Wyssmann), Wwe., Schmiedweg 7
 Luginbühl, Joh., Lehrer, Muristrasse 8
 – Joh., Schäfter, Wylerringstrasse 9
 – Joh., städt Beamter, Diesbachstrasse 12
-– Joh.. Telegraphist, Lagerweg 1
+– Joh., Telegraphist, Lagerweg 1
 – Karl Jak., Hilfsarbeiter, Muldenstrasse 44
-– Karl (Aeschlimann), Pferdewärter. Reichenbachstrasse 55
+– Karl (Aeschlimann), Pferdewärter, Reichenbachstrasse 55
 – Karl Ernst, Tapezierer, Kirchgasse 12
 – L. C. E., Kindergärtnerin, Burgerspital
 – Louis. Viehhändler, Berchtoldstrasse 6 [31.040]
@@ -28423,7 +28383,7 @@ Luginbühl, Joh., Lehrer, Muristrasse 8
 – Rosa (Bärtschi), Wwe., Privatiere, Brunnhofweg 4
 – Rud., Prokurist, Freiestrasse 55
 – Susanna (Santschi), Firma Hs. Luginbühls
-Wwe.. Massschneiderei u. Uniformen, Zähringerstrasse 61 [31.437]
+Wwe., Massschneiderei u. Uniformen, Zähringerstrasse 61 [31.437]
 – Walter, Magaziner, Berchtoldstrasse 7
 – Walter, Autoraechaniker, Effingerstrasse 6 [26.306]
 – Walter Werner, Vernickler, Gryphenhübeliweg 10
@@ -28456,7 +28416,7 @@ Lüscher, Ad., gew. Schriftsetzer, Wyttenbachstrasse 22
 – Alfred (Seiler), Bankangest., Armandweg 4
 – Amalie (Aebi), Aarestrasse 102 [36.831]
 – Emil, jr., Direktor d. Fa. Lüscher, Leber & Cie., A.-G., Beundenfeldstr. 10 [29.964]
-– Emil, pens. .Pferdewärter, Breitfeldstr. 57
+– Emil, pens. Pferdewärter, Breitfeldstr. 57
 – Emma Frieda, Damenschneiderin, Gerechtigkeitsgasse 46
 – Erna, Damenschneiderin. Dählhölzliweg 3
 – Ernst, eidg. Beamt., Landhausw.32 [36.634]
@@ -28469,7 +28429,7 @@ Lüscher, Ad., gew. Schriftsetzer, Wyttenbachstrasse 22
 – Gottl. (Schenk), Privatier. Rosenweg 28
 – Gust. Ad., Kaufmann, Länggassstrasse 25 [24.974]
 – Hans, gew. Bäckermeister, Monbijoustr. 23 [23.798]
-– Hans, Dr jur,, Fürspr., Advokaturbureau (Monbijoustr. 51), Spitalgasso 34 [24.816]
+– Hans, Dr jur., Fürspr., Advokaturbureau (Monbijoustr. 51), Spitalgasso 34 [24.816]
 – Hans Alex. Gottfr., Kunstmaler, Willadingweg 37 [33.672]
 – Hans Theodor, Konfiserie, Monbijoustr. 23 [23.798]
 – Hedwig, städt. Beamtin, Bürkiweg 12
@@ -28489,7 +28449,7 @@ Lüscher, Ad., gew. Schriftsetzer, Wyttenbachstrasse 22
 – Marie (Aebi), Wwe., Engeriedw. 5 [36.308]
 – Max, Bankangestellter, Monbijoustr. 121 [28.092]
 – Oskar H., Postchauffeur, Wyttenbachstr. 22
-– Paul Arth.. Bureauangest.. Brückfeldstr. 22
+– Paul Arth., Bureauangest., Brückfeldstr. 22
 – Paul, Kassier b. Betreibungs- und Konkursamt Bern-Stadt, Brückfeldstrasse 22
 – Paul, Küfermeister und Weinhandlung, Postgasse 54 [36.936]
 Lüscher, Robert, Buchhalter, Belpstrasse 41
@@ -28503,7 +28463,7 @@ Lüscher, Robert, Buchhalter, Belpstrasse 41
 – & Arni, Pension Jolimont, Reichenbachstrasse 39 [32.202]
 – & Co., A., elektr. Anlagen. Friedeckweg 10 [21.734]
 – Leber & Cie., A.-G., Ledermanufakturen, mechan. Schäftefabrik, Werkzeuge, Maschinen für das graph. Gewerbe, Zeughausgasse 16 and Nägeligasse 5 [27.922]
-– Stengelin & Cie . Leder en gros, Treibriemen, Maschinen, Werkzeuge, Schuhfurnituren, Speichergasse 8 [23.495]
+– Stengelin & Cie., Leder en gros, Treibriemen, Maschinen, Werkzeuge, Schuhfurnituren, Speichergasse 8 [23.495]
 Lusser, Florian, Direktor d. Amts f. Elektrizitätswirtschaft, Giessereiweg 9
 – Jos. M. (Ceconi), Ingenieur, Hallwylstr. 21 [26.386]
 Lussi, Alb., Bereiter, Scheibenstrasse 25
@@ -28522,7 +28482,7 @@ Luterbacher, Hugo, Handelsgärtner, Gruberstrasse 18
 Luteyn, Anton J., Glasbläser, Rosenweg 9
 Luther, Martin Karl, Dr. phil., Wyttenbachstrasse 6
 Lüthi und Lüthy
-– Ad.. Hilfsarbeiter, Parkstrasse 11
+– Ad., Hilfsarbeiter, Parkstrasse 11
 – Adolf, Postangestellter, Gesellschaftsstr. 27
 – Alb., Kondukteur S. B. B., Muldenstr. 44
 – Alfred, Bahnhofrest. Weissenbühl, Chutzenstrasse 30 [24.428]
@@ -28560,7 +28520,7 @@ Lüthi und Lüthy
 – Emma Lina, Bureaulistin. Moserstrasse 8
 – Emma, Lehrerin an der Lorraineschule, Wylerstrasse 14 [34.238]
 – Emma, Hilfsarbeiterin, Metzgergasse 55
-– Ernst (Knobel), kant. Beamter. Gantrischstrasse 34 [23.825]
+– Ernst (Knobel), kant. Beamter, Gantrischstrasse 34 [23.825]
 – Ernst. Bahnarbeiter, Breitfeldstrasse 50
 – Ernst, Güterarbeiter d. S. B. B., Bümplizstrasse 192d
 – Ernst E., Bahnarbeiter, Brünnenstrasse 34, Bümpliz
@@ -28570,7 +28530,7 @@ Lüthi und Lüthy
 – Ernst, Gasarbeiter, Schwarzenburgstr. 62
 – Ernst (Schären), Hotel-Restaurant Simplon, Aarbergergasse 60 [28.382]
 – Ernst, Handlanger, Eggimannstrasse 34
-– Ernst, Hilfsarbeiter. Mattenbofstrasse 34
+– Ernst, Hilfsarbeiter, Mattenbofstrasse 34
 – Ernst, Hilfsarbeiter, Quartierhof 12
 – Ernst, Karrer, Weissensteinstrasse 25
 – Ernst, Kartograph, Rosenweg 28
@@ -28639,10 +28599,10 @@ Konditoren. Beundenfeldstrasse 3 [33.578]
 # Date: 1935-12-15 Page: 26020610/305
 Lüthi und Lüthy
 – Fritz Otto, Wagenmaler, Könizstrasse 22
-– G.. Geschäftsführer d. Komm, schweizer. Viehzuchtverbände (Muri [42.056]), Schanzenstrasse 6 i [24.201]
-– G.. & F., Hotel St. Gotthard, Bubenbergplatz 11/13 [21.611]
+– G., Geschäftsführer d. Komm, schweizer. Viehzuchtverbände (Muri [42.056]), Schanzenstrasse 6 i [24.201]
+– G., & F., Hotel St. Gotthard, Bubenbergplatz 11/13 [21.611]
 – Gertrud, Bureaulistin, Breitenrainstr. lö
-– Gertrud, Hilfsarbeiterin, Badgasse la
+– Gertrud, Hilfsarbeiterin, Badgasse 1a
 – Gertrud, lic. rer. pol., Bücherexpertin; Ma. rienstrasse 12 [33.192]
 – Gottfr., gew. Bäckermeister, Schönauweg 1
 – Gottfr., Handlanger, Jurastrasse 44
@@ -28698,7 +28658,7 @@ Lüthi und Lüthy
 – Joh., Chefmonteur, Mattenhofstrasse 41 [25.978]
 – Joh., Handlanger, Mattenenge 13
 – Joh. (Vuillemin), Heizer, Lentulusstr. 34
-– Joh. Friedr.. Hilfsarbeiter, Militärstr. 26
+– Joh. Friedr., Hilfsarbeiter, Militärstr. 26
 – Joh., Kaminfeger, Scheibenstrasse 25a
 – Joh., Landarbeiter, Niederbottigenweg 84, Bümpliz
 – Joh., Landjäger. Schützenweg 11
@@ -28716,32 +28676,32 @@ Lüthi und Lüthy
 – Jos., Heizer, Seidenweg 23
 – Karl J., Bibliothekar, Leiter d. schweizer.
 Gutenbergmuseums, Karl-Staufferstr. 16 [24.623]
-– Karl Rud.. Hilfsarbeiter, Federweg 53
+– Karl Rud., Hilfsarbeiter, Federweg 53
 – Karl R., Hilfsarbeiter, Schanzeneckstr. 7
 – Karl W., Malervorarbeiter bei de Quervain, Schneider & Co., Allmendstrasse 34 [36.904]
 – Karl Joh., Gipser- und Malergeschäft (Allmendstrasse 34), Klaraweg 18
 – Karl, Milchführer, Unt. Aareggweg 33
 – Karl, pens. Postillon, Belpstrasse 43
 – Karl Rud., Schlosser, Gerbergasse 33
-– Karl, Schreiner, Badgasse la
+– Karl, Schreiner, Badgasse 1a
 – Karl, pens. Wegmeister, Wylerfeldstr. 42
 – Klara Gertr., Bureaulistin, Holzikofenw. 14
 – Klara, Verkäuferin, Riedernstrasse 46, Bümpliz
 – Lena, Haushaltungslehrerin, Morgenstr. 81, Bümpliz
 – Lina (Jordi), Wwe., Spezereihdlg., Bernastrasse 71 [24.994]
-– Ludwig (Busset), Hilfsarbeiter. Dapplesweg 8
+– Ludwig (Busset), Hilfsarbeiter, Dapplesweg 8
 – Ludwig, Magaziner der Waffenfabrik, Pappelweg 8
 # Date: 1935-12-15 Page: 26020611/306
 Lüthi und Lüthy
 – Lydia Bertha, Fabrikarbeiterin, Wylerfeldstrasse 42
 – Magdalena (Lüthi), Wwe., Neufeldstr. 27
-– Marg., Verkäuferin, Badgasse la
+– Marg., Verkäuferin, Badgasse 1a
 – Margaretha, Modistin, Mühleplatz 8
 – Margaritha, Bureaulistin, Sonneggweg 19
 – Margaritha, Bureaulistin, Keltenstr. 104, Bümpliz
 – Margr., Kanzlistin O. P. D., Schauplatzg. 23
-– Margr. Rosina. Ladentochter. Allmendstrasse 50
-– Maria El., Damenschneid.. Keltenstr. 104, Bümpliz
+– Margr. Rosina. Ladentochter, Allmendstrasse 50
+– Maria El., Damenschneid., Keltenstr. 104, Bümpliz
 – Maria (Muster), Bridelstrasse 88
 – Maria Rosa, Giletschneiderin, Brunnhofweg 18
 – Marie, Aushilfe, Lentulusstrasse 34
@@ -28846,7 +28806,7 @@ Lüthi und Lüthy
 – O., & Cie., Kleiderstoffe, Konfekt., Marktgasse 37 [27.957]
 Lutiger, Arthur, Tapezierer, Breitfeldstr. 31
 – CI., Kontrolleur S. S. B., Rosenweg 20
-– Edwin Eduard, Elektroteehn.. Rosenweg 20
+– Edwin Eduard, Elektroteehn., Rosenweg 20
 Lütolf, Alois, Monteur, Schärerstrasse 1
 – Bertha L., Ladentochter, Schärerstrasse 1
 – Hans, gew. Beamter S. B. B., Wernerstr. 22 [35.562]
@@ -28883,7 +28843,7 @@ Lutz, A. Elisab., eidg. Beamtin, Effingerstr. 91
 – Joh. Georg Christ., Dr. phil., Beamter der
 Landesbibliothek, Viktoriastr. 69 [20.274]
 – Joh., Buchbinder, Brückenstrasse 12
-– Johanna Ad.. Bureaulistin, Effingerstr. 41
+– Johanna Ad., Bureaulistin, Effingerstr. 41
 – K. Felix, Sekretär der Kreispostdirektion, Hrch.-Wildstrasse 14
 – Karl, Fürsorger, Bäckereiweg 13
 – Leo Heinr., Kaufmann, Effingerstrasse 41
@@ -28902,7 +28862,7 @@ Luxin-Werk, Otto Schoeni, Fabrik chemischtechn. Produkte. Effingerstr. 71a [23.4
 Lysser, Herrn Gottfr. (Hirt), Schlachthofarbeiter, Breitfeldstrasse 50
 – Otto (Platzer), Metzgermeister, Waldheimstrasse 27
 Maag, A. Viktoria, Bankangestellte, Neufeldstrasse 111
-– Edgar (Berchten), eidg. Beamter, Reichenbachstrasse 8 . [28.191]
+– Edgar (Berchten), eidg. Beamter, Reichenbachstrasse 8 [28.191]
 – Em., Beamter S. B. B., Beaulieustrasse 31
 – Ernst, Müller, Wachtelweg 11
 – F. Martha, Ladentochter, Beaumontweg 28 [29.525]
@@ -28934,7 +28894,7 @@ Macri, L. S., Schuhmachermeister u. Schuhhandlung (Sennweg 7), Hirschengraben 6 
 Mädchenerziehungs-Anstalt Steinhölzli [45.051]
 Mädchenhort Länggasse, Länggassstrasse 62
 Mädchenschule, Neue. Nägeligasse 6 [27.981]
-Mädchensekundarschule, Monbijoustrasse 25 [24.6821, Laubeckstrasse 23 [24.8831] und Sulgeneckstrasse 26 [23.265]
+Mädchensekundarschule, Monbijoustrasse 25 [24.682], Laubeckstrasse 23 [24.883] und Sulgeneckstrasse 26 [23.265]
 Mädchenwaisenhaus, bürgerliches, Alexandraweg 28 [23.263]
 de Maddalena, B., in Fa. Gebr. de Maddalena, Hochfeldstrasse 7 [22.299]
 – Ignace, in Fa. Gebr. de Maddalena. Hochfeldstrasse 7 [35.438]
@@ -28994,7 +28954,7 @@ Mäder, Alb., Autofahrschule, Brückfeldstr. 23 [21.181]
 – Friedr., Melker, Alter Aargauerstalden 32
 – Friedr., Posthalter, Riedbachstrasse 341, Riedbach
 – Friedr., Schriftsetzer, Bühlstrasse 21a
-– Friedr., Weichenwärter. Zähringerstr. 75
+– Friedr., Weichenwärter, Zähringerstr. 75
 – Fritz, I3eamter S. B. B., Hochfeldstr. 19
 – Fritz, Hilfsarbeiter, Stalden 8
 – Fritz, Konfiserie, Aarbergerg. 31 [21.418]
@@ -29006,7 +28966,7 @@ Mäder, Alb., Autofahrschule, Brückfeldstr. 23 [21.181]
 – Hanna, Bureaulistin, Kasernenstrasse 38
 – Hanna, Bureaulistin, Myrtenweg 8, Bümpliz
 – Hanna, Bureaulistin O. Z. D., Brunnbofweg 32
-– Hans, Bäckermeister. Kramg. 76 [31.592]
+– Hans, Bäckermeister, Kramg. 76 [31.592]
 – Hans W., Landwirt, Waldau
 – Hans, Maler, Lentulusstrasse 28
 – Hans, Molkereiangestellter, Bäckereiw. 15
@@ -29026,7 +28986,7 @@ Mäder, Herm. Alb., Lok.-Heizer d. S. B. B., Berchtoldstrasse 42
 – Lina (Keller), Wwe., Herrengasse 17
 – Lydia P. H., Beamtin O. P. D., Allmendstrasse 35
 – Margr., Hilfsarbeiterin, Krippenstrasse 26
-– Maria A. (Häberli), Privat., Buchweg 16, . Riedbach
+– Maria A. (Häberli), Privat., Buchweg 16, Riedbach
 – Marie, Privatiere, Rehhagstr. 42, Bümpliz
 – Martha, Posthalterin, Riedbachstrasse 341, Riedbach
 – Martha, Priv., Rehhagstr. 42, Bümpliz
@@ -29142,7 +29102,7 @@ Mailand, Karl Georg, Kürschner, Marktg. 4 [24.727]
 Maillard, Em. (Lindenmann), Wwe., Schwarztorstrasse 21
 – Lina (Zurflüh), Lorrainestrasse 63
 Maillart, A., Zahnarzt, Dozent f. Kronen- u. Brückenarbeiten, Luisenstr. 26 [27.943]
-– Rob,, Ingenieurbureau, Ferd.-Hodlerstr. 18 [21.246]
+– Rob., Ingenieurbureau, Ferd.-Hodlerstr. 18 [21.246]
 Mailiefer, Germaine M., Coiffeuse, Hallerstrasse 31
 Mainardi, Vincenzo (Bernasconi), Baugesch., Schönbergweg 3 [23.655]
 Maire, Alb. Etienne, Hilfsarbeiter, Marzilistrasse 32
@@ -29153,7 +29113,7 @@ Maire, Alb. Etienne, Hilfsarbeiter, Marzilistrasse 32
 Maisch, L. (Horiler), Dr. jur., Fürspr., Advokaturbureau u. wirtschaftl. Organisation (Elfenstrasse 16 [28.454]), Bubenbergpl. 9 [24.441]
 — Lotte, Import von Glaswaren, Elfenstr. 16
 Maison, Charles Fr. F. (Simon), Ingenieur, Monbijoustrasse 67 [28.143]
-Maison Bühlmann, S. A,, Berne, Corsets und Damenartikel, Monbijoustrasse 28 [34.250]
+Maison Bühlmann, S. A., Berne, Corsets und Damenartikel, Monbijoustrasse 28 [34.250]
 Maison Rubis S. A., Zürich, Zweigniederlassung Bern, Bonneterie, Lingeriewaren, Spitalgasse 1, « Bäreek » [25.660]
 Maison « tiofa » (Guckenberger-Kohler), Türkischbad, Zeitglockenlaube 4 [32.288]
 Ma'itre, Jules Arth., Chauffeur, Murtenstr. 40
@@ -29174,7 +29134,7 @@ Mailet, Jacques, Typograph, Schanzenbergstrasse 34
 Mamie, Otto, Eisendreher, Waldheimstr. 25
 Mammele, Elsa Friederike. Giletmacherin, Kursaalstrasse 15
 – Emma, Bureaulistin, Kursaalstrasse 15
-– K.. Schneidermeister. Kursaalstrasse 15
+– K., Schneidermeister, Kursaalstrasse 15
 – Martha (Fasel), Damenfrisiersalon (Viktoriastrasse 43), Waisenhauspl. 15 [34.774]
 – Wilh. Herm., Coiffeur (Viktoriastrasse 43 [35.518]), Waisenhausplatz 15 [25.360]
 Mancini, Graz. C., Insp., Jubiläumsstr. 85 [28.083]
@@ -29243,7 +29203,7 @@ Marbot, Ernst, Monteur, Scheibenstrasse 25
 – Hans, Maschinenschlosser, Stationsweg 42
 – J., Hilfsarbeiter, Flurstrasse 24
 – Rosa, Frau, Längere, Mattenhofstrasse 20
-– Walter. Heizungsmonteur, Karl-Staufferstrasse 27
+– Walter, Heizungsmonteur, Karl-Staufferstrasse 27
 – Werner, Metzger, Gartenstrasse 4a Marca, Fed., Betriebstechniker d. S. S. B., Landoltstrasse 51 [26.399]
 – Germ. (Hurst), Damenschneiderin, Landoltstrasse 51
 Marcel, M. A. Cecile (Conod), Privat., Thunstrasse 63 [23.697]
@@ -29256,7 +29216,7 @@ Marchand, Andre, Beamter, Feldeggweg 1
 – Lucie Emma, Ladentochter, Beatusstr. 7
 – Marcel, Sekretär der Importstelle des Verbandes schweizer. Lederhändler, Hallwylstrasse 46 [33.917]
 – Ren6 G. Ch., Elektrotechniker. Aegertenstrasse 73
-– Rob.. Bankbeamter, Brunnmattstrasse 69
+– Rob., Bankbeamter, Brunnmattstrasse 69
 Marcionelli, Arturo, eidg. Beamter, Mittelstrasse 32
 Marconi, Dolores, Modistin, Metzgergasse 17
 Marcuard, Adele, Frl., Rent., Schänzlistr. 39 (Salem)
@@ -29274,7 +29234,7 @@ Marfurt, Anna Margr., Postbeamtin, Viktoriastrasse 53
 – K. B. L. Sophie (Medina), Wwe., Spitalackerstrasse 27
 Margairaz, A., Ausläufer, Forstweg 44
 – Ernest, Buchbinder, Forstweg 48
-Marggi, Walter. Kaufmann, Schwarztorstr. 22
+Marggi, Walter, Kaufmann, Schwarztorstr. 22
 Margot, Ch. Andrd, Beamter S. B. B., Breitenrainplatz 36
 – Emil Henri, int. Beamter, Spitalackerstrasse 21
 Fahrplan-Reklamedurch den Tourlsten-Fahrplan (Verlag Hallwag, Bern)ist lohnend und vielseitig, weil sie Ihre Firma und Erzeugnisse mit allen Kreisen in Verbindung bringt. Verlangen Sie Frei-Offerte vom Verlag.
@@ -29318,7 +29278,7 @@ Märki, Albert, Verkäufer, Fichtenweg 13
 – Erwin, Hilfsarbeiter, Kyburgstrasse 9
 – Frieda, Frau, Coiffeusegeschäft, Weissensteinstrasse 73
 – Fritz, Schneidermeister, Muristrasse 87 [28.523]
-– Gustav H., Kondukteur S. B. B.. Gewerbestrasse 21
+– Gustav H., Kondukteur S. B. B., Gewerbestrasse 21
 – Hans, Schneider, Muristrasse 87
 – Heidi, Modistin, Ulmenweg 13
 – J. Wilh., Fabrikarbeiter, Randweg 1
@@ -29340,7 +29300,7 @@ Marolf, Fritz, Bankbeamter, Flurstrasse 29
 – Fritz, Magaziner, Kasernenstrasse 19
 – Katli. (Strohmaier), Wwe., Dietlerstr. 14
 – Paul, Milchproduktenhandlg., Metzgerg. 10
-.— Rud. E., kant. Beamter, Tiefmattstrasse 6
+— Rud. E., kant. Beamter, Tiefmattstrasse 6
 Maron, Herm., Bankprokurist, Spitalackerstrasse 68 [36.917]
 – Math., Bankangestellte, Spitalackerstr. 68
 Maroni, Joh. Julius, Buchdrucker, Laubeckstrasse 53 [29.254]
@@ -29366,8 +29326,8 @@ Marthaler, Alfred. Kaufmann, Bümplizstr. 98
 – Fr., pens. Sektionschef b. d. Oberpostkontrolle, Neufeldstrasse 131 [35.662]
 – Frieda, Glätterin, Stöckackerstrasse 72, Bümpliz
 – Friedr., Arbeiter S. B. B., Freiestrasse 52
-– Friedr., alt Bahnarbeiter. Stöckackerstr. 72, Bümpliz
-– Friedr., Landwirt u. Fuhrhalter. Riedernstrasse 52, Bümpliz
+– Friedr., alt Bahnarbeiter, Stöckackerstr. 72, Bümpliz
+– Friedr., Landwirt u. Fuhrhalter, Riedernstrasse 52, Bümpliz
 – Friedrich, Ausläufer, Stöckackerstrasse 72, Bümpliz
 – Fritz Traugott, Landwirt, Oberbottigenweg 63, Oberbottigen
 – Fritz, Sohn, Landwirt, Riedernstrasse 52, Bümpliz
@@ -29385,8 +29345,8 @@ Marthaler, Hans, Angestellter, Polygonweg 31 [20.912]
 – Paul Niklaus, sen., Bümplizstrasse 118
 – Paul, Milch-, Butter- und Käsehandlung, Bümplizstrasse 118 [46.138]
 – Rudolf, Ausläufer, Polygonweg 31
-– Rud., Bahnarbeiter. Elisabethenstrasse 40
-– Rud., Hilfsarbeiter. Steinhauerweg 3
+– Rud., Bahnarbeiter, Elisabethenstrasse 40
+– Rud., Hilfsarbeiter, Steinhauerweg 3
 – Rud., Landwirt, Riedernstr. 42, Bümpliz
 – Rud., Sohn, Landwirt, Riedernstrasse 42, Bümpliz
 – Rud., Schreiner, Hochfeldstrasse 45
@@ -29498,7 +29458,7 @@ Marti, s. auch Marty u. Martin
 – Helene, Marienstrasse 25 [33.774]
 – Herm. A. (Messerli), Techniker, Breitfeldstr&ss6 36
 – Herm., Oberrichter, Kollerweg 32 [31.296]
-– Herm., Poslangestellter. Birkenweg 40
+– Herm., Poslangestellter, Birkenweg 40
 – Hermann Walter, in Firma Gebr. Marti, Schwarzenburgstrasse 4 [23.480]
 – Hermine (Haas), Wwe. d. Seminarlehrers, Schützenweg 5
 – Hilda O., Sekretärin, Laubeckstrasse 22
@@ -29518,13 +29478,13 @@ Hugo, Dr., literar. Bedakteur am «Bund», Junkerngasse 61 [31.346]
 – Joh., Polizist, Lorrainestrasse 58
 – Joh. Fr., Polizist, Murifeldweg 9
 – Joh. Chr., Schlosser, Brunnmattstrasse 77
-– Johanna Lydia, Ladentochter. Muesmattstrasse 30
+– Johanna Lydia, Ladentochter, Muesmattstrasse 30
 — Johanna, Dr. phil., Chemikerin, Schulweg 6
 Marti, siehe auch Marty und Martin
 – Juliette, Gehilfin Kr. T. D., Greyerzstr. 22
 – Karl, Bahnarbeiter, Worblaufenstr. 5a
 – Karl (Steffen), Büchsenmacher, Militärstrasse 40
-– Karl Rud., Gasarbeiter. Kasthoferstr. 20
+– Karl Rud., Gasarbeiter, Kasthoferstr. 20
 – Karl Rud., Kaufmann, Viktoriastrasse 61
 – Karl, Obermandatträger, Wachtelweg 21
 – Karl Alfred, Provisionsreisender, Murifeldweg 21
@@ -29576,7 +29536,7 @@ Marti, s. auch Marty und Martin
 – Rud., Handlangei’, Waffenweg 20
 – Rud., Hilfsarb., Bottigenstr. 76, Bümpliz
 – Rud., Maurer, Weberstrasse 15
-– Samuel, Maschinenmeister. Murifeldweg 62
+– Samuel, Maschinenmeister, Murifeldweg 62
 – Theodor, Konfiserie, Belpstr. 18 [24.1011
 – Vreneii, Verkäuferin, Altenbergstrasse 102
 – Walter, Hilfsarbeiter, Cäcilienstrasse 20
@@ -29592,10 +29552,10 @@ Martig, Elise, Beamtin, Greyerzstrasse 28
 – Emma (Würsten), Wwe., Hallerstr. 12
 – Ernst, Postbeamter, Marktgasse 52
 – Gertr. Lina, Fabrikarb., Tannenweg 14
-– Lina (Haldemann), Wwe.. Tannenweg 14
+– Lina (Haldemann), Wwe., Tannenweg 14
 – Marie (Stubenrauch), Damenfrisiersalon, Marktgasse 52 [35.269]
 Martignoni, Gust. Ad., Kommis, Bantigerstrasse 32
-Martin, Ad., Dachdeckermeister. Junkerng. 14
+Martin, Ad., Dachdeckermeister, Junkerng. 14
 – Adolphe, Fabrikarbeiter, Junkerngasse 14
 – Alb., in Fa. A. Martin & Sohn, Magazinweg 10 [36.424]
 – Alb., in Fa. A. Martin & Sohn, Magazinweg 10
@@ -29643,7 +29603,7 @@ Marty, siehe auch Marti u. Martin
 – Alois, Wärter, Schermenweg 30
 – Edwin, Mechaniker, Rodtmattstrasse 53
 – Erwin. Buchbinder. Wiesenstrasse 81
-– Hermine, Ladentochter. Gerechtigkeitsg. 46
+– Hermine, Ladentochter, Gerechtigkeitsg. 46
 – Ida, Näherin, Neuengasse 15
 – J. (Siegrist), eidg. Beamter, Optingenstr 45 [27.560]
 – Joh., Ing. der B. K. W., Viktoriastrasse 47 [34.507]
@@ -29846,13 +29806,13 @@ Matti, Arn., Gärtnermeister, Mühlenplatz 10
 – Ernst, Chauffeur, Brunnmattstrasse 47
 – Ernst, Versich.-Inspektor, Mittelstr.il
 – Hans Arn., Dr. jur., Prof., Fürsprecher (Helvetiastr. 41 [23.106]), Münzgraben 6 [21.645]
-– Hermann, Prof. Dr. med.. Chefarzt d. Chirurg. Abtlg. d. Zieglerspitals, Sonnenbergstrasse 9 [22.087]
+– Hermann, Prof. Dr. med., Chefarzt d. Chirurg. Abtlg. d. Zieglerspitals, Sonnenbergstrasse 9 [22.087]
 – Jakob, Postbeamter, Seidenweg 42
 – Joh., Gemüsehandlung, Stauffacherstr. 12 [23.479]
 – Karl Gottfr., Metzger, Bernstr. 103, Bümpliz
 – Karl Gottl., Schuhmacher, Muldenstr. 48
 – Klara Luise, Bureaulistin, Gesellschaftsstrasse 25
-– Luise, Wwe.. Gesellschaftsstrasse 25
+– Luise, Wwe., Gesellschaftsstrasse 25
 – Magdal., Wwe., Mittelstrasse 11
 – Paul, Heizer. Mühleplatz 10
 – Rosa, Postgehilfin, Gesellschaftsstrasse 25
@@ -29868,7 +29828,7 @@ Mattmüller, A., Rotkreuzschwester, Hallerstrasse 62 [28.313]
 – Julius, Verwalter, Zeughausgasse 39
 Matz, Ernst. Zeichner für graphische Reproduktion, Podtmattstrasse 90
 Matzinger, Albert, Pferdewärter, Allmendstrasse 48
-– Emil, Beamter. Steigerweg 18
+– Emil, Beamter, Steigerweg 18
 – Emil, Beamt. S.B.B., Hallerstr. 53 [27.506]
 – Emil, Reisender, Zeughausgasse 22
 – -Joh., Milchführer, Wylerstrasse 23
@@ -29881,7 +29841,7 @@ Mätzler, Herm. Bernh., Dr. jur., eidg. Beamter, Schwarztorstrasse 17 [28.995]
 Mauch, Hermann, Bankbeamter, Moserstr. 40
 – Sam. (Stucker), Moserstrasse 40
 Maucher, Ernst, Zeugschmied, Ladenwandstrasse 98
-– M.. Schneider, Gesellschaftsstrasse 41
+– M., Schneider, Gesellschaftsstrasse 41
 Mauderli, Adele (Fasnacht), Wwe. d. Bankdirektors, Dählhölzliweg 19 [34.331]
 – Elise (Nebel), Wwe., Falkenhöheweg 17 [34.630]
 – Fritz Wilh., Dr. med., Arzt, Schanzenstr. 4 [28.950]
@@ -29899,7 +29859,7 @@ Mauerhofer, s. auch Maurhofer
 – Arnold, Sektionschef b d. Generaldirektion
 P. T. T., Donnerbühlweg 5a [35.186]i —Dora Hermine, Fabrikarbeiterin, Brunng. 8
 – Ernst, Kaufmann, Karl-Schenkstrasse 9
-– Ernst, Stallmeister. Sandrainstrasse 4a
+– Ernst, Stallmeister, Sandrainstrasse 4a
 – Friedr., Wagner, Marzilistrasse 23
 – Fritz, Dr. med., Spezialarzt für innere
 Krankheiten, Schanzenbergstr. 27 [33.508]
@@ -29980,10 +29940,10 @@ Maurer, s. auch Murer
 – Friedr (Rüfenacht), Gruppenführer, Stadtbachstrasse 6
 – Friedr. (Märki), gew. Malermeister, Eschmapnstrasse 9 [32.958]
 – Friedr., Handlanger, Forstweg 46
-– Friedr,, Hilfsarbeiter, Murifeldweg 44
+– Friedr., Hilfsarbeiter, Murifeldweg 44
 – Friedr., Schreiner. Seidenweg 18
 – Friedr., Schriftsetzer, Elisabethenstr. 45
-– Fritz, Bereiter. Stauffacherstrasse 12
+– Fritz, Bereiter, Stauffacherstrasse 12
 – Fritz (Röthlisberger), Chauffeur S. O. B., Martiweg 16
 – Fritz, Coiffeur, Bahnhöheweg 86, Bümpliz
 – Fritz Walter, Karossier, Rütlistrasse 2
@@ -29996,7 +29956,7 @@ Maurer, s. auch Murer
 – Hanna K., Arbeiterin S. B. B., Gutenbergstrasse 8
 – Hedwig Frieda, Bureaulistin. Könizstr. 39
 – Henriette M. J (Ticky), Damenschneiderin, Mäntel, Pelze, Schauplatzgasse 9
-– Herm., Dr. oec. publ., Sekretär, Gutenbergstrasse .7
+– Herm., Dr. oec. publ., Sekretär, Gutenbergstrasse 7
 – Herm. (Balmer), Kaufmann, Hochfeldstr.24
 – Herm., Kommis, Kranügasse 60
 — Hulda G., Damenschneiderin, Forstweg 36
@@ -30023,7 +29983,7 @@ Maurer, siehe auch Murer
 – Marie, Bureaulistin, Lagerweg 7
 – Marie Marg., Bureaulistin, Könizstrasse 39
 – Marie, Ladentochter, Stauffacherstr. 12
-– Marie (Zaugg), Wwe.. Polygonweg 4
+– Marie (Zaugg), Wwe., Polygonweg 4
 – Martha, Damenschneiderin, Kapellenstr. 12 [34.978]
 – Max Eugen, Beamter S. B. B., Depotstr. 46
 – Max, Zeichner, Kornhausplatz 2
@@ -30031,7 +29991,7 @@ Maurer, siehe auch Murer
 – Oskar, Magaziner, Polygonweg 4
 – Oskar E., Vertreter, Thunstr. 103 [27.685]
 – Otto, Bäckermeister, Breitenrainstrasse 59 [32.751]
-– Otto (Heggendorn). Chef der Eilgutexpedition, Neufeldstrasse 10 . [27.781]
+– Otto (Heggendorn). Chef der Eilgutexpedition, Neufeldstrasse 10 [27.781]
 – Otto, Kanzleisekretär, Friedensstrasse 11
 – Otto, Notar, Prokurist der Kantonalbankvon Bern, Mühlemattstrasse 41 [29.519]
 – Paul, Ausläufer, Polygonweg 4
@@ -30098,12 +30058,12 @@ Maxim A.-G., Fabrik thermo-elektr. Apparate, Verkaufsfiliale Bern, Mittelstrasse
 v. May, Alice. Junkerngasse 61 [33.956]
 – Armin K. L., Bankbeamter, Blumenbergstrasse 6
 – Beat Gust. M. (Bergemann), Bubenbergplatz 4
-.— Ed. Alfr. (Marcuard), Instruktionsoffizier, Münzrain 3a [36.227]
+— Ed. Alfr. (Marcuard), Instruktionsoffizier, Münzrain 3a [36.227]
 v. May, Erich (v. Graffenried), Techn. Bedarfsartikel, Elfenauweg 19 [32.913]
 – Eugen (Brunner), Dr. med., Kinderarzt, Obere Dufourstrasse 29 [22.760]
 – Gabriel M., Obere Dufourstrasse 47
 – Lea (Abegglen), Wwe., Bubenbergplatz 4
-– M. G. (Thomas), Wwe., Ob. Dufourstr. 47 [34.711] .
+– M. G. (Thomas), Wwe., Ob. Dufourstr. 47 [34.711]
 – M. Dorothea, Rotkreuzschwester, Freiburgstrasse 18
 May, s. auch Mai und Mey
 – Gottfr., Sekretär b. d. eidg. Landestopographie, Heimstrasse 24, Bümpliz
@@ -30113,7 +30073,8 @@ Maybach, s. auch Maibach
 – Kurt, cand. jur., Helvetiastr. 21 [33.232]
 – Otto (Berger), Notar (Helvetiastrasse 21 [33.232]), Neuengasse 41 (v. Werdt-Passage) [24.602]
 – Theodor, Bankangestellter, Helvetiastr. 21
-– Valentine, Lehrerin, Brunnadernrain 8v. Maydell, Sophie M. A., Heilsarmeeoffizierin, Laupenstrasse 27
+– Valentine, Lehrerin, Brunnadernrain 8
+v. Maydell, Sophie M. A., Heilsarmeeoffizierin, Laupenstrasse 27
 Maydell, Carola, Angestellte, Habsburgstr. 6
 Mayer, s. auch Maier, Meier und Meyer
 – Anton Wilhelm, Vers.-Angest., Frohbergw. 5 [29.054]
@@ -30133,7 +30094,7 @@ Mayor, Emil, Beamter, Wildermettweg 39
 Mayr, Kreszentia, Modegeschäft, Marktg. 65 [21.523]
 Mayser, Julius (Immer), gew. Bankprokurist, Monbijcustrasse 28
 – Olga M., Sekundarlehrerin, Monbijoustr. 28 [36.669]
-– Ruth E.. Lehrerin, Monbijoustrasse 28
+– Ruth E., Lehrerin, Monbijoustrasse 28
 Meag A.-G., Liegenschaftenhandel, Bärenpl. 9
 Mechano-therapeutisches Institut im Spital Salem (Dr. F. Büeler), Schänzlistrasse 39 [24.333]
 Mechler, Charles A., Typogr., Gewerbestr. 18a
@@ -30148,7 +30109,7 @@ Medofsky, N., Tillierstrasse 52
 Meer, Chr., gew. Bahnarbeiter, Elisabethenstrasse 35
 – Elisabeth (Schweizer), Wwe., Konradweg 9
 – Elise, Bureauangestellte, Konradweg 9
-– Friedr.. Bäcker, Murtenstrasse 26
+– Friedr., Bäcker, Murtenstrasse 26
 – Friedr., Billetteur d. S. S. B., Muristr. 54
 – Friedrich, Mechaniker, Muldenstrasse 57
 – Hans, Coiffeur, Murtenstrasse 26
@@ -30156,7 +30117,7 @@ Meer, Chr., gew. Bahnarbeiter, Elisabethenstrasse 35
 – Margaritha, Bankangestellte, Konradweg 9
 – Mina, Weberin, Elisabethenstrasse 35
 – Paul, Vorsteher der Arbeitshütte, Sulgenrain 26
-– Rud.. Schriftsetzer, Murtenstrasse 26
+– Rud., Schriftsetzer, Murtenstrasse 26
 – Werner, Hilfsarbeiter, Effingerstrasse 41d
 – & Cie., Möbelverkauf, Innenarchitektur, Effingerstrasse 21/23 [25.656]
 Meerstetter, Eduard, Bauzeichner, Junkerngasse 26
@@ -30170,7 +30131,7 @@ Megert, Adolf, Bauarbeiter, Nordweg 6
 – Dewet R., eidg. Angest., Effingerstr. 33
 – Emil, Angestellter, Waffenweg 16
 – Ernst Otto, Buchhalter, Breitfeldstr. 10
-– Fritz Emil, Pferdewärter. Breitfeldstr. 6
+– Fritz Emil, Pferdewärter, Breitfeldstr. 6
 – Hanna, Bureaulistin, Effingerstrasse 55
 – J. Jakob, Hilfsarbeiter, Mattenenge 9
 – J., Schuhmachermeister, Sulgeneckstr. 64
@@ -30184,7 +30145,7 @@ Megert, Adolf, Bauarbeiter, Nordweg 6
 – Robert Willi., Schriftsetzer, Frikartweg 16
 – Rosa, Fabrikarbeiterin. Bahnstrasse 63
 – Rosine Kath. (Knutti), Wwe., Effingerstrasse 55
-– Rud.. Maschinenmeister, Muristrasse 73
+– Rud., Maschinenmeister, Muristrasse 73
 Megroz, Ernst, Maler, Herzogstrasse 24
 Mehlhorn, Ed., Rechnungsführer der Staat.skanzlei, Jägerweg 2 [28.489]
 Mehner, G Hugo. Schneider, Beaumontw. 14
@@ -30261,7 +30222,7 @@ Meister, siehe auch Meystre
 – Lina, Lingere, Brunnmattstrasse 36
 – Mario (Jakob), Wwe., Schwarztorstr. 19
 – Marie Hedwig, Breiteweg 10
-– Marie Gertr., Ladentochter. Marzilistr. 25
+– Marie Gertr., Ladentochter, Marzilistr. 25
 – Marie, Wäscherin, Schifflaube 46
 – Marie (Trautwein), Wwe., Schänzlistr. 47
 – Martha (Kuhn), Wwe., Optingenstr. 41
@@ -30288,7 +30249,7 @@ Mellier, Frank (Jaton), Beamter b. eidg. Patentamt, Lorrainestrasse 65
 Melliger, Alphons Hans, Dr. jur., eidg. Beamter, Steinerstrasse 12
 – Elise (Flühmann), Wwe., Gipser- u. Malergeschäft. Graffenriedweg 6 [34.482]
 Melloni, Lse. Jeanne, Fabrikarbeiterin, Birkenweg 49
-Membrez, Leopold G., Archivbeamter. Moserstrasse 25
+Membrez, Leopold G., Archivbeamter, Moserstrasse 25
 – Paul Alfr. Eug., Postbeamter, Schwarztorstrasse 53
 Mende.Edw. (Morgenthaler), Dr.med., Brunnadernrain 37 [28.328]
 – Fanny (Moser), Witwe des Ingenieurs, Tscharnerstrasse 13 [32.671]
@@ -30299,7 +30260,7 @@ Meng, Florian (Graf), eidg. Beamter, Scheuermattweg 2 [21 746]
 – Fritz, eidg. Beamter, Jägerweg 3 [33 048]
 – Herm. (Hänni), Postangest., Hochfeldstrasse 43
 – Martha V., Bureaulistin, Kramgasse 30
-– V . Wwe . Kramgasse 30 [33 695]
+– V., Wwe., Kramgasse 30 [33 695]
 Menge, Antoinette, Bureaulistin, Pestalozzistrasse 16
 – Augusta, Lingere, Pestalozzistrasse 16
 – Erich, Gärtner. Pestalozzistrasse 16
@@ -30310,7 +30271,7 @@ Mengisen, U. J., Sattler, Wylerstrasse 69
 Menner, Otto (Bücher), Zollbeamter, Sennw. 9
 Mennet, Jules, Dr. med., Spezialarzt für Geburtshilfe und Frauenkrankheiten, Seilerstrasse 3 [27.244]
 – Marg. A. Bl., Bankangestellte, Seilerstr. 3
-Menotti, Maria D., Fabrikarbeit,, Ulmenweg 4
+Menotti, Maria D., Fabrikarbeit., Ulmenweg 4
 Menso, Marg., Wwe., Musikerin, Zähringerstrasse 69
 – Renata, Bureaulistin, Zähringerstrasse 69
 Ment, J. Gottfr., Postangest., Hubelmattstr. 8
@@ -30326,11 +30287,11 @@ Mercantil A.-G., Kaffee- u. Tee-Spezialgesch., Karl-Schenk-Haus, Spitalgasse 4 [
 Mercedes-Benz Automobil A.-G., Zürich. Filiale Bern, Weissenbühlweg 40 [25.952]
 Mercerat, Jules Emile Henri, Kaufmann, Scheuermattweg 12 [27.969]
 Mergozzi, Giov., Direktor b. Troesch & Cie., A.-G., Gutenbergstrasse 5 [31.722]
-Merian. A.. Bürobedarf u. Vertretungen Tavelweg 16 [31.796]
+Merian. A., Bürobedarf u. Vertretungen Tavelweg 16 [31.796]
 – E. (ALles), Tavelweg 16 [31.796]
 – Emil Max. in Fa Merian. Studer & Cie..
 Weissensteinstrasse 93 [31.955]
-– Emil Rud.. Prediger, Tavelweg 16
+– Emil Rud., Prediger, Tavelweg 16
 – Ernst Paul, in Fa. Merian. Studer & Cie., Chutzenstrasse 26
 – M (Scheurmann). Wwe., in Fa. Merian, Studer & Cie., Chutzenstrasse 26 [28.731]
 # Date: 1935-12-15 Page: 26020630/323
@@ -30395,12 +30356,11 @@ Merz, Albin, Geschäftsführer, Cäcilienstr. 14 [32.854]
 – Friedr., Schlosser, Rodtmattstrasse 108
 – Fritz Emil, Postangestellter, Berchtoldstr. 9
 – Fritz (Eggenschwiler). Prokurist der Kantonalbank von Bern, Seidenweg 45
-– G. Friedr., Pferdewärter. Rodtmattstr. 108
+– G. Friedr., Pferdewärter, Rodtmattstr. 108
 – Georg Hans, Dr. jur., Fürspr. (Effingerstrasse 61 [23.501]), Bollwerk 15 [24.901]
 – Gertrud, Laupenstrasse 45
 – Guido W., Buchhalter, Friedheimweg 51
-Merz, Hans Diri. Architekt. 22.966
-Mayweg 3
+Merz, Hans Diri. Architekt, 📞 22.966 Mayweg 3
 – Hans, Neuengasse 14
 – Hans Alb., Maschinist, Wattenwyhveg 28
 – Hans, Mechaniker, Herzogstrasse 24
@@ -30421,7 +30381,7 @@ Merz, Johann Architekt, 📞 22.966 (Wenser), Mayweg 3
 – Luise, gew. Lehrerin, Distelweg 19
 – Lydia. Bureaulistm, Sickingerstrasse 7
 – Marie (Schmid). Wwe., Laupenstrasse 27
-– Max Emil, kaufm. Angest.. Freiburgstr. 30
+– Max Emil, kaufm. Angest., Freiburgstr. 30
 – Otto, Beamter S. B. B., Hallerstrasse 56
 – Otto, Dreher, Sickingerstrasse 7
 # Date: 1935-12-15 Page: 26020631/324
@@ -30433,7 +30393,7 @@ Merz, Otto Gust., Mech. Werkstätte (Herzogstrasse 20 [27.729]), Zollikofen
 – Viktor (Spring), pens. Bundesrichter, Monbijoustrasse 123 [20.889]
 – Walter V., Architekt, Kirchbühlweg 30
 – Walter Fritz, Schriftsetzer, Bümplizstr. 188
-– Walter Jakob. Dr., Ghem.. Bümplizstr. 97
+– Walter Jakob. Dr., Ghem., Bümplizstr. 97
 – Werner P., Mechaniker, Bümplizstr. 188
 – & Benteli, chemisches Laboratorium, Bümplizstrasse 97 [46.194]
 Meschini, Luigi, Metzger, Mittelstrasse 30
@@ -30448,12 +30408,12 @@ Messer, Ad., Hilfsarbeiter, Matzenriedstr. 103, Oberbottigen
 – Elise (Tröhler), Gutsbesitzerin, Matzenriedstrasse 113, Oberbottigen
 — Fr., Bäckerei und Konditorei, Rodtmattstrasse 118 [32.242]
 — Friedr., Bankangestellter, Rodtmattstr. 118
-– Friedr.. Gipser, Läuferplatz 3
+– Friedr., Gipser, Läuferplatz 3
 – Fritz, Chauffeur, Brunnhofweg 37
 — Ida, Frau, Zigarrenhdlg., Brunnmattstr. 48
 — Jakob, Chauffeur, Wabernstrasse 6
 — Jakob, Präparator, Neufeldstrasse 7
-– Joh. Rud.. Metzger, Birkenweg 19
+– Joh. Rud., Metzger, Birkenweg 19
 — Joh., Zugführer, Seidenweg 2
 — Louis O., Einkäufer, Aarbergergasse 36
 – Moritz, Zeughausarbeiter, Breitfeldstr. 32
@@ -30461,7 +30421,7 @@ Messer, Ad., Hilfsarbeiter, Matzenriedstr. 103, Oberbottigen
 – Ros., Frau, Feldheimweg 42a, Bümpliz
 Messerli, Ad., Bureauangest., Bäckereiweg 17
 – Ad., Coiffeurgeschäft (Bremgarten), Neuengasse 43 [35.552]
-– Ad.. Metzger, Dalmaziweg 67
+– Ad., Metzger, Dalmaziweg 67
 — Albert, Fabrikarbeiter, Felsenaustrasse 16
 – Albertine, Pension, Breitenrainplatz 27 [21.994]
 — Alfred Hch. (Scheidegger), Bankbeamter, Niggelerstrasse 16 [35.647]
@@ -30518,7 +30478,7 @@ Messerli, Elise, Lingere, Mindstrasse 4
 – Gottfr., Bauamtarbeiter, Wangenstrasse 26, Bümpliz
 – Gotth. Ad., Lehrer, Rehhagstr. 34, Bümpliz
 – Gottl., Installationsgesch. f. elektr. Anlagen (Lorrainestr. 2 [36.611]), Zeughausgasse 24 [35.525]
-– Gottl., Rangiermeister S. B. B.. Krippenstrasse 22
+– Gottl., Rangiermeister S. B. B., Krippenstrasse 22
 – Hans W., Chauffeur-Mech., Morellweg 9
 – Hans, Hilfsarbeiter S. B. B., Krippenstr. 22
 – Hans, Metzger, Kasernenstrasse 40
@@ -30578,7 +30538,7 @@ Paul W., Schlosser, Jurastrasse 89
 – Walter, Geometer, Effingerstrasse 79
 – Walter, Inspektor der Schweizer. Unfall-Versich.-Ges. Winterthur, Marktgasse 54
 – Walter, Postangestellter, Jurastrasse 17
-– Walter E.. Velomechaniker, Breitfeldstr. 15
+– Walter E., Velomechaniker, Breitfeldstr. 15
 – Werner Gottl., elektrotechn. Installationen (Wildermettweg 26 [32.336]), Spitalackerstrasse 60 [28.999]
 Messerli, Werner, Kaufmann, Bümplizstr. 27
 – Werner, Postangestellter, Fährstrasse 36
@@ -30631,7 +30591,7 @@ Mettler, Ernst Fr. (Küpfer), eidg. Beamter, Junkerngasse 13
 – Ida, Empfangsfräulein, Schauplatzgasse 26
 – Jakob, Badmeister, Gerechtigkeitsgasse 45
 – Jak. W. (Rickli), Masch.-Ing., Güterstr. 46.
-– Jakob (Pricam), Postangest.. Bühlstr. 33 [20.754]
+– Jakob (Pricam), Postangest., Bühlstr. 33 [20.754]
 – Josefa E. (Gilhart), Giessereiw, 9 [36.883]
 – Leopold, Buchdrucker, Schwarztorstr. 55a [35.708]
 – Marcelle Jenny, Bureaulistin, Viktoriarain 3
@@ -30651,7 +30611,7 @@ Metzger und Mezger
 – Ernst Hch., Kaufmann, Stauffacherstr. 33 [29.080]
 – Ernst, Malermeister, Länggassstrasse 86 [20.611]
 – Ernst (Roth), Ziegeleiarbeiter, Stalden 8
-– Fr. Wilh.. Bankbeamter, Muristrasse 59 [36.031]
+– Fr. Wilh., Bankbeamter, Muristrasse 59 [36.031]
 – Frieda, dipl. Masseuse, Fusspflege, Marktgasse 34 [36.047]
 – Gertrud Frieda, Verkäuferin, Wachtelw. 19
 – Gottfr. G., Fabrikarb., Bümplizstrasse 83b
@@ -30683,7 +30643,7 @@ Mey, s. auch Mai u. May
 – Emma (Weber), Wwe., Belpstrasse 37
 – Fr. Ernst, Bauzeichner, Belpstrasse 39 [36.758]
 – Lorenz, Schriftsetzer, Dietlerstrasse 12
-Meybohm, Herm., Sektionschef der Kriegstechn. Abtlg. d. Militärdepart.. Ingenieur, Kirchenfeldstrasse 57 [34.598]
+Meybohm, Herm., Sektionschef der Kriegstechn. Abtlg. d. Militärdepart., Ingenieur, Kirchenfeldstrasse 57 [34.598]
 Meyer und Meier, s. auch Maier und Mayer
 – Ad. (Zumstein), Gipser- u. Malergeschäft, Holzikofenweg 21 [28.397]
 – Adele, Damenschneiderin, Krippenstr 16
@@ -30713,7 +30673,7 @@ Meyer und Meier, s. auch Maier und Mayer
 – Alfr., Maurer, Frohbergweg 11
 – Alfr. S., Mascb.-Schlosser, Rodtmattstr. 71
 – Alfr., Schlosser, Herzogstrasse 18
-– Alfr., Pächter. Untermattweg 14. Bümpliz
+– Alfr., Pächter, Untermattweg 14. Bümpliz
 – Alfr., Heizungsmonteur, Jurastrasse 40
 – Alfr. (Reinhardt), dipl. Ingen., Monbijou-Strasse 69 [36.321]
 # Date: 1935-12-15 Page: 26020634/327
@@ -30806,8 +30766,7 @@ Meyer und Meier, s. auch Maier und Mayer
 – Ernst (Haussener), Alpeneckstrasse 11 [28.286]
 – Ernst, Hutmacher, Wallgasse 4
 – Ernst, Dachdecker, Zaunweg 22
-– Ernst, Dr. Ing., techn. Experte am Eidg.
-Amt für geistiges Eigentum, Denzlerstr. 6 [28.959]
+– Ernst, Dr. Ing., techn. Experte am Eidg. Amt für geistiges Eigentum, Denzlerstr. 6 [28.959]
 – Ernst, Fabrikarbeiter, Hopfenweg 42
 – Ernst (Rotondo), Kaufm., Hubelmattstr. 12
 – Ernst I., kaufm. Angest., Thunstrasse 23
@@ -30872,7 +30831,7 @@ Meyer u. Meier, s. auch Maier und Mayer
 – Hans, Bäcker, Stöckackerstr. 89, Bümpliz
 – Hans (Tanner), Bäckerei-Konditorei, Lorrainestrasse 58 [29.731]
 – Hans W. (Brettschneider), Brunnmatt-Drogerie u. Reformhaus, Brunnmattstrasse 46 [22.337]
-– Hans, Dr. phil.. Sek.-Lekrer, Asylweg 22, Bümpliz [46.152]
+– Hans, Dr. phil., Sek.-Lekrer, Asylweg 22, Bümpliz [46.152]
 – Hans, Dr. med. dent., Zahnarzt (Effingerstrasse 99 [32.065]), Karl-Schenk-Haus, Spitalgasse 4 [22.543]
 – Hans Reinh., Ingenieurbureau Bern u. Zürich, Spezialbureau f. Wasserbau, Hallerstrasse 58 [20.672]
 – Hans Rud., GäTtner. Weissensteinstr. 35
@@ -30940,7 +30899,7 @@ Meyer und Meier, s. auch Maier und Mayer
 – Joh., gew. Waffenkontrolleur i. d. Waffenfabrik, Karl-Staufferstrasse 28
 – Johann Gustav, Kondukteur der S. B. B., Muldenstrasse 49a
 – Joh. Rud., Gipser, Hopfenrain 19
-– Johanna. Ladentochter. Pestalozzistr. 16
+– Johanna. Ladentochter, Pestalozzistr. 16
 – Jos. Eduard (v. Bergen), Elektr. Unternehmungen und elektrotechn. Bedarfsartikel, Thunstrasse 17 [22.331]
 – Jos., Sachwalter, Inkasso, Verwaltungen (Allmendstr. 10), Spitalgasse 22 [20.700]
 – Josef, pens. Maschinist, Breitfeldstr. 42
@@ -30974,7 +30933,7 @@ Meyer u. Meier, s. auch Maier u. Mayer
 – Ludwig Arn., Monbijoustrasse 18
 – Ludwig, Musikapparatenbau. Junkerng. 55 [33.866]
 – Luise (Juzeler), Niggelerstrasse 7
-– Luise (Grütter). Wwe.. Neufeldstrasse 126
+– Luise (Grütter). Wwe., Neufeldstrasse 126
 – Luise (Senn), Wwe., Neuengasse 18
 – Luise (Wey), Cafe Moleson, Speicherg. 21u. Aarbergergasse 24 [24.463]
 – Lydia, Bankangestellte, Wyttenbachstr. 15
@@ -31007,14 +30966,13 @@ Meyer u. Meier, s. auch Maier u. Mayer
 – Otto Albert, Bahnarbeiter, Aehrenweg 34, Bümpliz
 – Otto, Chefmonteur, Muristr. 97 [28.747]
 – Otto Jul., Angestellter, Wylerstrasse 6
-Buchdruck-Clichesein- und mehrfarbig HallWBg BCMIliefert gut und preiswert Telephon 28.222
 # Date: 1935-12-15 Page: 26020637/330
 Meyer und Meier, s. auch Maier und Mayer
 – Otto Julius, Fürsprecher, Monbijoustr. 67 [28.752]
 – Otto, Goldschmied, Mindstrasse 7
 – Otto, Handlanger. Muesmattstrasse 33a
 – Otto, kaufm. Angest., Frohbergweg 10
-– Otto,, kaufm. Angestellter. Zentralweg 25
+– Otto., kaufm. Angestellter, Zentralweg 25
 – Otto, Kaufmann, Kramgasse 80 [21.087]
 – Otto, Vermessungstechniker, Bernastr. 58
 – P. H., Beamter der S. B. B., Brückfeldstrasse 22 [27.278]
@@ -31046,12 +31004,12 @@ Meyer und Meier, s. auch Maier und Mayer
 – Rosa Paul., Haushaltungslehrerin, Eschenweg 17
 – Rosa, Ladentochter, Stöckackerstrasse 89, Bümpliz
 – Rosa, Schneiderin, Dietlerstrasse 22
-– Rosa (Schenk), Wwe.. Strickerin, Lenzw. 5
+– Rosa (Schenk), Wwe., Strickerin, Lenzw. 5
 – Rosa (Suter), Wwe., Aegertenstrasse 57 [20.237]
 – Rosa Anna, Weissnäherin, Primel weg 3
 – Rosina, Schneiderin, Sulgenauweg 4
 – Rosina (Strahm), Wwe., Pestalozzistr. 16
-– Rud.. Bankaneestellter, Murtenstrasse 94
+– Rud., Bankaneestellter, Murtenstrasse 94
 – Rudolf H. (Führer), Maschinenmeister, Weissenbühlweg 6
 – Rud. (Stehler), Notar (Viktoriastrasse 27), Waisenhausplatz 27
 – Rud., Postangestellter, Schützenweg 13
@@ -31104,13 +31062,12 @@ Meyer und Meier, s. auch Maier u. Mayer
 – & Sohn, E., Garage Bärengraben, Muristalden 6 [25.682]
 – Gebr. (J. Ernst & F. Rudolf), Gipser- und Malergeschäft, Weissensteinstr. 26 [21.658]
 – Gebr., elektromech.Werkstätten, Sulgenauweg 31 [25.643]
-Meyer-Müller & Co. 23.311
-A.-G., Teppichhaus, ßubenbergplatz 10
+Meyer-Müller & Co. 📞 23.311 A.-G., Teppichhaus, ßubenbergplatz 10
 Meyerhofer, Ernst, Maler, Altenbergstr. 14
 – Ernst, Monteur, Bollwerk 23
 – Friedr., Schreinermstr. (Länggassstr. 30), Seidenweg 54 [36.582]
 – Friedr., Chauffeur, Dietlerstr. 8 [45.530]
-– Fritz, Malermeister. Altenbergstrasse 50 [36.014]
+– Fritz, Malermeister, Altenbergstrasse 50 [36.014]
 – Hedwig. Strickerin. Mittelstrasse 6a
 – Herm. Otto, Chauffeur, Lagerweg 5
 – Joh., Malermstr., Altenbergstr. 84 [36.014]
@@ -31134,7 +31091,7 @@ Meystre, Blanche Louise, Drosselweg 19
 – Charles Rene, jun., kaufm. Angestellter, Spitalgasse 14
 – Jules Cäsar, kaufm. Angest., Drosselweg 19
 – Louis, pens. Postbeamter, Drosselweg 19
-– Marcel Jean D. Angestellter. Spitalg. 14
+– Marcel Jean D. Angestellter, Spitalg. 14
 Mezenen, Arnold, Hilfsarbeiter, Nordweg 12
 Mezener, Fritz (Bitzius), Oberst, Chef d. eidg.
 Kriegsmaterialverwaltg., Oranienburgstr. 7 [28.770]
@@ -31186,7 +31143,7 @@ Michel, A. Erika, Oberin der Rot-Kreuz-Pflegerinnenschule, Lindenhofspital, Hüg
 – -Franz Jos., Coiffeur (Brunngasshalde 63), Metzgergasse 62
 – Franz, Spengler, Schöneggweg 25
 – Frieda, Heimpflegerin, Muristrasse 77
-– Friedr Rud., Angestellter. Donnerbühlw. 15
+– Friedr Rud., Angestellter, Donnerbühlw. 15
 – Friedr., Hilfsarbeiter, Gerechtigkeitsg. 35
 – Friedr., Magazinchef, Trachselweg 37
 – Friedr., Postangestellter, Distelweg 11
@@ -31195,7 +31152,7 @@ Michel, A. Erika, Oberin der Rot-Kreuz-Pflegerinnenschule, Lindenhofspital, Hüg
 Milchwirtschaftliche Beratungsstelle
 Michel, Friedrich, Wagnermeister, Bümpiizstrasse 114a [46.o23j
 – Friedrich Wilh., Handlanger, Freiburgstrasse 370, Bümpliz
-– Fritz Otto, Bankbeamter. Tillierstrasse 53
+– Fritz Otto, Bankbeamter, Tillierstrasse 53
 – Fritz, Hilfsarbeiter, Brunngasse 16
 – Fritz A., Reisender, Berchtoldstrasse 13
 – Fritz, Postangestellter, Eichmattweg 10
@@ -31205,7 +31162,7 @@ Michel, Friedrich, Wagnermeister, Bümpiizstrasse 114a [46.o23j
 – Georg, Hilfsarbeiter, Kesslergasse 21
 — Gertrud, Damenschneiderin. Schwarztorstrasse 27
 – Gottfr., Bureaulist, Mattenhofstrasse 9
-– Gottfr.. Chauffeur. Schwarztorstrasse 103
+– Gottfr., Chauffeur. Schwarztorstrasse 103
 – Gottfr., Hilfsarbeiter, Federweg 55
 – Gottfr., Karrer, Polygonweg 15
 – Gottfr., Maler, Kasthoferstrasse 12
@@ -31234,8 +31191,7 @@ Michel, Friedrich, Wagnermeister, Bümpiizstrasse 114a [46.o23j
 – Lina. Damenschneiderin, Erlachstrasse 5
 – M. F. A., Beamter S. B. B., Zähringerstrasse 29
 – Marg. Lse., Modistin, Hochfeldstrasse 19
-– Marg., Orient-Tea-Room (Schwarztorstr.
-Nr. 23b), Gurtengasse 4 [20.904]
+– Marg., Orient-Tea-Room (Schwarztorstr. Nr. 23b), Gurtengasse 4 [20.904]
 – Marie Fr., in Fa. Gisiger & Michel, Pension Villa Frey, Schwarztorstrasse 71
 – Marie M., Coiffeurgeschäft, Herren- und Damensalon, Hubelmattstrasse 56 [33.391]
 – Marie, Fabrikarbeiterin, Kasthoferstr. 8
@@ -31264,7 +31220,7 @@ Michou, David Ernest, Angestellter S. B. B., Lorbeerstrasse 12, Bümpliz
 Miedel, Esther Elis., Zahntechnikerin. Holzikofenweg 29
 – Margaretha (Sulkowsky), Wwe., Kanonenw r eg 18
 Miehle, Josef, Magaziner, Alleeweg 7
-– Josef. Schubmachermeister. Gruberstr. 10
+– Josef. Schubmachermeister, Gruberstr. 10
 Miescher, Ernst, Elektromonteur, Krippenstrasse 18
 – Ernst Ph., Installateur b. Gaswerk, Schosshaldenstrasse 29
 – Gottfr., Schlosser, Krippenstrasse 18
@@ -31408,10 +31364,10 @@ Mischler, Anna, Wwe., Morillonstrasse 2
 – Friedr., Maurer, Bernstr. 44, Bümpliz
 – Fritz Chr., Maurer, Gerechtigkeitsgasse 15
 – Gertrud, Bureaulistin, Wiesenstrasse 26
-– Gertrud. Ladentochter. Genossenweg 10
+– Gertrud. Ladentochter, Genossenweg 10
 – Gottfr., Lok.-Führer, Schlossstrasse 9
 – Gottfr., Hilfsarb., Bärengasse 16, Bümpliz
-– —Gottfr.. Maurer, Genossenweg 21
+– —Gottfr., Maurer, Genossenweg 21
 – Gottl., Schuhmachermeister, Holzikofenw. 1
 – Hedw. Klara, Ladentochter, Genossenw. 10
 – Herm., Beamter S. B. B., Freiestrasse 30
@@ -31428,7 +31384,7 @@ Mischler, Anna, Wwe., Morillonstrasse 2
 – Joh. Fr., Magaziner, Trachselweg 3
 – Joh., Wegaufseher, Murtenstrasse 47
 – Johanna. Bankangestellte, Wiesenstr. 26
-– Johanna Gertr.. Bureaul.. Genossenweg 10
+– Johanna Gertr., Bureaul., Genossenweg 10
 – Johanna, Modistin, Scheuerrain 6
 – Johanna, Näherin, Holligenstrasse 70
 – Karl, Bodenleger, Brunngasse 30
@@ -31457,7 +31413,7 @@ Mischler, Karl Rud. Otto, Mechaniker, Genossenweg 10
 – Rob., Telephonmonteur, Neufeldstr. 159 [35.138]
 – Rud., Maurer, Bümplizstrasse 46
 – Sam., Fabrikarbeiter, Gewerbestrasse 11
-– T. F. Walter, Hilfsarbeiter. Pestalozzistr. 14
+– T. F. Walter, Hilfsarbeiter, Pestalozzistr. 14
 – Walter, Elektrotechniker, Fischerweg 14
 – Walter, Maurer, Brünnenstr. 76, Bümpliz
 – Walter, Magaziner, Wildermettweg 41
@@ -31504,7 +31460,7 @@ Mögli, Ernst Emil, Bauamtarb., Jurastr. 4L)
 – Karl Otto, Hilfsarbeiter, Seidenweg 15
 – Werner, Paul, Coiffeur, Postgasse 16
 Möhl, Emil, Chauffeur, Könizstrasse 57
-– Fritz, Stallmeister. Wildhainweg 8
+– Fritz, Stallmeister, Wildhainweg 8
 – Hans. Giessereiar beiter, Bümplizstrasse 56
 Möhler, Friedr., Monotypegiesser, Sandrainstrasse 94
 – Fritz (Gisin), Bremser S. B. B., Seidenw. 38
@@ -31527,7 +31483,7 @@ Moll, Arthur, Lokomotivheizer, Martiweg 9
 – Bruno, Beamter S. B. B., Bühlstrasse 14
 – Emma, Verkäuferin, Spitalgasse 4
 – Ernst. Fürspr., Dr. jur., Direktionspräs. d. Bern. Kraftwerke, Elfenstr 4 [32.452]
-– Friedr.. Buchhalter, Landoltstrasse 63
+– Friedr., Buchhalter, Landoltstrasse 63
 – Hans, Kondukteur, Bridelstrasse 95
 – Henri, Malermeister, Wiesenstrasse 28
 – Jolanda W., Damenschneiderin, Wylerstrasse 73
@@ -31578,7 +31534,7 @@ Monnard, Ad., Hilfsarbeiter, Sulgenauweg 38
 Monnat, Rob., kant. Beamter, Gäcilienstr. 35
 Monnerat, Leon (Steudler), Bankbeamter, Nigg0jgrsträss© 8
 Monnier, Fritz Rene, Cafe Winkelried, Mattenhofstrasse 12 [22.161]
-– Karl Alb., Direktor der GAP., Gesellschaftsstrasse 79 . .. [26.167]
+– Karl Alb., Direktor der GAP., Gesellschaftsstrasse 79 [26.167]
 – Raymonde Margr., Jubiläumsstrasse 79
 Monnin, Georgine, Steno-Dact., Gesellschaftsstrasse 18b
 Monod, Gabriel V. (Kuhn), Kondukteur der S. B. B., Freie Strasse LI
@@ -31588,7 +31544,7 @@ Montani, Luise, Kinderfräulein, Neueng. 43
 Montavon, Francois, Prokurist der Kantonalbank von Bern, Effingerstrasse 95
 Montblanc-Staubsauger A.-G., Zaunweg 22
 Monteil, E., Ingenieur, Geschäftsleiter d. Verbandes Schweizer. Motorlastwagenbesitzer (Falkenhöheweg 10 [27.614]), Bahnhofplatz 5 [22.489]
-Montet, Gabriele, Dr. phil.. Konservatorin derentomolog. Sammlung d. Naturhistor. Museums, Schillingstrasse 26de Montmollin, Leon, Ing., Kapellenstrasse 10
+Montet, Gabriele, Dr. phil., Konservatorin derentomolog. Sammlung d. Naturhistor. Museums, Schillingstrasse 26de Montmollin, Leon, Ing., Kapellenstrasse 10
 Montre Awiw S. A., Uhrenversandgeschäft, Schwarztorstrasse 20
 Moor, s. auch Mohr
 – Arnold Rudolf, Hauswart im kant. Gewerbemuseum, Zeughausgasse 2
@@ -31599,7 +31555,8 @@ Moor, s. auch Mohr
 – Hans, Bereiter, Stockerenweg 25
 – Joh., Bauamtarbeiter, Murifeldweg 2
 – Johanna Berta (Fink), Lehrerin, Schwarztorstrasse 102
-Moos, Jak. (Huber), Beamter, Eigerweg 1v. Moos, Emma El. M., Säuglingsfürsorgerin, Neufeldstrasse 114
+Moos, Jak. (Huber), Beamter, Eigerweg 1
+v. Moos, Emma El. M., Säuglingsfürsorgerin, Neufeldstrasse 114
 Moosbrugger, Georges Antoine, eidg. Beamter, Falkenhöheweg 15a
 — Julie Alice (Hodel), Wwe., Falkenhöheweg 15a
 Mooser, Egon Alfred, Teeraum Mercantil (Monbijoustrasse 92), Gurteng. 6 [28.275]
@@ -31609,7 +31566,7 @@ Moosmann, A. G. W. (Stauffer), Kaufmann, Berchtoldstrasse 25
 – Jakob, Landjäger, Bremgartenstrasse 35
 Jakob, eidg. Beamter, Hochfeldstrasse 67
 – Julia, Monbijoustrasse 34 [35.359]
-– Martha (Stauffer), Philatelistin, Berchtoldstrasse .25
+– Martha (Stauffer), Philatelistin, Berchtoldstrasse 25
 Morand, Alex., Dr. med. dent., Zahnarzt (Sonnenbergrain 9 [28.284]), Marktgasse 9 [22.814]
 Morandi, G., Gipser- u. Malermeister, Waffenweg 23 [31.678]
 – Giuseppe, jun., Maler, Monbijoustrasse 68
@@ -31620,7 +31577,7 @@ Morath, Ferd., Feilenbergstrasse 18
 Morattel, Blanche L., Damenschneiderin, Gurtengasse 6
 Moraz, Andre P., Coiffeur, Monbijoustr. 73
 Mordasini, Attilio G., Maler, Wiesenstrasse 70
-– Charles, Gipser- u. Malermeister. Wiesenstrasse 70 [22.922]
+– Charles, Gipser- u. Malermeister, Wiesenstrasse 70 [22.922]
 – Ideo, Maler, Wiesenstrasse 70
 Morel und Morell
 – Hermann, Schlosser, Alleeweg 11a
@@ -31679,16 +31636,16 @@ Morgenthaler, Alfr., Mechan., Forsthausw. 4
 – Ernst, Tapezierermeister, Breitfeldstr. 55 [20.769]
 – Frangois, Maschinentechn., Neufeldstr. 137
 – Fr., Billardfabrikant, in Fa. Morgenthaler
-. & Cie , Aarestrasse 98 [33.425]
+— & Cie , Aarestrasse 98 [33.425]
 – Friedr., Handlanger, Frohbergweg 6
 – Friedr. Otto, Billardfabrikant, Landoltstrasse 35 [27.950]
 – Friedr., Schuhmacher, Lorrainestrasse 43
 – Fritz, Handlanger, Gruberstrasse 12
 – Gottfr., Wegaufseher, Jolimontstrasse 16
-– Gustav Ad.. Zigarrenhdlg. (Allmendstr. 14), Spitalackerstrasse 59 [32.566]
+– Gustav Ad., Zigarrenhdlg. (Allmendstr. 14), Spitalackerstrasse 59 [32.566]
 – H. (Wyss). Beamter der S. B. B., Beaulieustrasse 82 [29.679]
 – Hans, städt. Armeninspektor, Bubenbergstrasse 27 [36.969]
-– Hans R.. Ansläufer, Seidenweg 3
+– Hans R., Ansläufer, Seidenweg 3
 – Hans, Ingenieur. Archivstr. 15 [22.620]
 – Hans Rud., Elektrotechn., Neufeldstr. 137
 – Hans, Handlanger, Bremgartenstrasse 49
@@ -31711,7 +31668,7 @@ Morgenthaler, Alfr., Mechan., Forsthausw. 4
 – Otto, Bedienter, Kasernenstrasse 11a
 – Otto, Drogist, Freiburgstrasse 43
 – Paul Werner, Mechan., Freiburgstrasse 43
-– R. Friedr.. Faktor, Muristrasse 77
+– R. Friedr., Faktor, Muristrasse 77
 – Roland (Ramseyer), Spezereihdlr., Marktgasse 18
 – Rosa Marie, Gerantin, Simonstrasse 23
 – Rosa, Weberin, Lorrainestrasse 41
@@ -31749,7 +31706,7 @@ Wirz & Möri, A.-G., Blumenbergstrasse 35 [32.801]
 – Marie, pens. Angestellte d. S. B. B., Berchtoldstrasse 2
 – Otto Willi, Verkäufer, Gerechtigkeitsg. 17
 – Rob., Metzger, Bümplizstrasse 119
-– Walter Ernst. Angest.. Breitenrainstr. 71
+– Walter Ernst. Angest., Breitenrainstr. 71
 – Willy E., kaufm. Angest., Bersethweg 2
 Morier, Achmed M. B., Patissier, Seilerstr. 25 [28.926]
 – Betty (Wagner), Frau, Seilerstrasse 25 [28.926]
@@ -31758,7 +31715,7 @@ Morier, Achmed M. B., Patissier, Seilerstr. 25 [28.926]
 – Therese, Verkäuferin. Seilerstrasse 25 [28.926]
 v. Morlot, Ed., gew. Adjunkt der schweizer.
 Militärkanzlei, Kramburgstr. 14 [33.949]
-Morniroli, Oreste, Postbeamter. Seidenw. 40
+Morniroli, Oreste, Postbeamter, Seidenw. 40
 Moro, Emilia, Schneiderin, Brunngasse 58
 Morosoli, Giovanni, Bühlstrasse 51 [32.926]
 – Giuseppe, kaufm. Angest., Bühlstrasse 51
@@ -31783,7 +31740,7 @@ Mösch, Anna (Leichle), Wwe., Blumensteinstrasse 5
 – Johann Friedr., Gärtner, Lorrainestr. 2
 – Karl Ad., Beamter S. B. B., Schwarztorstrasse 23b
 – Karl Werner. Kaufmann. Blumensteinstr. 5
-– Walter. Sektionscnef bei der Abtlg. Geniedes Militärdepartements, Schönbergweg 24 [24.688]
+– Walter, Sektionscnef bei der Abtlg. Geniedes Militärdepartements, Schönbergweg 24 [24.688]
 – Walter, Versieh.-Inspektor, Bernastr. 55 [20.185]
 Moschard, Georges, gew. Bankier. Monbijoustrasse 10 [34.107]
 Möschberger, Emma, Damenschneiderin, Effingerstrasse 6a
@@ -31829,7 +31786,7 @@ Moser, Alfr., Malermeister, Schönauweg 4 [32.798]
 – Anna Klara, Telephonistin, Brückfeldstr. 15 [21.861]
 – Armin, Elektro-Ing., Falkenweg 9 [22.104]
 – Arnold. Quartieraufseher des V. Bezirks, Muristrasse 31 [20.453]
-– Arthur, Konsumangest.. Bridelstrasse 12
+– Arthur, Konsumangest., Bridelstrasse 12
 – Barbara Marie, Verkäuferin, Freiburgstrasse 364, Bümpliz
 – Bernh., Handlanger, Freiburgstrasse 393, Bümpliz
 – Bertha R., Fabrikarbeiterin, Schönauweg 4
@@ -31842,7 +31799,7 @@ Moser, Alfr., Malermeister, Schönauweg 4 [32.798]
 – Chs. F., Dr., Abteilungschef der kanton. Eisenbahndirekt., Kanonenweg 18 [35.225]
 – Chr A. F., Handlanger, Jurastrasse 37
 – Christ., Handlanger, Gruberstrasse 18
-– Chr., Korbflechter. Schifflaube 44
+– Chr., Korbflechter, Schifflaube 44
 – Chr. Gottfr., Metalldreher, Klösterlistutz 4
 – Christ., gew Postillon. Freiburgstrasse 56
 – Christ., Magaz., Stöckackerstr. 67, Bümpliz
@@ -31851,7 +31808,7 @@ Moser, Alfr., Malermeister, Schönauweg 4 [32.798]
 – Ed. (Biel), Lichtreklame, Effingerstr. 65 [24.365]
 – Elisabeth, Ob. Dufourstrasse 23
 – Elisab (Graf), Frikärtweg 23 [36.336]
-– Elisaüeth Margr.. Glätterin, Krippenstr. 26
+– Elisaüeth Margr., Glätterin, Krippenstr. 26
 – Elise (Wampfler), Wwe., Aarbergerg. 53
 – Elise V., Ladentochter, Magazinweg 6
 – Elsi, Frau, Kunsthandwerk, Marktgasse 56 [20.174]
@@ -31882,13 +31839,13 @@ Moser, Emilie, Bureaulistin, Bierhübeliw. 29
 – Ernst, Dr., Stadttierarzt, Gotthelfstr. 14 [25.073]
 – Ernst, eidg. Beamter, Scheuermattweg 17
 – Ernst (Geiser), eidg. Beamter, Weissensteinstrasse 74
-– Ernst, Führergehilfe d. S. B. B.. Sonneggring 12
+– Ernst, Führergehilfe d. S. B. B., Sonneggring 12
 – Ernst, Hilfsarbeiter, Brünnenstrasse 41, Bümpliz
 – Ernst Friedr., Lok.-Führer, Freiestr. 50
 – Ernst, Landjäger, Ferd -Hodlerstrasse 7
 – Ernst, Magaziner. Lerchenweg 31
 – Ernst, Masch.-Schlosser, Freiestrasse 50
-– Ernst. Masch.-Teehn.. Schwarztorstr. 101
+– Ernst. Masch.-Teehn., Schwarztorstr. 101
 – Ernst, Mech. Werkstätte, Kehrgasse 33, Bümpliz
 – Ernst. Mechaniker, Bühlstrasse 27a
 – Ernst, Mechaniker, Länggassstrasse 67
@@ -31917,8 +31874,8 @@ Moser, Friedr., Gärtner, Turnweg 7
 – Friedr., Gipsermeister, Schöneggweg 19 [33.401]
 – Friedr., gew. Güterschaffner, Breitfeldstrasse 50
 – Friedr , Hilfsarbeiter, Ladenwandstr. 21
-– Friedr.. Hilfsarbeiter, Steinhauerweg 3
-– Friedr., Hilfsarbeiter. Rütlistrasse 11
+– Friedr., Hilfsarbeiter, Steinhauerweg 3
+– Friedr., Hilfsarbeiter, Rütlistrasse 11
 – Friedr., Magaziner, Holligenstrasse 76
 – Friedr., Maschinenmeister, Bernstrasse 19, Bümpliz
 – Friedr., Maschinist im Inselspital, Gartenstrasse 23
@@ -31941,7 +31898,7 @@ Moser, Friedr., Gärtner, Turnweg 7
 – Fritz, Magaziner, Weissensteinstrasse 84
 – Fritz, Versicherungsagent, Bernstrasse 26, Bümpliz
 – Fritz, Maler, Scheibenstrasse 19
-– Fritz, Maschinentechn . Schwarztorstr. 101
+– Fritz, Maschinentechn., Schwarztorstr. 101
 – Fritz, Metzger, Freiestrasse 31
 – Fritz (Liewen), Postunterbureauchef, Kursaalstrasse 15
 – Fritz Eug., Schlosser, Fabrikstrasse 41
@@ -31952,7 +31909,7 @@ Moser, Friedr., Gärtner, Turnweg 7
 – Gertrud, Blumenbinderin, Bernstrasse 19, Bümpliz
 – Gottfr., eidg. Beamter, Neubrückstrasse 76
 – Gottfr., Ausläufer, Murifeldweg 17
-– Gottfr., Coiffeur, Stauffacherstrasse la
+– Gottfr., Coiffeur, Stauffacherstrasse 1a
 – Gottfr., Handlanger. Ulmenweg 4
 – Gottfr. Fr., Heizungsmonteur, Bümplizstrasse 150
 – Gottfr., Maler, Landoltstrasse 83
@@ -31960,7 +31917,7 @@ Moser, Friedr., Gärtner, Turnweg 7
 – Gottfr., pens. Tramarbeiter, Murifeldw. 17
 – Gottl., Handlanger, Altenbergstrasse 20
 – Gottl., Magaziner, Dalmazirain 40
-– Gottl.. Schmiedmeister, Bümplizstrasse 111
+– Gottl., Schmiedmeister, Bümplizstrasse 111
 – Gottl., Zimmerpolier, Länggassstrasse 67
 – Hans, Bäcker, Bümplizstrasse 146
 – Hans, Bankbeamter, Landoltstrasse 35
@@ -31987,7 +31944,7 @@ P. T. T., Fischerweg 20 [25.270]
 – Ida, Beamtin, Grüner Weg 5
 – Ida (Zybach), Wwe., Gasthof zum Bären, Bümplizstrasse 150 [46.029]
 – J. A., gew. Güterschaffner, Holligenstr. 39
-– J. Alex., pens. Sattlervorarbeiter. Mezenerweg 7
+– J. Alex., pens. Sattlervorarbeiter, Mezenerweg 7
 – J. Friedr., Hilfsarbeiter, Waldheimstr. 53
 – J., Merceriewaren, Monbijoustrasse 19
 – J. L. Emil, Gipser, Mauerrain 8
@@ -32001,7 +31958,7 @@ P. T. T., Fischerweg 20 [25.270]
 – Joh., Lok.-Heizer, Zinggstrasse 10
 – Joh., mech. Zaunmacherei und Abbruchunternehmung, Freiburgstr. 98 [24.469]
 – Joh., pens. Monteur, Krippenstrasse 26
-– Joh. A.. Musiker, Junkerngasse 36
+– Joh. A., Musiker, Junkerngasse 36
 – Joh., Nachtwächter der W.-F., Parkstr. 1
 – Joh. Friedr., Postangest., Thunstrasse 41b
 – Joh., Spengler, Ferd.-Hcdlerstrasse 16
@@ -32065,14 +32022,12 @@ Moser, Karl, Bahnangestellter S. B. B., Bottigenstrasse 67, Bümpliz
 – Oskar (Marti), Musiklehrer, Brückfeldstrasse 23 [36.393]
 – Otto Ferd., Buchhalter, Spitalackerstr. 19
 – Otto F. A., Coiffeur, Herren- u. Damensalon (Bollwerk 31), Genfergasse 5 [31.045]
-Fachmännische Beratungin allen vorkommenden Fragen der Branchedurchsfetfbacher
-Gerechtigkeitsg. 59 Telephon 21.040
 # Date: 1935-12-15 Page: 26020648/341
 Moser, Paul A., Schmied, Brünnenstrasse 111, Bümpliz [46.276]
 – Paul (Schertenleib), Bäckermstr., Simonstrasse ll [22.524]
 – Paul E., Bäcker, Alleeweg 34
 – Paul Fritz, Kaufmann, Gartenstrasse 23
-– Paul Herm.. Hilfsarbeiter, Kesslergasse 35
+– Paul Herm., Hilfsarbeiter, Kesslergasse 35
 – Paul, Ingenieur, Murtenstrasse 15 [65.316]
 – Paul, Postbeamter, Rodtmattstrasse 66
 – Paul. Postbeamter, Cäcilienstrasse 5
@@ -32090,7 +32045,7 @@ Moser. Fürsprecher, & E. Werthmüller (Daxeihoferstrasse 19 [33.622]), Marktg. 
 – Rosalie, Photographin, Armandweg 9
 – Rosina (Schmid), Wwe., Mittelstrasse 13
 – Rud., Autotaxis, Hallerstrasse 62 [24.070]
-– Rud. Joh.. Hilfsschlosser, Gerbergasse 7
+– Rud. Joh., Hilfsschlosser, Gerbergasse 7
 – Rud., Milch-, Butter- und Käsehandlung, Dapplesweg 1 [23.657]
 – Rud., Mechaniker, Schläflirain 9
 – Rud., Pferdewärter, Scheibenstrasse 23
@@ -32175,8 +32130,7 @@ Mosimann, Jakob Gottl., kaufm. Angestellter, Sulgenrain 8 [28.146]
 – Martha (Dick), Wwe., pension. Lehrerin, Schanzeneckstrasse 19
 – Mathilde, Telegraphengehilfin. Aebistr. 3
 – Max, Dr., Brückfeld-Apotheke, Neubrückstrasse 73 [21.109]
-– Mina, Damenschneiderin, Junkerng. 19
-. [32.785]
+– Mina, Damenschneiderin, Junkerng. 19 [32.785]
 – Paul, Lehrer, Briinnenstr. 52, Bümpliz
 – Rosa (Jordi), Wwe. des Notars, Vereinsweg 12 [31.640]
 – Rosa (Schenk), Wwe., Aebistr. 3 [27.907]
@@ -32195,7 +32149,7 @@ Motorrad-Kalender, Schweiz., Red. u. Verlag, Breitenrainstrasse 97 [28.222]
 Motta, Carmen, Bankangest., Bernastr. 16
 – Giuseppe, Dr., Bundesrat, Bernastrasse 16 [25.274]
 – Riccardo, Dr. jur., Bankbeamter, Bcrnastrasse 54 [21.268]
-– Sigismondo, Beamter d. Int. Bureaus f. gewerbl., liter. u. künstl. Eigentum, Ob. Dufourstrasse 45 [31.505]
+– Sigismondo, Beamter d. Int. Bureaus f. gewerbl., liter, u. künstl. Eigentum, Ob. Dufourstrasse 45 [31.505]
 Mottaz, Paul A., Tapezierer, Klaraweg 7
 Mottier, Edgar, Dr jur., Gartenstrasse 12
 – Marie S. F. I., Postbeamtin, Allmendstr. 14
@@ -32228,14 +32182,14 @@ Muheim, Anton, Dr. Ghem., Sennweg 13
 – Ida (Hemmann), Wwe., Beaulieustr. 17 [36.193]
 Mühle, Louis, Bankbeamter, Aarbergerg. 4
 – Emma (Blau), Zigarrenhandlung «Box», Aarbergergasse 4 [24.923]
-– Louis Alb., kaufm. Angestellter. Aarbergergasse 4
+– Louis Alb., kaufm. Angestellter, Aarbergergasse 4
 – Marie Julie, Modistin, Aarbergergasse 18
 Mühlebach, Max, Metzger, Konsumstrasse 12
 – Pius, Reisender, Konsumstrasse 12
 – Walter (Bossard), Monteur, Studerstr. 66a
 – Willy, kaufm. Angest., Konsumstrasse 12
 Mühleisen, Max, eidg. Beamter, Fischerw. 19
-Mühlemann, Adolf, Planton d. kant. Polizeidirektion, Bümplizstrasse la
+Mühlemann, Adolf, Planton d. kant. Polizeidirektion, Bümplizstrasse 1a
 – Albert, Schreiner, Wylerstrasse 40
 – Albert, Elektriker, Waffenweg 17
 – Albert, Molkereifachmann, Bridelstr. 42
@@ -32257,7 +32211,7 @@ Mühlemann, Adolf, Planton d. kant. Polizeidirektion, Bümplizstrasse la
 Mühlemanii, F. Otto, Bankbeamter, Beundenfeldstrasse 4 [27.074]
 – Friedr., Gipser, Forsthausweg 4
 – Friedr., Velomechan., Weissensteinstr. 81
-– Fritz O., .Bankangestellter, Hauensteinw.12
+– Fritz O., Bankangestellter, Hauensteinw.12
 – Fritz (Küng), Chauffeur, Altenbergstr. 55
 – Fritz, eidg. Beamter, Ailmendstrasse 12 [36.975]
 – Fritz, Hilfsarbeiter, Metzgergasse 14
@@ -32296,11 +32250,11 @@ Mühlemanii, F. Otto, Bankbeamter, Beundenfeldstrasse 4 [27.074]
 — Werner A., Prokurist. Kirchenfeldstr. 33
 – Willy, Bureaulist, Freiburgstr. 383, Bümpliz
 Mühlematter, Ad., Typograph. Neufeldstr 27f
-– Elsa M.. Verkäuferin, Murtenstrasse 153g
-± Fritz, Chauffeur, Murtenstrasse 153g
+– Elsa M., Verkäuferin, Murtenstrasse 153g
+— Fritz, Chauffeur, Murtenstrasse 153g
 – Jakob, Melker, Postgasse 46
-P° s t an Sestellter. Seidenweg 48v.
-Mühlenen, siehe auch v. Mülinen
+P° s t an Sestellter, Seidenweg 48
+v. Mühlenen, siehe auch v. Mülinen
 – A. Walo, Verw.-Rat, Effingerstrasse 75 [23.927]
 — Adele, L., Telephonistin, Brückfeldstr. 10
 – Eugen, Kaufmann, in Fa. v. Mühlenen & Co., Fischerweg 6 [31.904]
@@ -32337,7 +32291,7 @@ Mühlethaler, Alb., Bankbeamter, Wylerstr. 73
 – Hans, Lok.-Führer, Effingerstrasse 99
 – Hans, Beamter S. B. B., Hallerstrasse 53
 – Hedw. Lse., Sekretärin, Effingerstr. 99
-– Jakob, Bäckermstr.. Kesslerg. 25 [32:944]
+– Jakob, Bäckermstr., Kesslerg. 25 [32:944]
 – Marie, Damenschneiderin, Gerechtigkeitsgasse 46
 – Max Hans, Kaufmann, Effingerstrasse 99
 – Olga, Fabrikarbeiterin, Sulgeneckstr. 58
@@ -32380,10 +32334,10 @@ Müller, Eisenbau 23.538vormals R. & L. Müller, mech. Werkstätte u. Eisenkonst
 – Ad., Spengler, Seidenweg 40
 – Alb. Wilh., Elektromonteur, Mattenhofstrasse 29
 – Alb., Handlanger, Brünnenstr. 34. Bümpliz
-– Alb. F.. Direktor, Archivstrasse 2 [22.589]
+– Alb. F., Direktor, Archivstrasse 2 [22.589]
 – Albert, Packer, Bümplizstrasse 38
 – Albertine, Papeterie und Holzschnitzereien (Steinersti. 6 [36.525]), Kramgasse 83 [31.995]
-.— Alex., Handlanger, Platanenweg 12
+— Alex., Handlanger, Platanenweg 12
 – Alfr., jun., Schuhmacher, Spitalackerstr. 55 [31.563]
 – Alfred (Merz), Tillierstrasse 4 [32.367]
 – Alfred Osk., Ausläufer, Wildermettweg 41
@@ -32461,7 +32415,7 @@ Müller, s. auch Miller
 – Emil, Drogist, Gerechtigkeitsgasse 44
 – Emil, Geschäftsführer, Bühlstrasse 25
 – Emil Fr. Jos., Hilfsarbeiter, Murtenstr. 217, Bümpliz
-– Emil C.. Konditor, Federweg 29c
+– Emil C., Konditor, Federweg 29c
 – Emil, Metzger, Tscharnerstrasse 45
 – Emil (Boillat), Prokurist d. Kantonalbank, Fischerweg 15
 – Emil, Portier, Neuengasse 26
@@ -32507,7 +32461,7 @@ Müller, s. auch Miller
 – Erwin, kaufm. Angest., Junkerngasse 3
 – Erwin, Polierer, Vereinsweg 11
 – Eug. Theod., Depotarb. S. B. B., Gartenstrasse 23
-– Eug.. Küchenchef, Marktgasse 49
+– Eug., Küchenchef, Marktgasse 49
 – Eug. Arth., Magaziner, Tscharnerstr. 36
 – Eug. (Moulin), Typograph, Elisabethenstrasse 13
 – Eug. (Thüler), Verwaltungsgehilfe bei der
@@ -32520,7 +32474,7 @@ Kreispostdirektion, Länggassstrasse 76
 – Fr. Bertha (Sauser), Wwe., Luisenstr. 27
 – Franz Alois, Apotheker, Thunstrasse 46a
 – Franz, Dr. chem., Moserstrasse 52
-– Franz Jos.. Hilfsarbeiter, Aarbergerg. 51
+– Franz Jos., Hilfsarbeiter, Aarbergerg. 51
 – Franz O., Hilfsarbeiter, Badgasse 35
 – Franz, in Fa. Müller & Spycher, Freiburgstrasse 73 [22.148]
 – Franz Peter, kaufm. Angest., Optingenstrasse 43
@@ -32585,7 +32539,7 @@ Müller, s. auch Miller
 – Hans. Masch.-Techn. u. Prokurist, Hochfeldstrasse 110
 – Hans, Mechaniker W.-F., Lorrainestr. 48
 – Hans Hektor W., Maler, Seftigenstr. 30a
-– Hans L.. Postbeamter, Berchtoldstrasse 45
+– Hans L., Postbeamter, Berchtoldstrasse 45
 – Hans, Schreinermeister (Schwarzenburgstrasse 4), Rosenweg 5 [34.119]
 – Hans Ed., städt. Beamter, Eman.-Friedlistrasse 10
 – Hans. Telephonarbeiter, Metzgergasse 64
@@ -32603,12 +32557,12 @@ Müller, s. auch Miller
 – Helene, Zigarrengeschäft, Eigerplatz 8
 – Herrn H., Dr. med., Arzt, Freiburgstr. 18
 – Herm., Akquisiteur, Brückenstrasse 11
-– Herm., Beamter S. B B.. Gutenbergstr. 12
+– Herm., Beamter S. B B., Gutenbergstr. 12
 – Herm., Chauffeur, Mattenhofstrasse 12
 – Herm., Elektriker, Gutenbergstrasse 11 [24.538]
 – Herm. Jul., Hilfsarbeiter, Muesmattstr. 43
 – Herm., Souschef S. B. B., Engestrasse 1
-– Herm. (Rutz), Vertreter. Neufeldstr. 114
+– Herm. (Rutz), Vertreter, Neufeldstr. 114
 – Hermine, Ladentochter, Steinerstrasse 7
 – Hermine (Cornaz), Wwe., Kesslergasse 11
 – Hilda E., eidg. Angestellte, Tavelweg 21
@@ -32631,7 +32585,7 @@ Müller, s. auch Miller
 – Jean Gottfr., eidg. Angest., Stauffacherstrasse 31
 – Joh. Heinrich, Aufzugrevisor u. Vertreterder «Stigler»-Aufzüge, Wachtelweg 19 [31268]
 – Joh. Friedr., Bäcker, Hopfenweg 32a
-– Joh Friedr., Bereiter. Jägerweg 14
+– Joh Friedr., Bereiter, Jägerweg 14
 – Joh. Friedr., Buchbinder, Seidenweg 20
 – Joh. Hch., Bureaulist. Felsenaustrasse 33
 – Joh., Chauffeur. Federweg 29e
@@ -32646,7 +32600,7 @@ Müller, s. auch Miller
 – Joh. (Wittwer), Hilfsarb., Berchtoldstr. 7
 – Joh., Kaufmann, Spitalgasse 14
 – Joh., Maurer, Lagerweg 12
-– Joh., Schneidermeister. Freiburgstr. 159
+– Joh., Schneidermeister, Freiburgstr. 159
 – J. A. Aug., Schriftsetzer, Schönburgstr. 43
 – Joh. Fr., Spengler u. Installateur, Herzogstrasse 22
 – Joh., Spinner, Felsenaustrasse 22 i
@@ -32661,16 +32615,16 @@ Müller, s. auch Miller
 – Johanna (Weber), Wwe. des Ingenieurs, Schlösslistrasse 47
 – Jos., sen., Privatier, Kollerweg 8 [22.798]
 – Jos. (Zahnd), Kaufmann, Effingerstr. 6a
-– Jos. Fr. J.. Kommis, Wattenwylweg 19
+– Jos. Fr. J., Kommis, Wattenwylweg 19
 – Jos. Ivar (Steudler), Musikdirektor, Optingenstrasse 49 [36.176]
 – Josef (Röthlisberger), Lebensmittelhdlg. u. Dekateur, Bühlstrasse 49 [36.109]
-– Jos.. Handlang., Burgunderstr. 105, Bürnpl, – Joseph, Dr med dent., prakt. Zahnarzt (Mittelstrasse 32), Marktgasse 41 [33.815]
+– Jos., Handlang., Burgunderstr. 105, Bürnpl, – Joseph, Dr med dent., prakt. Zahnarzt (Mittelstrasse 32), Marktgasse 41 [33.815]
 – Jos. Joh., Handel in Autos, Kollerweg 8 [22.798]
 – Jos., Reisender, Monbijoustrasse 27
 – Jul., Torpedo-Schreibmaschine, Bureaumöbel u. Bureauart., Mittelstr. 6 [32.175]
 – K. Gustav (Brönnimann), eidg. Beamter, Südbahnhofstrasse 15
 – K., Wwe., Karl-Schenkstrasse 1 [36.610]
-– Karl, Buchhalter. Moserstrasse 24
+– Karl, Buchhalter, Moserstrasse 24
 – Karl Alfr., Lok.-Führer S. B. B., Hochfeldstrasse 107
 – Karl. Hilfsarbeiter, Wylerringstrasse 96
 – Karl, Kaufmann, Pestalozzistrasse 30
@@ -32715,7 +32669,7 @@ Müller, s auch Miller
 – Luise, Bureaulistin, Schwarzenburgstr. 4
 – Luise (Wyss), Wwe., Brückfeldstrasse 30 [22.284]
 – Luise, in Fa. Müller & Hostettler, Münzrain 4
-– M. Regina (Wenger), Wwe., Zieglerstr. 42 [31.1661
+– M. Regina (Wenger), Wwe., Zieglerstr. 42 [31.166]
 – Magdalena (Nufer), Wwe., Gerbergasse 15
 – Magdalena Marg., Damenschneiderin, Badgasse 35
 – Marg. N. (Berthoud), Wwe., Mattenhofstrasse 40
@@ -32723,8 +32677,7 @@ Müller, s auch Miller
 – Marg. (Salvisberg), Steigerweg 17
 – Marg., Telephonistin, Simplonweg 7
 – Margar. (Härry), Klavierlehrerin, Gutenbergstrasse 12 [27.848]
-– M. Luise, Inhaberin d. Fa. Müller, vorm.
-R. & L. Müller, Schanzenbergstrasse 31 [22 752]
+– M. Luise, Inhaberin d. Fa. Müller, vorm. R. & L. Müller, Schanzenbergstrasse 31 [22 752]
 – Maria A (Frutig), Wwe., Schneiderin, Wiesenstrasse 49
 – Maria Flora. Vertreterin, Bundesrain 16
 – Maria Lse., Bureaulistin, Thunstrasse 46a
@@ -32739,7 +32692,7 @@ R. & L. Müller, Schanzenbergstrasse 31 [22 752]
 – Marie, Telegraphistin, Viktoriarain 17
 – Marie (Stotzer), Wwe., Aarhergergasse 4
 – Marie (Wittwer), Wwe., Rodtmattstr. 62
-– Marie (Bolliger), Wwe., in Fa. Müller-Bolliger & Cie.. Ob. Dufourstrasse 49 [24.529]
+– Marie (Bolliger), Wwe., in Fa. Müller-Bolliger & Cie., Ob. Dufourstrasse 49 [24.529]
 – Marie Martha, Angestellte, Marktgasse 49
 – Martha. Bureauangestellte, Herrengasse 17
 – Martha. Ladentochter, Länggassstrasse 68
@@ -32749,7 +32702,7 @@ R. & L. Müller, Schanzenbergstrasse 31 [22 752]
 – Max, Dr med., Spezialarzt für Nervenkrankheiten, Monbijoustrasse 35 [23.066]
 – Max. Eisendreher. Murtenstrasse 155h
 – Max Erw., Techniker, Weihergasse 16
-– Max Hch.. Hilfsarbeiter. Rodtmattstr. 62
+– Max Hch., Hilfsarbeiter, Rodtmattstr. 62
 – Max Hans, Kaminfeger, Waffenweg 18
 – Max, Maler, Neufeldstrasse 111
 # Date: 1935-12-15 Page: 26020655/348
@@ -32782,7 +32735,7 @@ Müller, Max 📞 31.152 Spezialgeschäft für echte Perserteppiche (Museumstras
 – Rosa El. (Wetterwald), Spezerei-, Früchteu. Gemüsehandlung. Moserstrasse 52
 – Posina (Eggler), Wwe., Finkenhubelweg 26
 – Rud., Bäckerei, Birkenweg 9 [23.532]
-– Rud., Beamter B. L. S.. Eichmattweg 7
+– Rud., Beamter B. L. S., Eichmattweg 7
 – Rud. Friedr., Buchbinder, Badgasse 33
 – Rud., Handlanger, Stadtbachstrasse 8
 – Rud., Handlanger. Brückenstrasse 12
@@ -32812,7 +32765,7 @@ Müller, s. auch Miller
 – Walter (Roth), Kunstmaler u. Zeichenlehrer. Brunnadernstrasse 92 [32.888]
 – Walter, Schreiner, Schöneggweg 32
 – Walter, Postangestellter, Dalmaziweg 83
-– Walter. Weber, Elisabethenstrasse 57
+– Walter, Weber, Elisabethenstrasse 57
 – Werner, Elektriker, Altenbergstrasse 14
 – Werner (Rufener), Konfiserie, Bäckerei, Länggassstrasse 16 [29.895]
 – Werner Fr., Heizungsmonteur, Muesmattstrasse 35
@@ -32820,7 +32773,7 @@ Müller, s. auch Miller
 – Wilh., Bücherexperte d. kant. Rekurskommission, Eman.-Friedlistrasse 14 [27.868]
 – Wilh. (Bürgi), Dr. med., Arzt, Länggassstrasse 19 [23.067]
 – Wilh., Hilfsarbeiter, Länggassstrasse 96
-– Wilh. Ad., Hilfsarbeiter. Monbijoustr. 68a
+– Wilh. Ad., Hilfsarbeiter, Monbijoustr. 68a
 – Wilh., Kaufm., Weissenbühlw. 29b [34.432]
 – Wilh., Massgeschäft, Schauplatzgasse 5 [27.699]
 – Wilh. H., Spengler, Gerbergasse 11a
@@ -32832,7 +32785,7 @@ Müller, s. auch Miller
 – & Cie., A. P., Papierhaus zum Zähringer, Büroartikel- u. Papierhdlg., Buchbinderei, Kramgasse 60 [35.363]
 – & Cie., A.-G., Schreibbücherfabrik Bern, Länggassstrasse 7 [21.277]
 – J., Gabathuler & Co. (Nachfolger J. Gabathuler), Leinen- u. Baumwollgewebe, Aussteuern u. Herrenwäsche, WaisenhauspU [27.292]
-– & Co.. Rud., Bierausschankapparate, Verzinnungs- u. Vernicklungsanstalt, Seftigenstrasse 51, Bureau: Balmweg 28 [24.470]
+– & Co., Rud., Bierausschankapparate, Verzinnungs- u. Vernicklungsanstalt, Seftigenstrasse 51, Bureau: Balmweg 28 [24.470]
 – & Hostettler, Steppdecken-Atelier und Dekorationen, Münzrain 4 [36.682]
 – & Marti, Sattlerei und Carrosserie, Eigerplatz 13 [28.299]
 – & Schade, Musikalien- u. Musikinstrumentenhandlung, Spitalgasse 20 [31.691]
@@ -32864,7 +32817,7 @@ Mumenthaler, Adolf, pens. Postangest., Landhausweg 3
 – Marg. (Kopp), Wwe., Weissensteinstr. 38
 – Max, Hilfsarbeiter, Standstrasse 26
 – Otto E. (Schneider), Beamter d. O. T. D., Steigerweg 26
-– R.. Bureaulistin, Seftigenstrasse 19
+– R., Bureaulistin, Seftigenstrasse 19
 – Rosa, Glätterin, Landoltstrasse 63
 – Ulrich (WHz), Schneidermeister, Mühlemattstrasse 44
 – Walter, Hilfsarbeiter, Standstrasse 26
@@ -32883,7 +32836,7 @@ Munari, Ant., Mechaniker, Breitenrainpl. 27
 Münch, Alfr. Max, Eisendreher, Militärstr. 43
 – Alfred, Zahnarzt, Laupenstr. 6 [34.334]
 — E. Alb., Berufsberater, Steigerweg 22
-– E Apotheke u . Drogerie, Aarbergerg. 39 u. Ryffligässchen 16 [23.077]
+– E Apotheke u. Drogerie, Aarbergerg. 39 u. Ryffligässchen 16 [23.077]
 – Elfca, Bureauangestellte, Bantigerstr. 50
 – Eric, Hauptmann, Instruktionsoffizier des
 Genie, Südbahnhofstrasse 4 [23.648]
@@ -32992,13 +32945,13 @@ Muri, Murri u. Mury, s. auch Müri
 – Alois, Chef der techn. Abtlg. der O. T. D., Elfenstrasse 3 [25.222]
 – Anna, Damenschneiderin, Wiesenstrasse 64
 – Arnold, Hilfsarbeiter, Freiburgstrasse 174
-– Ed., Vorarbeiter. Aehrenweg 26 Bümpliz
+– Ed., Vorarbeiter, Aehrenweg 26 Bümpliz
 – Ernst, Milchhändler, Kirchackerweg 17, Bümpliz [46.158]
 Muri, Murri u. Mury, s. auch Müri
 – Ernst, jun., Milchhändler, Kirchackerw. 17, Bümpliz
 – Ernst, Handlanger, Brünnackerweg 19, Bümpliz
 – Ernst, Milchträger, Kirchackerweg 17, Bümpliz
-– Eug.. Fabrikarbeiter, Tunnelweg 7
+– Eug., Fabrikarbeiter, Tunnelweg 7
 – Friedr. (Weissmüller), Pension, Stockerenweg 11
 – Friedr., Mechaniker, Muldenstrasse 42
 – Gottfr., Pferdewärter, Rodtmattstr 53
@@ -33016,7 +32969,7 @@ M üri u. Müry, s. anch Muri. Murri u. Mury
 – Ernst W., Masch.-Zeichner. Murtenstr. 155f
 – Gottfr., Fabrikarbeiter, Magazinweg 6
 – Samuel, Elektrotechniker, Monbijoustr. 21
-– Verena Rosa. Ladentochter. Masrazinwes 6
+– Verena Rosa. Ladentochter, Masrazinwes 6
 – Walter (Hunziker), Dr. phil., Gymnasiallehrer, Willadingweg 38 [32.907]
 – Werner. Masch-Schlosser. Murtenstr. 155f
 – Wilh , Handlanger. Murtenstrasse 155f
@@ -33025,7 +32978,7 @@ Muriset, Anny M., Sekret., Bubenbergstr. 12a
 – Emma (Burkhalter), Kolonialwarenhdlg, Depotstrasse 22 [33.962]
 Müristrasse Nr. 76 A.-G., Viktoriastrasse 69
 Muristrasse Nr. 78 A.-G., Viktoriastrasse 69
-Murkowsky, Alb.. Hilfsarb., Wylerringstr.9
+Murkowsky, Alb., Hilfsarb., Wylerringstr.9
 – Maria, Schneiderin, Stockerenweg 13
 Mürner, Christian, Gärtn., Beundenfeldstr. 16
 – Ernst, Telephonmonteur, Tavelweg 8
@@ -33063,7 +33016,7 @@ Muster, Abraham Fr., Schreiner, Wylerstr. 59
 – Pauline, Kassierin, Wylerstrasse 59
 – Walt. Fr., Bankangest., Elisabethenstr. 47
 Musterschule d. evang. Seminars, Muristr. 10 [29.506]
-v. Mutach, Aloys, Dr. med.. Holligenstr 44 [24.369]
+v. Mutach, Aloys, Dr. med., Holligenstr 44 [24.369]
 – Hilda, Frl., Holligenstrasse 44 [24.369]
 – Marg., Frl., Friedhofweg 24 (Schöneck)
 – Marg. (v. May), Wwe. d. Dr. med., Luisenstrasse 45 [31.654]
@@ -33077,7 +33030,7 @@ Mutti, Adolf, Giessereiarbeiter, Zentralweg 25
 – Ernst Ghr., Hilfsarbeiter, Hohgantweg 16
 – Fritz, Hilfsarbeiter, Badgasse 59
 – Gottl., Hilfsarbeiter, Wylerringstrasse 52d
-– Hans W.. Spediteur. Steinauweg 29
+– Hans W., Spediteur. Steinauweg 29
 – Joh., Handlanger, Murtenstrasse 153c
 – Joh., Schlosser, Waaghausgasse 6
 – Maria, Angestellte, Bahnstrasse 73
@@ -33090,8 +33043,7 @@ Mutzenberg, Ernst, städt. Beamter, Blumenbergstrasse 6
 – Kurt H., Versieh.-Ang., Blumenbergstr. 6
 Lilly Hilda, Verkäuferin, Blumenbergstr. 6
 — E. (Krebser), Wwe., Lentulusstrasse 47
-Mutzner, Karl, Dr ing., Direktor des eidg.
-Amtes für Wasserwirtschaft, Jubiläums-Strasse 72 [34.208]
+Mutzner, Karl, Dr ing., Direktor des eidg. Amtes für Wasserwirtschaft, Jubiläums-Strasse 72 [34.208]
 Muzzulini, Jos. Vik. (Dietrich), Ingenieur, Fischerv eg 22 [23.339]
 – Marg., Coiffeuse, Damensalon, Fischerweg 22 [23.339]
 Mina (Dietrich), Frau, Damensalon, Wylerstrasse 63 [27.998]
@@ -33099,7 +33051,7 @@ Mina (Dietrich), Frau, Damensalon, Wylerstrasse 63 [27.998]
 N.
 Nabholz, Jeanne (Robert), Wwe. des Ingenieurs, Zähringerstrasse 22
 – Paul, Ingenieur d. S. B. B., Gesellschaftsstrasse 31
-– Walter. Sattler und Tapezierer, Birkenweg 42
+– Walter, Sattler und Tapezierer, Birkenweg 42
 Nabuco de Gouvca, brasilianischer Gesandter, Helvetiastrasse 39 [31.285]
 Nachbur, Ernst. Küfer, z. Tessiner Weinkeller (Moserstrasse 35), Kesslergasse 40
 – Xaver W. E., Ausläufer, Lorrainestrasse 2
@@ -33133,10 +33085,10 @@ Näf, Anna, Stickerin, Kapellenstrasse 9
 – J., Zigarrenhandlung (Neubrückstr. 82), Hirschengraben 24 [35.829]
 – Konrad, eidg. Beamter, Willadingweg 34
 – Maria Pauline, Stickerin, Balmweg 29
-– Melchior, Webermeister. Wyttenbachstr. 13
+– Melchior, Webermeister, Wyttenbachstr. 13
 – Otto, Adjunkt d. Direktors d. Städt. Strassenbahnen, Eigerplatz 3 [27.787]
 – Peter, Bundesbeamter, Mühlemattstr. 36
-– Walter, Grundbuchgeometer. Brunnadernstrasse 10 [31.973]
+– Walter, Grundbuchgeometer, Brunnadernstrasse 10 [31.973]
 – Walter Hrch., Verkäufer, Elfenauweg 17a
 Nafzger, Alice, Ladentochter, Kirchenfeldstr.29
 – Ernst, Pferdewärter, Kasernenstrasse 21b
@@ -33149,7 +33101,7 @@ Nagel, Arthur Friedrich, Kaufmann, Tavelweg 6
 – Ernst, Müller, Eymattstr. 168, Bümpliz
 – Hans. Abwart, Bühlstrasse 26
 – Konrad (Hilty), Beamter der S. B. B., Zähringerstrasse 73
-– Otto W., Bankbeamter, Länggassstr. 21a [36.4411
+– Otto W., Bankbeamter, Länggassstr. 21a [36.441]
 – Rob. Friedr., kant. Beamter, Haspelweg 30 [31.301]
 Nägeli, Albert Friedr., Steindrucker, Depotstrasse 44
 – Alfred, Kaufmann, Schwarztorstrasse 11
@@ -33165,8 +33117,8 @@ Nägeli, Albert Friedr., Steindrucker, Depotstrasse 44
 – O., Dr. med., Professor, Spezialarzt für
 Hautkrankheiten, Effingerstr. 39 [24.809]
 – Osk. (Bolliger), Bankkontrolleur, Gryphenhübeliweg 39 [20.892]
-– Rudolf, Ingenieur in Fa. Nägeli & Co., Kramburgstrasse 16 [23.9311
-– & Cie.. Patentanwaltsbureau, Bundesg 16 [22.281]
+– Rudolf, Ingenieur in Fa. Nägeli & Co., Kramburgstrasse 16 [23.931]
+– & Cie., Patentanwaltsbureau, Bundesg 16 [22.281]
 Nägelin, Karl, Architekturbureau (Scheuermattweg 21 [20.032]), Monbijoustrasse 6 [22.658]
 – Karl Alb., Lehrer. Rehhagstr. 18, Bümpliz
 – & Co., Emil, Neuer industrieller Blindenbetrieb, Basel, Wasch- und Putzmittel, Zweigniederlassung: Gerechtigkeitsg. 33
@@ -33211,14 +33163,14 @@ Neeser, Arnold, pens. Lehrmeister a. d. Lehrwerkst. d. Stadt Bern, Schreinerabte
 – Paul, Scftlosser, Könizstrasse 77
 – Rud., Depotarbeiter S. S. B., Murifeldw. 3
 – Walter, Architekt, Effingerstrasse 65
-Nef, Alb., Dr., Kapellmeister. Florastr. 22 [34.340]
+Nef, Alb., Dr., Kapellmeister, Florastr. 22 [34.340]
 – Carolina, Krankenpflegerin, Bubenbergstrasse 49
 – Jak. (Schacher), Postbeamter, Spitalackerstrasse 7
 – Max (Steimlin), Redakteur, Münzrain 3a [24.918]
 Neher, Ernst, Fabrikant. Schiösslistrasse 19 [35.894]
 – Gallus, Zuschneider, Anshelmstrasse 22
 – J. M., Söhne, A.-G., Fabrikation v. Schreibbüchern, Bureauartikelm und Lederwaren, Belpstrasse 20 [22.196]
-– Johanna (Haslebacher), Privat., Viktoriarain 6 .
+– Johanna (Haslebacher), Privat., Viktoriarain 6
 – Ludwig Arm., Belpstrasse 23 [32.895]
 – Paul Ernst, Kaufmann, Schlösslistrasse 19
 # Date: 1935-12-15 Page: 26020660/353
@@ -33243,7 +33195,7 @@ Nencki, D. Marc., Konzertsängerin, Wernerstrasse 6 [32.655]
 – Lydia M., Haushaltungslehrerin, Wernerstrasse 6
 – Martin Ad., Maschinentechn., Wernerstr. 6
 Nenniger, Emil, pens. Kontrolleur der Kriegstechn. Abteilung, Brunnmattstrasse 49
-– Heinr,, Feinmech., Brunnmattstrasse 49
+– Heinr., Feinmech., Brunnmattstrasse 49
 – Luise, Bureaulistin, Humboldtstrasse 5
 – Viktor Friedr., Mechan., Dapplesweg 2
 Nenning, Anna (Mezger), Schreibmaschinenarbeiten, Vervielfältigungen, Buchhaltungen, Marktgasse 42 [27.687]
@@ -33313,13 +33265,13 @@ Neuenschwander, Fritz II., Tel.-Monteur, Murifeldweg 22
 – Gottl., Karrer, Brunnmattstrasse 23
 – Hans, Kaufmann, Wylerstrassc 53
 – Hans, Landwirt, Rosshäusernstrasse 64, Riedbaoh
-— Hans P.. Magaziner, Werdtweg 17
-– Hans Ed., .Zeichner, Attinghausenstr. 23
+— Hans P., Magaziner, Werdtweg 17
+– Hans Ed., Zeichner, Attinghausenstr. 23
 – Ida Math., Bureaulistin, Seftigenstrasse 27
 – J. Rud. pens. Lok.-Führer, Rohrweg 31
 – J. Chr., Sattlermeister, Waldheimstr. 27
 – Jakob, Architekt, Weissensteinstrasse 110
-– Joh.. Bahnarbeiter, Breitfeldstrasse 2
+– Joh., Bahnarbeiter, Breitfeldstrasse 2
 – Joh., Handlanger, Willadingweg 44
 – Johann, Kaufmann, Güterstrasse 32
 – Joh., Maler, Muldenstrasse 49a
@@ -33354,27 +33306,27 @@ Neuenschwander, Fritz II., Tel.-Monteur, Murifeldweg 22
 – Walter, Ausläufer, Bümplizstrasse 83
 – Walter Herm., Velomechaniker, Blumenweg 5
 – Walter, Zentralheizungen (Schönbergw. 21 [34.945]), Elisabethenstrasse 13 [22.283]
-– Werner Ad.. Automechan., Sonneggring 16
+– Werner Ad., Automechan., Sonneggring 16
 – Werner, Maurer, Bümplizstrasse 83
 – Werner, Maurer, Willadingweg 44de Neufville, Rob. Alex., Privat., Junkerng. 29 [23.277]
 Neugebauer, Emma Kl. (Studer), Bühlstr. 55a
 – Franz W., kaufm Angest., Bühlstrasse 55a
-Neuhaus, Abr. Gottfr., Hilfsarb,, Schmiedw. 6
+Neuhaus, Abr. Gottfr., Hilfsarb., Schmiedw. 6
 – Anne M. C., Bureaulistin, Morillonstr. 7
 – Anna Marg., Einlegerin, Federweg 57
 – Antonie G. M., Bureaulistin, Morillonstr. 7
 – Arthur Ad., Dekorateur, Zähringerstr. 51
 – Gaelina E., Coiffeuse, Rathausgasse 6
-– Charles, Coiffeur- u. Coiffeuse-Salon (Rathausgasse 6), v. Werdt-Passage 4 [36.2201
+– Charles, Coiffeur- u. Coiffeuse-Salon (Rathausgasse 6), v. Werdt-Passage 4 [36.220]
 – E. Adolf, Handlanger, Rodtmattstrasse 73
-– E. Walter. Chauffeur, Brunngasse 36
+– E. Walter, Chauffeur, Brunngasse 36
 – Ed. Emil, Hilfsarbeiter, Flurstrasse 6
 – Elise, Privatiere, Bümplizstrasse 11
-– Emil, Photograph), Dalmaziweg 65
+– Emil, Photograph, Dalmaziweg 65
 – Emil Herm., Schlachthofangestellt., Scheibenstrasse 32
 – Eugen Edouard (Röthlisberger), Bodenleger, Birkenweg 31
 – Flora Fanny. Kanzlistin, Greyerzstrasse 51
-– Friedr.. Bahnarbeiter, Fichtenweg 15
+– Friedr., Bahnarbeiter, Fichtenweg 15
 – Fritz Hrch., Bureaulist, Federweg 57
 – Gerard, Prof, de mus., Sennw. 3 [26.038]
 – Hedwig, Ladentochter, Birkenweg 31
@@ -33385,7 +33337,7 @@ Neuhaus, Abr. Gottfr., Hilfsarb,, Schmiedw. 6
 – Klara Anna, Damenschneiderin, Birkenweg 31
 – Lina, Schneiderin, Hubelmattstrasse 48a
 – Lina, Vorsteherin, Zähringerstrasse 3
-– Ludwig Alfr., Hilfsarbeiter. Länggassstr. 84
+– Ludwig Alfr., Hilfsarbeiter, Länggassstr. 84
 – Louis Alfr., Elektromonteur, Länggassstr. 84
 – Margr., Angestellte, Greyerzstrasse 51
 – Marie L. (Blanc), Wwe., Fischerweg 19 [26.287]
@@ -33408,7 +33360,7 @@ Neuhaus, Abr. Gottfr., Hilfsarb,, Schmiedw. 6
 – Walter Paul, Schreiner, Muesmattstr. 39
 – Werner. Tapezierer. Zähringerstrasse 51
 Neuhauser, Lydia, Drogistin, Wylerstrasse 49
-Neukomm, Alb. (Kleeb), Hilfsarbeiter. Schöneggweg 22
+Neukomm, Alb. (Kleeb), Hilfsarbeiter, Schöneggweg 22
 – Aug., Monteur, Laubeckstrasse 191
 – Fr., Buchdrucker, in Firma Neukomm & Salchrath, Effingerstrasse 97 [29.377]
 – Hedwig, Schönbergweg 10
@@ -33440,7 +33392,7 @@ Neutra Treuhand AG. [34.735] besorgt Expertisen, Revisionen, Treuhandfunktionena
 Neuweiler, Arnold Ed., Vertretungen (Brunnadernstrasse 94), Christoffelgasse 4
 – Emil Ernst, Schreiner, Gerbergasse 26
 – Emilie -(Comte), Wwe. (Brunnadernstr. 94 [35.566]), Christoffelgasse 4 [24.323]
-– Walter. Dr med.. Schanzenstrasse 23
+– Walter, Dr med., Schanzenstrasse 23
 Neuwerth, Jos. Louis, Wagenführer S. S. B., Wattenwylweg 32
 Newbery, E. L., Sprachlehrerin, Effingerstr. 37
 Ney, Anna B. E. (Abt), Wwe., Monbijoustr. 95 [34.032]
@@ -33458,7 +33410,7 @@ Nicole, Marius Francois, Dr. jur., Scheuermattweg 8 [36.894]
 Nicolet, Andre (Steinmann), Dr. med., Spezialarzt für Chirurgie, Alpeneckstr. 1 [27.970]
 – Friedr., Reisender, Mattenhofstrasse 15
 Nicolet, Jules, Kaufmann, Fischerweg 19
-– Louis E.. Handlanger, Lentulusstrasse 26
+– Louis E., Handlanger, Lentulusstrasse 26
 – Marcel Aug., Einzüger G. W. B., Pestalozzistrasse 6
 – Marthe, Bureaulistin, Zieglerstrasse 45
 – Mathilde S., Angestellte, Belpstrasse 14
@@ -33537,7 +33489,7 @@ von Niederhäusern, Adolf, Bankangestellter, Thunstrasse 109
 — Friedr., Spengler, Neufeldstrasse 19
 – Hermann, Hilfsarbeiter, Oberbottigenw. 18, Oberbottigen
 – Karl, Landwirt, Oberbottigenweg 18, Oberbottigen
-– Karl, Pferdewärter. Breitfeldstrasse 13
+– Karl, Pferdewärter, Breitfeldstrasse 13
 — Lina, Bureauang., Seftigenstr. 99 [26.067]
 ‚ Rob., Schreiner, Gesellschaftsstrasse 4
 Rudolf, Landwirt, Oberbottigenweg 25, Oberbottigen
@@ -33572,7 +33524,7 @@ Niggli, Flora Bertha, Ladentochter, Engehaldenstrasse 192
 – Otto, Maschinist, Engehaldenstrasse 192
 – Theodor, Mechaniker, Militärstrasse 28b
 – Walter, Modellschreiner, Flurstrasse 3
-Nigst, J., Arch. 22,361 (Steigerweg 2 [34.987]), Kyburgstr. 13. Uebernahmevon Neubauten, Umbauten, fachgem. Beratung in allen Baufragen, Erstellen von Plänen usw.
+Nigst, J., Arch. 📞 22.361 (Steigerweg 2 [34.987]), Kyburgstr. 13. Uebernahmevon Neubauten, Umbauten, fachgem. Beratung in allen Baufragen, Erstellen von Plänen usw.
 – Paul F. (Münger), Dr. med., Privatdozent, Spezialarzt f. Chirurgie, Monbijoustr. 49 [24.576]
 Nikes, s. auch Nikles
 – Ed., Monteur E. W. B. Drosselweg 27
@@ -33629,7 +33581,7 @@ Nikies, s. auch Nikes
 Nil, A. P. Berta, Klavierlehrerin, Untere Dufourstrasse 24
 – Ida Rosalie, Lehrerin, Unt. Dufourstr. 24
 Nilfisk Staubsauger A.-G., Zürich, Filiale: Schauplatzgasse 11 [27.556]
-Nilli, Ernst Gust.. Fabrikarbeiter. Seidenw. 14
+Nilli, Ernst Gust., Fabrikarbeiter, Seidenw. 14
 – Hans Alex., Chauffeur. Fabrikstrasse 33
 – Hedwig Martha, Verkäuferin, Stadtbachstrasse 46
 – Margaritha H., Damenschneiderin, Stadtbachstrasse 46 [28.592]
@@ -33639,7 +33591,7 @@ Nilli, Ernst Gust.. Fabrikarbeiter. Seidenw. 14
 Niquille, Charlotte M. L., Bureaulistin, Kirchenfeldstrasse 6
 – Eleonore, eidg. Angest., Marienstrasse 32
 Niquille, Marie (von der Weid), Wwe. des Generaldir. d. S. B. B., Kirchenfeldstrasse 6 [34.760]
-– Marie AL, Bureaulistin O. Z. D.. Gutenbergstrasse 9
+– Marie AL, Bureaulistin O. Z. D., Gutenbergstrasse 9
 – Paul. Dr., Zahnarzt (Monbijoustrasse 29 [35.787]), Laupenstrasse 5 [31.418]
 Nirk, Friedr. Alfred, Poliss., Brunnhofweg 19
 Nissen, Hedwig, Waldhöheweg 17
@@ -33661,7 +33613,7 @@ Nobs, Ad., Gemüsehändler. Zwiebelngässch. 3
 – Elsa Olga, Bureaulistin, Hochbühlweg 5
 – Friedrich Alfred. Bäcker u. Konditor, Zieglerstrasse 26
 – Friedr., Hilfsarbeiter, Elisabethenstr. 55
-– Friedr., Fabrikarbeiter. Chutzenstrasse 27
+– Friedr., Fabrikarbeiter, Chutzenstrasse 27
 – Friedr Wilh., kaufm. Angest., ElisabethenstrassG 55
 – Fritz, Bäckermstr., Zieglerstr. 26 [23.476]
 – Fritz, Spengler. Standstrasse 33
@@ -33681,7 +33633,7 @@ Nobs, Ad., Gemüsehändler. Zwiebelngässch. 3
 – Martha, Ladentochter, Wylerringstr. 70
 – Max Leon, Mechaniker, Tscharnerstr. 23
 – Paul Werner, Artist, Schauplatzgasse 29
-– Rob. Herm., Hilfsarbeiter. Jurastrasse 38
+– Rob. Herm., Hilfsarbeiter, Jurastrasse 38
 – Rosalie, Turnlehrerin, Sennweg 5 [27.991]
 – Walter, Hilfsarbeiter, Gerechtigkeitsg. 52
 – Walter, Lith.-Maschinenmeister, Seidenweg 66
@@ -33736,7 +33688,8 @@ Nüesch, A. (Sigrist), Wwe., Brückfeldstr. 16 [34.536]
 – Paul Walter, Mechaniker, Länggassstr. 57
 Nufer, Albert, Kondukt. B. L. S., Lerchenw. 31
 – Hans Albert, Bahnarbeiter, Schwarztorstrasse 95
-– Hans, Postbeamter, Zieglerstrasse 45v. Nunkowits, Kath. (Reichenbach), Damenschneiderin. Lerchenweg 37
+– Hans, Postbeamter, Zieglerstrasse 45
+v. Nunkowits, Kath. (Reichenbach), Damenschneiderin. Lerchenweg 37
 Nünlisi, Eriedr, Bahnmeister, Bühlstrasse 12
 – Joseph Emil, röm.-kathol. Pfarrer, Dekan, Taubenstrasse 4 [21.584]
 – Wilhelm, Schreiner, Morillonstrasse 19
@@ -33780,7 +33733,7 @@ Nussbaumer, Andre, Beamter b. ei dg. Militärdepartement, Viktoriarain 11
 # Date: 1935-12-15 Page: 26020666/359
 Nussbaumer, Maria, Verkäuferin, Lorrainestrasse 27
 – Martha, Ladentochter, Steinauweg 18
-– Max Alb.. Schlosser. Ladenwandstrasse 35
+– Max Alb., Schlosser. Ladenwandstrasse 35
 – Oskar Adolf, Maurer, Ladenwandstr 35
 – Otto Fr., Beamter der G.-D. der P. T. T., Gäcilienstrasse 20 [29.369]
 – Paul Hans (Voirol), Aktuar, Wernerstr. 12
@@ -33794,7 +33747,7 @@ Nüssli, Alb., Spediteur, Zähringerstrasse 45
 – Alb., Spinner, Elisabethenstrasse 57
 – Elise Rosa, Fabrikarbeiterin. Elisabethenstrasse 57
 – Ernst, Fabrikarbeiter, Tunnelweg 2
-– Hans. Fabrikarbeiter. Tunnelweg 2
+– Hans. Fabrikarbeiter, Tunnelweg 2
 – Heinrich Emil, Restaurant Weissenbühl, Seftigenstrasse 47 [21.956]
 – Julius, eidg. Beamter, Lorrainestrasse 6a
 – Marie, Fabrikarbeiterin, Länggassstr. 30
@@ -33836,7 +33789,7 @@ Nydegger
 Nydegger, Fridolin, Hilfsarbeiter, Länggass-Strasse 21
 – Frieda. Ladentochter, Platanenweg 3
 – Frieda, Zimmervermieterin, Bühlstr. 59
-– Friedr. Rud.. Dienstmann, Marktgasse 34
+– Friedr. Rud., Dienstmann, Marktgasse 34
 – Friedr., Kutscher, Seidenweg 33
 – Friedr., Maler, Seidenweg 33
 – Friedr. (Hirschi), Maler, Rütlistrasse 10
@@ -33963,8 +33916,8 @@ Nyffenegger, Alfr., Chauffeur, Kesslergasse 23
 – Friedr., Hilfsarbeiter, Pestalozzistrasse 28
 – Friedr., Hilfsarbeiter, Weberstrasse 15
 – Friedr., Schneider, Altenbergstrasse 50
-– Gottfr., Angestellter. Tiefenaustrasse 112
-– Gottl.,, Postgehilfe, Thormannmätteliw. 27 [21.393]
+– Gottfr., Angestellter, Tiefenaustrasse 112
+– Gottl.., Postgehilfe, Thormannmätteliw. 27 [21.393]
 – Hans, Buchbinder, Belpstrasse 43
 – Hedwig, Ladentochter, Steinerstrasse 5
 – Heinr. Ad., Kunstmaler (Chutzenstr. 21), Weissensteinstrasse 87 [35.520]
@@ -34044,7 +33997,7 @@ Oberson, Julie M., Bureauangest., Hallerstrasse 60
 – Walter Felix, Angestellter, Weissensteinstrasse 93 [26.197]
 – Willy Raymond, Angestellter der Schweiz.
 Mobiliar-Versich.-Ges., Scheuermattweg 14
-Obertelegraphendirektion, eidg., Speicherg. 6m. .. [62]
+Obertelegraphendirektion, eidg., Speicherg. 6m. [62]
 Obertüfer, Ferd., Metalldreher, Standstr. 19
 Oberwaisenkammer, Sekretariat (Rud. Hügli, Notar), Marktgasse 37 [28.287]
 Oberzolldirektion, eidg., Bundesgasse 3 [61]
@@ -34125,7 +34078,7 @@ Oderbolz, Fritz, Inspektor der Evangel. Gesellschaft, Nägeligasse 9 [22.583]
 Odermatt, Albert, Maschinenmeister, Hopfenweg 26
 – Anton, Fräser, Bridelstrasse 28
 – Hans Robert. Maler, Rodtmattstrasse 77
-– J. K., Schreiner, Rodtmattstrasse 77 .
+– J. K., Schreiner, Rodtmattstrasse 77
 – Karl, Konditor. Steigerweg 21
 Oeffentliche Telephonstationen, s. Posttarif, Abteilung Telephon
 Offermann, Emilie, Zigarren- u. Tabakhdlg., Effingerstrasse (16) 9 [24.704]
@@ -34141,12 +34094,12 @@ Ogg, Walter, Coiffeur, Ensingerstrasse 8
 Oggenfuss-Reiche, J. G. Hans, Vertr. f. Schokoladeformen u. Blechpackungen, Brunnadernstrasse 28d [28.672]
 Ogi, Alb., Kasthoferstrasse 20
 – Gertrud. Falzerin, Kasthoferstrasse 20
-O’Gormann, E., Dr. jur.. Schanzeneckstr. 25
+O’Gormann, E., Dr. jur., Schanzeneckstr. 25
 Oehler, Frieda, Ladentochter, Bachstrasse 8
 – Meinrad, Feinmechaniker, Mattenhofstr. 35
 – Rob. Georg, Dr. phil., Vennerweg 2
 Oehme, Friedr. Rud., Retoucheur, Ob. Dufourstrasse 49
-Oehrli, Adolf, Schuhmachermeister. Postg 42 [36.921]
+Oehrli, Adolf, Schuhmachermeister, Postg 42 [36.921]
 – Ad. Jak., Schuhmacher, Postgasse 42
 – Alfred, kaufm. Angest., Sonneggweg 11
 – Ernst, Hilfsarbeiter, Burgunderstrasse 55, Bümpliz
@@ -34168,12 +34121,12 @@ Olivieri, Filippo, Hilfsarbeiter, Rosenweg 5
 Olloz, Doris (Bauermeister), med. dent., Zahnärztin, Monbijoustrasse 39 [35.304]
 – M. Olga, Bureaulistin, Muesmattstrasse 30
 Olsen, Peter Frederik. Maler. Waffenweg 21
-Olson, Alb V.. Missionsdir., Ensingerstr 12
+Olson, Alb V., Missionsdir., Ensingerstr 12
 – Hazel Marie, Angestellte, Ensingerstr. 12
 Olzinger, Hans, Sänger am Stadttheater, Schwarzenburgstrasse 4
 Omlin, Alois, Dr., Tierarzt, Sulgenauweg 25 [36.773]
 Ommerli, Ernst Friedrich, Elektro-Ingenieur, Fischermätteliweg 2
-– Fritz, Schreinerei und Zimmereigeschäft, Fischermätteliweg 2 [22.2891
+– Fritz, Schreinerei und Zimmereigeschäft, Fischermätteliweg 2 [22.289]
 – Herm., Möbelschreiner, Weissensteinstr. 6
 Omnibus, städt., siehe Stadtomnibus
 Omodei, H. M., Bureaulistin, Mittelstr. 64
@@ -34199,11 +34152,11 @@ Oppliger, Ernst, Gärtner, Aebistrasse 15
 – Friedr., Chemigraph, Könizstrasse 39
 – Friedr., Installateur, Ladenwandstrasse 51
 – Fritz, Tramkondukteur, Karl-Hiltystr. 17
-– Gertrud Joha.. Ladentochter, Wiesenstr. 51
+– Gertrud Joha., Ladentochter, Wiesenstr. 51
 – Gertrud. Damenschnciderin,. Forsthausw. 2
 – Gertrud, Verkäuferin, Könizstrasse 39
 – Gottfr., pens. eidg. Angestellter, Gerechtigkeitsgasse 9
-– Gottfr. Friedr.. Fuhrmann. Seftigensfr. 16
+– Gottfr. Friedr., Fuhrmann. Seftigensfr. 16
 – Hans, Hilfsarbeiter, Hrch.-Wildstrasse 11
 – Hans Walter, Schreibarbeiten u. Vervielfältigungen, Chutzenstrasse 39 [28.714]
 – Hans. Schriftsetzer. Weissenbühlweg 14
@@ -34212,7 +34165,7 @@ Oppliger, Ernst, Gärtner, Aebistrasse 15
 – Jakob, pens. Heizer, Unt. Aareggweg 31
 – Joh. E., eidg. Beamter, Ob. Villettenmattstrasse 8
 – Joh. Rob., Dachdecker, Ladenwandstr. 51
-– Joh.. Pferdewärter. Wiesenstrasse 51
+– Joh., Pferdewärter, Wiesenstrasse 51
 – Joh., Schreiner, Greyerzstrasse 31
 – Jules Ls., in Fa. Jaggi & Oppliger. Weinhandlung, Scheuerrain 3 [31.335]
 – Karl Fr., Hilfsarbeiter, Schifflaube 26
@@ -34225,10 +34178,7 @@ Oppliger, Ernst, Gärtner, Aebistrasse 15
 – Walter, Hilfsarbeiter, Ladenwandstr. 51
 – Waiter, Masch.-Schlosser, Mattenhofstr. 13
 – Wilh. Hans, Faktor, Bernstr. 98, Bümpliz
-Oppliger & Frauchiger AG.
-«H- 26.111
-Konfiserie, Zwieback und Zwiebackinehl, Spitalg. 1
-Altes Geschäft: Aarbergergasse 23 [27.575]. Tea-Room Bäreck: Ecke Spitalgasse/Bärenplatz [21.6151
+Oppliger & Frauchiger AG. 📞 26.111 Konfiserie, Zwieback und Zwiebackinehl, Spitalg. 1 Altes Geschäft: Aarbergergasse 23 [27.575]. Tea-Room Bäreck: Ecke Spitalgasse/Bärenplatz [21.615]
 Orell Füsöli & Cie., Annoncen-Expedition u. Affichage, Bahnhofplatz 1 [22.191]
 v. Orelli, Ros. Berta. Sek.-Lehrerin, Malerw. 1
 Orgiazzi, Giacomo, Mechaniker, Gerbergasse 9
@@ -34236,7 +34186,7 @@ Oeri, Joh. Georg, Angest., Scheuerrain 5 [22.250]
 Oertli, Heinr., Dr., Ingenieur, Diesbachstr. 25 [36.708]
 – - Theodor, Bankbeamter, Brunnadernstr. 104
 Oes, Ernst, Mechaniker, Konsumstrasse 14a
-Oesch, Ad.. Einzieher E. W. B., Stockerenw. 1
+Oesch, Ad., Einzieher E. W. B., Stockerenw. 1
 – Alfred, in Fa. J. Oesch & Sohn, Zeigerw. 7 [28.262]
 – Alois, kaufm. Angestellter, Kramgasse 51
 – Anna (Oesch), Wwe., Kramgasse 51
@@ -34257,7 +34207,7 @@ Oesch, Ernst, Hilfsarbeiter, Allmendstr. 50
 – Hans, Dachdecker, Dammweg 7
 – Hans Ernst, Mech. u. Heizer, Freiestr. 47
 – Hans, Standesweibel, Postg. 72 [21.492]
-– Helena A . Glätterin. Gerbergasse 17
+– Helena A., Glätterin. Gerbergasse 17
 – Jakob, Hilfsmonteur, Breitfeldstrasse 65
 – Jakob, in Fa. Oesch & Sohn, Elisabethenstrasse 21
 – Joh., Buchbinder, Postgasse 47
@@ -34285,9 +34235,9 @@ Oser, Chs. A. L., eidg. Beamter, Ensingerstrasse 37
 Ossenf, Philippe Ad. (Staude), kaufm. Angest., Emanuel-Friedlistrasse 19 [29.067]
 Ossola, Giuseppe, Maurer, Kanonenweg 16
 Osswald, Albert, Bau- und Möbelschreinerei (Jägerweg 6), Rathausplatz 3 [35.377]
-– Ernst, sen.. Schreiner, Elisabethenstr. 19
+– Ernst, sen., Schreiner, Elisabethenstr. 19
 – Eug., Beamter, Marktgasse 47
-– Ferd. (Riedo), Hilfsarbeiter. Aarstrasse 106
+– Ferd. (Riedo), Hilfsarbeiter, Aarstrasse 106
 Oester, Alfred Arth., Schlosser, Gerechtigkeitsgasse 32
 – Oskar, Chauffeur, Gerbergasse 41
 – Oskar, Spengler, Gerechtigkeitsgasse 32
@@ -34305,7 +34255,7 @@ Bureaux f. geistiges Eigentum. Thunstr. 19 [20.938]
 – Joh., Ghefmonteur, Greyerzstrasse 35
 – Martha, Ladentochter, Schanzenbergstr. 30
 – Wendelin, Schirmflicker, Brunngasse 42
-Osterwalder, Ad. Jos. F., Buchhalter. Beundenfeldstrasse 51 [31.336]
+Osterwalder, Ad. Jos. F., Buchhalter, Beundenfeldstrasse 51 [31.336]
 Ostheimer, Andreas, Schriftsetzer, Stöckackerstrasse 79. Bümpliz
 Ostinelli, Pasquale L., Beamter der S. B. B., Seidenweg 30
 Oswald, Arnold, Rodtmattstrasse 87
@@ -34315,7 +34265,7 @@ Oswald, Arnold, Rodtmattstrasse 87
 – Heribert Guido, Mech., Monbijoustrasse 67
 – Herm., Elektromonteur, Grüner Weg 5
 – Joh., Maurer, Fröschmattweg 12b, Bümpliz
-– Marie L.. Ladentochter. Kasernenstr. 21a
+– Marie L., Ladentochter, Kasernenstr. 21a
 – Rudolf, Hilfsarbeiter, Gutenbergstrasse 5
 Oetiker, Elisabeth, Angest., Zähringerstr. 15
 – Ernst Max, Elektriker, Holligenstrasse 39
@@ -34326,7 +34276,7 @@ Oetiker, Elisabeth, Angest., Zähringerstr. 15
 Oetliker, Hanna, Lehrerin, Schifflaube 52
 Ott und Otth
 – Albert, Mechaniker, Gesellschaftsstr. 35
-– Alex.. Maschinenmeister, Lentulusstr. 28
+– Alex., Maschinenmeister, Lentulusstr. 28
 – Alfred, Zigarren- und Papeteriegeschäft, Ecke Birkenweg 27-Allmendstrasse [31.851]
 – Alwin Jak., Architekt, Haspelweg 38
 – Anna, Frau, Coiffeuse, Herren- u. Damensalon, Kl. Muristalden 36 [28.664]
@@ -34361,8 +34311,8 @@ Ott und Otth
 – Walter, Mechaniker, Cäcilienstrasse 16
 – Werner A., kaufm. Angest., Länggassstr. 55
 – Werner, Maschinenschlosser, Talweg 3
-Ottensooser, Fr.. Dr med. et phil., Arzt und Chemiker, Privatdozent, Hochfeldstr. 111 [23.200]
-Otter, Ph. H.. Putzmacherin, Weissenbühlweg 34
+Ottensooser, Fr., Dr med. et phil., Arzt und Chemiker, Privatdozent, Hochfeldstr. 111 [23.200]
+Otter, Ph. H., Putzmacherin, Weissenbühlweg 34
 – Robert, Maurer, Postgasse 48
 Ottiker, Lina (Meili), Privat., Denzlerstr. 7 [31.302]
 Oettinger, Max, A.-G., Havanna-Haus, Basel, Filiale Bern, Bahnhofplatz 11 [27.255]
@@ -34478,9 +34428,9 @@ Pardatscher, Leopold, Küfer, Berchtoldstr. 45
 Pardo, Carlos Alb., Handelsrat der argentinischen Gesandtschaft, Kalcheggweg 4 [21.804]
 Parfümerie J. Jenny, Aktiengesellschaft, Bern, Marktgasse 65
 Parfümerie millefleurs Societe Anonyme Berne, Marktgasse 17 [34.939]
-Paris, Aug.. Marbrerie et Sculptures, Murtenstrasse 36 [27.620]
+Paris, Aug., Marbrerie et Sculptures, Murtenstrasse 36 [27.620]
 – C J., Sekr. der französ. Gesandtschaft, Alpenstrasse 17 [24.461]
-– Louis Aug.. Direktor, Kapellenstrasse 6
+– Louis Aug., Direktor, Kapellenstrasse 6
 Pärli, Alb. Emil, Ingenieur, Beaulieustr. 27 [27.663]
 – Beatrice R., pens. Telephonistin, Amthausgasse 1
 – Felix Rudolf, Beamter, Stöckackerstr. 97, Bümpliz
@@ -34496,11 +34446,11 @@ Parodi, Andre Gust., eidg. Beamter, Junkerngasse 51 [32.602]
 Paroz, Clement, Kammerschreiber, Fischerweg [20.724]
 Parpan, Anton, Länggassstrasse 15 [33.639]
 – Margr. M. K., Ladentochter, Länggassstrasse 15
-Parquet- u. Chaletfabrik A.-G.. Bern, Sulgenbachstr. 12 [22.116i]
+Parquet- u. Chaletfabrik A.-G., Bern, Sulgenbachstr. 12 [22.116i]
 Parquet-Verband, Schweiz., Verkaufsbureau: Kapellenstrasse 6 [24.822]
 Parraf, Henri Josef, Bureaulist, Seftigenstrasse 36
 Partesana, Alfr., in Fa. L. Fankhauser & Cie., Seidenweg 36
-– Heinrich, Hilfsarbeiter. Genossenweg 7
+– Heinrich, Hilfsarbeiter, Genossenweg 7
 Parvex, Arnold, Zollbeamter, Monbijoustr. 51
 Pasche, Georges Alb., Bankinspektor, Ensingerstrasse 14
 Paschoud, Ch., Postkommis, Breitenrainstr. 41 [28.381]
@@ -34511,8 +34461,7 @@ Pasquier, Juliette, Lehrerin, Gerechtigkeitsgasse 29 [32.588]
 Pasquier, Max Aug., Versich.-Beamter, Breitenrainstrasse 25
 Passantenbureau, im Burgerspital, Bubenbergplatz 4
 Pass- und Fremdenpolizei, Kramgasse 24
-Pasteur, H. L., Sekretär b. d. Abteilung für
-Auswärtiges des eidg. Polit. Departements, Ensingerstrasse 5 [25.091]
+Pasteur, H. L., Sekretär b. d. Abteilung für Auswärtiges des eidg. Polit. Departements, Ensingerstrasse 5 [25.091]
 – Rosa (Wächli), Wwe., Seftigenstrasse 97
 Patentamt, Internat., Helvetiastr. 7 [25.331]
 – kantonales, Kramgasse 24 [21.5481
@@ -34569,11 +34518,11 @@ Pauli, Gertrud, Sekretärin, Breitenrainstr. 41
 – Joh., Chauffeur, Könizstrasse 67
 – Joh., Handlanger. Aehrenweg 26. Bümpliz
 – Joh. Fr., Heizungsmonteur, Predigerg. 8
-– Joh.. Karrer, Freiburgstrasse 72
+– Joh., Karrer, Freiburgstrasse 72
 – Joh Jakob. Steinhauer. Rodtmattstr. 33
 – Johanna, Arbeitslehrerin, Wildhainweg 12
 – Julie (Rohrer), Wwe., Mühlemattstr. 59 [32.586]
-– K. G., Heizer S. B. B.. Eggimannstrasse 27
+– K. G., Heizer S. B. B., Eggimannstrasse 27
 – Karl, Küfer, Sulgenbachstrasse 10
 – Klara, Lagergehilfin, Könizstrasse 55
 – L., Frau, Rohes, Neubrückstrasse 95 [36.118]
@@ -34589,15 +34538,15 @@ Pauli, Gertrud, Sekretärin, Breitenrainstr. 41
 – Walter, Angestellter, Freiburgstrasse 72
 – Walter, Buchbinderei, Luisenstrasse 7 [36.370]
 – Walter, Chauffeur S. O. B., Muldenstr. 41a
-– Walter. Velos- u. Motorradhandlung (Eggimannstrasse 27), Freiburgstr. 72 [36 963]
+– Walter, Velos- u. Motorradhandlung (Eggimannstrasse 27), Freiburgstr. 72 [36 963]
 – Werner, Kassenschlosser, Länggassstr. 83
 – Werner Otto. Schreiner. Rodtmattstr 33
 – Willi Emil, Bankangestellter, Sulgenrain 10
 – Willi Ernst, Techniker, Kursaalstrasse 13
 Paupe, Gaston L R., eidg. Beamter, Hallerstrasse 39
-– H. L. J.. kant. Beamter. Trechselstr. 8
+– H. L. J., kant. Beamter, Trechselstr. 8
 Payern, Georg Edg., Angest., Waagbausg. 8
-Payot & Cie.. A.-G.. Buchhandlung und Verlag. Bundesgasse 16 [35.537]
+Payot & Cie., A.-G., Buchhandlung und Verlag. Bundesgasse 16 [35.537]
 Pecaut, Adrien (Lüthi), Bureaulist, Brückfeldstrasse 35
 Peco A.-G., Fil. Bern, Geräte u. Prod. f. Fussbodenpflege, Effingerstrasse 30 [32.394]
 Pederzani, Erminia, Bureaulistin, Greyerzstrasse 21
@@ -34609,7 +34558,7 @@ Pedrini, Felice, Chemiker, Hirschengraben 10
 Pedroni, Leiio, Mech Werkstätte, Speichergasse 35
 Pedroita, Luigi, eidg. Beamter, Schauplatzgasse 11
 Peetz, J. Martin, Antiquariat (Schläflistr. 4), Kramgasse 8 [27.518]
-Peitsch, Jean, Schneidermeister. Kramg 16 [31.233]
+Peitsch, Jean, Schneidermeister, Kramg 16 [31.233]
 Pelissier, Jean Francois. Kaufm., Seftigenstrasse 10
 Pelix, Jankel, Uebersetzer, Schwarztorstr. 69
 Pellaton, Bluette, Daktylographin, Greyerzstiasse 18
@@ -34620,7 +34569,7 @@ Pellegrini, Angelo, Marbrier, Bridelstr. 12
 – Antonio, Maurerpolier, Wiesenstrasse 3
 – Giovanna Fabrikarbeiterin, Seidenweg 19
 – Plinio (Siegfried), Sekretär der O. P. D., Gesellschaftsstrasse 29
-– T . Maurer. Gewerbestrasse 20
+– T., Maurer. Gewerbestrasse 20
 – Vincenzo, ital. Handelsattache, Thunstr. 43 [32.850]
 Peiler, Franz (Suter), Hilfsarbeiter, Holligenstrasse 13
 – Georg, Maschinist, Bühlstrasse 25
@@ -34634,11 +34583,11 @@ Pelozzi, Emilio Mario. Mech., Genossenw. 21
 – Luigi. Maurer. Standstrasse 33
 – Teodore G., Maurer, Länggassstrasse 79
 Peltan, Jos., Mechaniker. Bethlehemstrasse 23, Bümpliz [46.2381
-– Martha. Dr.. Zahnärztin (Bethlehemstr 23, Bümpliz [46 238]), Bärenplatz 2 [27.580]
+– Martha. Dr., Zahnärztin (Bethlehemstr 23, Bümpliz [46 238]), Bärenplatz 2 [27.580]
 Pelzhaus z. Bären, Pelzwaren- u. Kürschneratelier, Spitalgasse 34 I. [22.473]
 Pension Luisa, Luisenstrasse 43 [21.561]
 Pensions- u. Krankenkasse, Städt., Junkerngasse 41 [21.511]
-Pequignot, Eug.. Fürsprecher, Adjunkt d Direktors d Handelsabtlg d Volkswirtsrh.-Dep., Jubiläumsstrasse 53 [35.697]
+Pequignot, Eug., Fürsprecher, Adjunkt d Direktors d Handelsabtlg d Volkswirtsrh.-Dep., Jubiläumsstrasse 53 [35.697]
 Perdomi, Bernhard, Hilfsarbeiter, Zähringerstrasse 53
 – Johanna, Fabrikarbeiterin, Zähringerstr. 53
 Perello, Alice Lina, Bureaulistin, Balmweg 22
@@ -34650,14 +34599,12 @@ Perier, s. auch Perrier und Perriere
 – Roger Ami, Angestellter, Morillonstr. 32
 Perinat, Ch Gust, Handlanger. Platanenw. 3
 Perincioli, St., Skulpteur, Egghölziiweg 40 [35.529]
-Umänderungen, Reparaturen für alle Zentralheizungssysteme Pärli & Co.
-Beratungen, Vorschläge besorgt Ihnen jederzeit prompt u. gewissenhaft Hirschengraben 2 Tel. 24.881
 # Date: 1935-12-15 Page: 26020675/368
 Perler, Adrien R. (Späni), Bremser S. B. B., Rohrweg 6
 – Clemens (Mensch), Techniker, Wylerstr. 34
 – Peter Louis, Kolporteur, Effingerstr. 6
 Perlet, Gaston, Dr. med., Arzt, Bubenbergplatz 9 [24.451]
-– Jules, eidg. Beamter. Sonneggweg 21
+– Jules, eidg. Beamter, Sonneggweg 21
 – Marie Rosa (Imhoff), Wwe., Kapellenstrasse 28 [32.069]
 – Pierre Paul, Schuhmachermeister., Berchtoldstrasse 2
 Perlstein, Marc, Dr., Chem., Tscharnerstr. 5
@@ -34672,19 +34619,18 @@ Perren, Erna, Bureaulistin, Zähringerstr. 24
 – Rob., Prokurist, Simonstrasse 23
 Perrenoud, Blanche, Schneiderin, Luisenstrasse 18
 – Claire (Poulin), Wyttenbachstrasse 22
-Perrenoud, J., & Cie. 24,130
-A.-G., Möbelfabrik, Verkaufsstelle Bern, Amthausgasse 2/Theaterplatz
+Perrenoud, J., & Cie. 📞 24.130 A.-G., Möbelfabrik, Verkaufsstelle Bern, Amthausgasse 2/Theaterplatz
 – M. Margr. El., Bureaulistin, Wyttenbachstrasse 10
 – Marie (Leuenberger), Wwe., Telephonistin, Wyttenbachstrasse 10
 – Werner, Schriftsetzer, Güterstrasse 40
 Perret, Adolphe, Beamter, Beaulieustrasse 11
 – Andre, Mechaniker, Laupenstrasse 17
-– Bernard. Hilfsarbeiter. Alten bersrstr. 34
+– Bernard. Hilfsarbeiter, Alten bersrstr. 34
 – Cesar Philippe, eidg. Beamter, Mühlemattstrasse 16
 – Charles E., Subdirektor d. Spar- u. Leihkasse, Ensingerstrasse 24 [36.780]
 – Charles, Dr. jur., Fürsprecher, Helvetiastrasse 31 [35.718]
 – Hans Arn., Magaziner, Schöneggweg 30
-– Herm.. Vernickler, Sandrainstrasse 33a
+– Herm., Vernickler, Sandrainstrasse 33a
 – Jean Pierre, Chauffeur, Brückenstrasse 21
 – L. Aug., pens. Heizer G.-W., Sandrainstrasse 33a
 – Margr. Elise, Damenschneiderin, Karl-Schenkstrasse 1
@@ -34697,7 +34643,7 @@ Perriere, s. auch Perier und Perrier
 – Fr. Ls., Bankangestellter, Diesbachstr. 27
 Perrin, Armande, Bureaulistin der O. Z. D., Schwarzenburgstrasse 60 [45.043] 1
 – Charles Mathias, Bankbeamter, Falkenw. 8
-– Donat Francis, Postbeamter. Länggassstrasse 59
+– Donat Francis, Postbeamter, Länggassstrasse 59
 Perrin, Georges Ad., Journalist, Sulgenrain 10 [22.488]
 – Georges Ed., Kupferstecher, Schillingstr. 28
 – Hilaire, Pferdewärter, Rodtmattstrasse 52
@@ -34712,16 +34658,16 @@ Perrot, Friedrich H., Maler, Wiesenstr. 64
 – Helene, Klara, Einlegerin, Wiesenstr. 64
 – Joh. Alfr., Mechaniker, Turnweg 17
 – Joh. Ad., Techniker, Attinghausenstr. 21
-– Johanna Margr.. Einlegerin, Turnwes 17
+– Johanna Margr., Einlegerin, Turnwes 17
 – Leon, Malermeister, Wiesenstr. 64 [26.150]
 – Mina Ida, Laborantin, Wiesenstrasse 64
 – Rud. Werner, Masch.-Schlosser, Turnw. 17
 – Walter, Spengler, Wiesenstrasse 64
-Persitz, S.. Fürsprecher. Advokaturbureau
+Persitz, S., Fürsprecher. Advokaturbureau
 Belpstr. 18 [27.584]), Spitalg. 18 [28.293]
 Personalzentrale der Schweiz. Gesellschaft für
 Psychiatrie, Murtenstrasse 11 [23.249]
-Personeni, Barth.. Hilfsarbeiter, Bahnhöheweg 102. Bümpliz
+Personeni, Barth., Hilfsarbeiter, Bahnhöheweg 102. Bümpliz
 – Elisa M. Fabrikarbeiterin, Bahnhöheweg 102, Bümpliz
 – Ines Maria, Bureaulistin, Bahnhöhew. 102, Bümpliz
 – Lina, Bureaulistin, Bahnhöheweg 102, Bümpliz
@@ -34736,14 +34682,14 @@ Perucchi, Arturo, Maurer, Helvetiastrasse 17
 Peruhag, Patent-Erwirkungs- u. Handels-Gesellschaft, Christoffelgasse 4 [23.504]
 Pervangher, Ugo S., Inspektor der O. Z. D., Optingenstrasse 35
 Pesavento. Ant., Bildhauer. Pestalozzistr. 28
-Pesch, Alb., Direkter b. Brann A.-G., Marktgasse 37 . [24.8381
+Pesch, Alb., Direkter b. Brann A.-G., Marktgasse 37 [24.8381
 Peschke, Emil, Uhrmacher. Lorrainestr 8a
 Peschl, Franz, Wirt im Hotel-Rest. ''''' Mann, Aarbergergasse 41 [23.141]
 – Verena. Konzertsängerin, Aarbergerg. 41 [23.141]
 Pessina, Angelo, Handlanger. Gesellschaftsstrasse 30
 – El. E., Ladentochter, Effingerstrasse 9
 Pestalozzi, Anna Hedwig (Schwarzenbach), Wwe., Blumenbergstrasse 14 [28.061]
-– E. H.. Geometer. Ing., Effingerstrasse 88 [35.5361
+– E. H., Geometer, Ing., Effingerstrasse 88 [35.5361
 # Date: 1935-12-15 Page: 26020676/369
 Pestoni, Karl Walter, Maler, Brunnmattstrasse 47
 Peter, s. auch Petter
@@ -34796,7 +34742,7 @@ Peter, s. auch Petter
 – Paul, Photograph, Stöckackerstr. 53, Bümpliz
 – R., Sattler- u. Tapezierermeister (Zähringerstrasse 50), Berchtoldstrasse 4 [21.478]
 – Reinhold, jun., Sattler, Zähringerstr. 50
-– S.. Karrer, Schläflirain 1
+– S., Karrer, Schläflirain 1
 – Ulrich, Handlanger, Stöckackerstrasse 53, Bümpliz
 – Walter Gottfr., Elektromechaniker, Sulgenbachstrasse 19
 – Walter, Sekretär, Effingerstrasse 59
@@ -34867,13 +34813,13 @@ Peyer A.-G. [22.041] Techn. Artikel, Oele und Fettwaren, Storenfabrik, Wagen- un
 – Hilda Rosalie, Zahntechnikerin, Marktg. 13
 – Klara Rosalie, Kindergärtnerin, Marktg. 13
 – Martha, Bureaulistin, Kalcheggweg 21
-– Paul, Angestellter. Optingenstrasse 39
+– Paul, Angestellter, Optingenstrasse 39
 – Willi, Bureaulist, Rosenweg 7
 – Schwestern, Kunst- u. Antiquitätenhdlg., Kirchgasse 22 [36.843]
 v. Peyer im Hof, A. E. C. (v. Wyttenbach), Wwe., Junkerngasse 37 [33.955]
 Peyfon, Martha (Garraux), Frau, Steinauweg 29 [27.483]
 Peytrignet, Alb., Trambilletteur, Zeltweg 13
-– Math Emma. Ladentochter. Zeltweg 13
+– Math Emma. Ladentochter, Zeltweg 13
 Pezolt, Alfr., Fürspr., Advokatur- u. Inkassobureau (Seftigenstrasse 10 [24.297]) Bundesplatz 4 [22.542]
 – Marie (Gattiker), Wwe. d. Notars. Thunstrasse 24 [22.447]
 – Rosa, Marzilistrasse 22c
@@ -34898,7 +34844,7 @@ Pfäffli, Alfr., Bauamtarbeiter, Kasthoferstr. 4
 – Ernst (Briillmann), Hilfsarbeiter, Scheibenstrasse 28
 – Ernst Emil, Schriftsetzer, Dalmazirain 40
 – Felix (Jäggi), Elektriker, Murtenstr 22
-– Franz Laurenz, Pferdewärter. Rodtmattstrasse 91
+– Franz Laurenz, Pferdewärter, Rodtmattstrasse 91
 – Fr., Webermeister, Sulgenrain 28
 – Frieda, Sulgenrain 28
 – Gottl. (Geissmann), Hilfsarbeiter, Jurastrasse 99
@@ -34908,7 +34854,7 @@ Pfäffli, Alfr., Bauamtarbeiter, Kasthoferstr. 4
 – Karl Ernst, Lederzuschneider, Herzogstr. 2
 – Lina (Plüss), Wwe., Molkereiprodukte, Murtenstrasse 5 [22.564]
 – Rudolf. Postbeamter, Effingerstrasse 54
-– Walter. Oberpferdewärter, Wiesenstr. 73
+– Walter, Oberpferdewärter, Wiesenstr. 73
 Pfähler, Pierre E., Ingenieur, Effingerstr. 54
 Pfahrer, Joh., Schriftsetzer, Freiburgstr. 442, Bümpliz
 – Joh., Sohn, Chauffeur, Freiburgstr. 442, Bümpliz
@@ -34924,7 +34870,7 @@ Pfänder, Bertha Clara, Manuelstrasse 78
 Johannes. Hilfsarbeiter, Friedheimweg Ui
 # Date: 1935-12-15 Page: 26020678/371
 Pfänder, Louise, Schneiderin, Optingenstr. 35 [27.204]
-– Simon Gottfr., Hilfsarbeiter. Wylerfeldstrasse 50
+– Simon Gottfr., Hilfsarbeiter, Wylerfeldstrasse 50
 – Sophie Adele, Frl., Manuelstrasse 78
 – Werner Alb., Dr., Chemiker. Manuelstr. 78 [34.2171
 Pfändler, Lili, Bureaulistin, Mühlemattstr. 18
@@ -34942,13 +34888,13 @@ Pfau, Anna (Pfau), Privatiere, Morgenstr. 11, Bümpliz
 Pfäuti, Alfr., pens. Angest. S. B. B., Schlossstrasse 121
 – Joh. (Denzler), Bankprokurist, Monbijoustrasse 94 [23.349]
 – Karl, Knecht, Alter Aargauerstalden 32
-– Sam.. Schneider, Rabbenthalstrasse 41
+– Sam., Schneider, Rabbenthalstrasse 41
 Pfefferli, Eugen, Visiteur S. B. B., Kirchbergerstrasse 61
 Pfeifer und Pfeiffer
 – Anna Martha, Bureaulistin, Jubiläumspl. 6 [21.7811
 – Anna, Schneiderin, Beundenfeldstrasse 42
 – Elisabeth, Verkäuferin, Beundenfeldstr. 42
-– Gottl.. Konfiseur, Lerchenweg 31
+– Gottl., Konfiseur, Lerchenweg 31
 – Jakob, Rest. z. braunen Mutz, Genf erg. 3 [26.255]
 – Jakob. Telephonarbeiter, Hauensteinweg 12
 – Jakob, Steinhauer, Fröschmattweg 18, Bümpliz
@@ -34992,19 +34938,19 @@ Pfister, Akt.-Ges., Möbelhaus, Filiale Bern, Schanzenstrasse 1 [23.075]
 – Alfred, Melker, Rehhagstr. 42, Bümpliz
 – Alice, Bureaulistin, Gutenbergstrasse 14
 – Aline Erna, Frl., Neufeldstrasse 17
-– Anna Elisabeth. Bureauangest.. Rohrw. 3
+– Anna Elisabeth. Bureauangest., Rohrw. 3
 – Armin, Eisendreher, Waffenweg 10
 – Arnold, gewes. Schreinermeister, Gesellschaftsstrasee 31
 – Arnold. Stationsbeamter S. B. B., Hochfeldstrasse 106
 – Benjamin, Pfarrer an der Pauluskirche, Neufeldslrasse 6 [24.975]
 – Bertha, Fabrikarbeiterin, Cäcilienstrasse 18
-– Bertha Margr., Ladentochter. Altenbergstrasse 4
+– Bertha Margr., Ladentochter, Altenbergstrasse 4
 – Bertha, Verkäuferin, Scheibenstrasse 55
 – Christ., Kondukteur, Badgasse 33
 – Elsa Alice, Bureaulistin, Greyerzstr. 33
 – Emil, Bankangestellter, Könizstrasse 39
 – Emil, Direktor, Waldhöheweg 23 [32.537]
-– Emil, jun.. Kaufmann. Waldhöheweg 23
+– Emil, jun., Kaufmann. Waldhöheweg 23
 – Emma, Fabrikarbeiterin, Muesmattstr. 45
 – Emma, Hilfsarbeiterin, Freiburgstr. 346, Bümpliz
 – Ernst, Gasarbeiter, Badgasse 31
@@ -35012,7 +34958,7 @@ Pfister, Akt.-Ges., Möbelhaus, Filiale Bern, Schanzenstrasse 1 [23.075]
 – Ernst Herm., kaufm. Angest., Mühlemattstrasse 14
 – Ernst, Schuhmacherms tr., Bantigerstr. 22 [33.537]
 – Ernst, Tapezierer, Altenbergstrasse 4
-– Erwin Karl, Vertreter. Gesellschaftsstr. 84
+– Erwin Karl, Vertreter, Gesellschaftsstr. 84
 # Date: 1935-12-15 Page: 26020679/372
 Pfister, Eugen Walter, Eisendreher, Waffenweg 10
 – Friedr., Kapellenstrasse 26
@@ -35032,7 +34978,7 @@ Pfister, Eugen Walter, Eisendreher, Waffenweg 10
 – Gottl., Gärtner, Gryphenhübeliweg 12
 – Gottl. (Sieber), pens. Lehrer. Elfenauw. 13
 – Hans, Architekt, Weissenbühlweg 8
-– Hans, Abwart d. S. B. B.. Schanzenstr. 6
+– Hans, Abwart d. S. B. B., Schanzenstr. 6
 – Hans, Fürspr., Generaldir. der Schweiz.
 Mobiliar-Versich.-Gesellschaft, Kirchenfeldstrasse 8 [31.079]
 – Hans Fr., Hilfsarbeiter, Buchenweg 18
@@ -35055,7 +35001,7 @@ Mobiliar-Versich.-Gesellschaft, Kirchenfeldstrasse 8 [31.079]
 – Joh. Fr., Schreiner, Bubenbergplatz 4
 – Joh. Ernst, Zeichner, Rohrweg 3
 – Jos. Karl, mech. Schuhmacherei, Breitenrainstrasse 41
-– Jos., Wärter. Schermenweg 36
+– Jos., Wärter, Schermenweg 36
 – Karl Fritz, Schlosser, Waffenweg 15
 – Karl (Matthaey), Generalagent der « Bäloise », Feuerversicherung, Breitfeldstr. 29 [29.983]
 – Lieseli, Verkäuferin, Schanzenstrasse 6
@@ -35097,8 +35043,8 @@ Pfisterer, Friedr., Kunstmaler, graph. Kunstu. Clicheanstalt, Balderstr. 30 [33.
 Pfisternzunft, Kramgasse 9
 Pflasterer, Emma, Buchhalterin, Wyttenbachstrasse 20
 – Ida, Wyttenbachstrasse 20
-– Richard, Hilfsarb.. Wyttenbachstrasse 20
-Pflegekinder-Aufsicht, städt.. Junkerng. 32 [21.511]
+– Richard, Hilfsarb., Wyttenbachstrasse 20
+Pflegekinder-Aufsicht, städt., Junkerng. 32 [21.511]
 Pflegerinnenheim des Roten Kreuzes mit Stellenvermittlung für Krankenpflegepersonal, Niesenweg 3 [22.903]
 Pflegerinnenschule Engeried, Sekretariat und Vermittlungsstelle an Private: Alpeneckstrasse 1 [23.544]
 Pflegerinnenschule des Roten Kreuzes, Privatspital Lindenhof, Hügelweg 2 [21.074]
@@ -35131,8 +35077,7 @@ Philippin, A. Marie (Oester), Wwe., Brückfeldstrasse 35
 Philippossian, Philippe, Privatier, Anshelmstrasse 10
 Philips-Lampen A.-G., Speichergasse 10
 Philologisch-pädagogisches Seminar, Gesellschaftsstrasse 2
-Phoenix, franz. Feuer- u. Lebensversicherung
-A.-G., Generalvertreter: P. König & Grimmer. Hotelgasse 1 [24.828]
+Phoenix, franz. Feuer- u. Lebensversicherung A.-G., Generalvertreter: P. König & Grimmer. Hotelgasse 1 [24.828]
 Physikalisches Institut, Sidlerstrasse 5 [32.738]
 Photo-Haus Metro, Waisenhausplatz 27 [21.842]
 Physiologisches Institut (Hallerianum), Bühl.platz 5 [21.572]
@@ -35148,7 +35093,7 @@ Piatti, G. L., Maurer, Waldheimstrasse 21
 Picard, Louis, Spitalackerstrasse 57 [22.570]
 – Pauline (Bloch), Wwe., Hallwylstrasse 37 [35.388]
 – Rene Andre, Vieh- und Pferdehändler, (Greyerzstr. 18 [23.681]), Speicherg. 27nccichini, Gius. (Rassu), Pension, Marktgasse 51
-Piccino, Henri Jean (Gherpillod), kaufm. Angestellter, Egelgasse 55 [20.980]nccoli, W.. Maschinenwäscher, Thunstr. 103richler, Josepha, Weberin, Brunngasshalde 45
+Piccino, Henri Jean (Gherpillod), kaufm. Angestellter, Egelgasse 55 [20.980]nccoli, W., Maschinenwäscher, Thunstr. 103richler, Josepha, Weberin, Brunngasshalde 45
 Pichonnat, Adrien. Pferdewärter, Breitfeldstrasse 38
 Pickel, Johann Franz, Faktor, Bümplizstr. 97
 – Rud. (Andres), Faktor, Effingerstrasse 97
@@ -35162,7 +35107,7 @@ Pieren, Alfr., Kolonialwaren, chem.-techn. Artikel, Könizstrasse 49
 – Ernst, Verträger, Waldheimstrasse 25
 – Friedr. Wilh., Angest. S. S. B., Frikartw. 20
 – Friedr., Zeitungsverkäufer, Könizstr. 49
-– Herm.. Postchauffeur, Weberstrasse 21
+– Herm., Postchauffeur, Weberstrasse 21
 – Karl Fr., Masch.-Schlosser, Gesellschaftsstrasse 76
 Pieri, Ad., Kommis, Hochfeldstrasse 9
 – Anna, Einlegerin, Buchenweg 12
@@ -35202,7 +35147,7 @@ Piquerez, Louis (Lagowskaja), Fürsprecher, Tavelweg 25
 – Paul Alb., Mechaniker, Schwarztorstr. 97
 Pirovani. Alfonso, Gipser, Blumenweg 7
 Pjrovano, Ugo G., Gipser, Zentralweg 24
-Pisoni, O.. Schneidermeister, Gewerbestr. 24
+Pisoni, O., Schneidermeister, Gewerbestr. 24
 Pistermann, Aron, Direktor der Flora A.-G., Monbijoustrasse 21 [24.192]
 – Waldemar S., kaufm. Angest., Monbijoustrasse 21
 Pitlik, Milan, Rat der tschechoslowakischen
@@ -35292,14 +35237,13 @@ Pochon, Charles, Bankangestellter, Dalmaziweg 43
 – Ernst Alex., Kaufmann, Dalmaziweg 43
 – Ernst, gew. Revisor der eidg. Finanzkontrolle, Aegertenstrasse 1 [34.040]
 – Fritz (Jent), Verleger, Effingerstrasse 1 [31.347]
-– Rene M. H.. Kaufmann. Diesbachstrasse 18
+– Rene M. H., Kaufmann. Diesbachstrasse 18
 – Ludw. Friedr. Hans (Bürki), Kaufmann, Diesbachstrasse 18 [32.109]
 Pochon, Gebr., AG. 21.757/58
 Gold- u. Silberschmiede und Uhrmacher, Marktgasse 55/57
 – Jent. Fritz, Verlag des «Bund» und Buchdruckerei, A.-G., Effingerstr. 1-3 [21.211], Buchdruckerei: ’ [21.238]
-van Podgoritschany, Bertha E.. Privatiere, Scheuermattweg 14 [27.976]
-Poggi, Cesare, italien. Legationsrat für das
-Auswanderungswesen, Elfenstrasse 14
+van Podgoritschany, Bertha E., Privatiere, Scheuermattweg 14 [27.976]
+Poggi, Cesare, italien. Legationsrat für das Auswanderungswesen, Elfenstrasse 14
 Pöhler, Oskar, in Fa. Pöhler & Co., Hockfeldstrasse 104 [28.040]
 – & Co., Hygia-Vertrieb, Neuengasse 3
 Polar, Elise, Frau, Hallerstrasse 2 [23.323]
@@ -35379,7 +35323,7 @@ Portenier, Alb., Tramangest., Könizstr. 43a
 – Alex., Hilfsarbeiter, Postgasse 14
 – Alfred Werner, Chauffeur, Fährweg 10
 – Friedr., Handlanger, Römerweg 7
-– G., Bäckermstr.. Forsthausweg 6 [24.826]
+– G., Bäckermstr., Forsthausweg 6 [24.826]
 – Gottfr., Magaziner, Murifeldweg 1
 – Gottfr., Taxi-Chauffeur, Seftigenstr. 95
 – Hans Jakob, Bautechniker, Seftigenstr. 64
@@ -35411,7 +35355,7 @@ Portner, Alfr., Gärtner, Schwyzerstärnweg 18 [20.327]
 – Alfr., Güterarbeiter der S. B. B, Bubenbergstrasse 10b
 – Alfr., Mechaniker, Munzingerstrasse 17
 – Alice Marie, Ladentochter, Mittelstrasse 21
-– Chr.. Bereiter. Militärstrasse 22
+– Chr., Bereiter, Militärstrasse 22
 – Christ. Rud., Küfer, Freiburgstrasse 155
 – Chr., gew. Milchhändler, Standstrasse 6
 – Elise Martha, Frau, Pens., Monbijoustr. 22
@@ -35434,10 +35378,10 @@ Portner, Alfr., Gärtner, Schwyzerstärnweg 18 [20.327]
 – Karl, Handlanger, Standstrasse 50
 – Luise, Angestellte, Stauffacherstrasse 41
 – Rosa, Bureaulistin, Standstrasse 6
-– Rud. Fritz, Hilfsarbeiter. Waffenweg 8
+– Rud. Fritz, Hilfsarbeiter, Waffenweg 8
 – Rud., Schreiner, Berchtoldstrasse 5
 – Rud., kaufm. Angest., Myrtenweg 11, Bümpliz
-– Walter, Schuhmachermeister. Postgasse 24 [36.243]
+– Walter, Schuhmachermeister, Postgasse 24 [36.243]
 – Werner, Konsumangestellter, Block weg 11
 Portugiesische Gesandtschaft, Kanzlei. Spitalgasse 30 [21.773]
 Portugiesisches Konsulat (Dr. A. Turrian), Amthausgasse ß [23.032]
@@ -35467,7 +35411,7 @@ PT [25.481]
 PT [35.173]
 – (6) Kirchenfeld, Bubenbergstrasse 8
 PT [25.297]
-– (7) Kornhaus, Kornhauspl. 18 PT [25.2951
+– (7) Kornhaus, Kornhauspl. 18 PT [25.295]
 – (8) Kramgasse, Kramgasse 1 PT [25.298]
 – (9) Länggasse, Mittelstr. 5 PT [25.293]
 – (10) Linde, Murtenstrasse 11 PT [25.472]
@@ -35482,9 +35426,9 @@ PT [26]
 – (17) Weissenbühl, Balmweg 20 PT [25.294]
 Poste, Hôtel et Cafe de la. Neuengasse 43 [22.864]; Cafe [22.478]
 Pötsch, Agathe (Rickenbach), Wwe., Damenschneiderin, Rabbentalstrasse 76
-– Rieh., Atelier f. Herrenschneiderei, Marktgasse 42v, Pourtales, L. M. A., Dr. med., Arzt d. eidg.
-Militärversicherung, Gartenstr. 9 [21.408]
-– Marie E.. Bibliothekarin, Gartenstrasse 9
+– Rieh., Atelier f. Herrenschneiderei, Marktgasse 42
+v. Pourtales, L. M. A., Dr. med., Arzt d. eidg. Militärversicherung, Gartenstr. 9 [21.408]
+– Marie E., Bibliothekarin, Gartenstrasse 9
 Poyet, Charles Ad., Bankbeamter, Gotthardweg 1
 – Erna Paulina, Bureaulistin, Neufeldstrasse 105
 – K., gew. Bundesweibel, Effingerstrasse 75
@@ -35495,7 +35439,7 @@ Poyet, Oskar E., jun., kaufm. Angestellter, Zähringerstrasse 82 [28.021]
 – Oskar Ernst (Lehmann), in Fa. «Astra», Zähringerstrasse 82 [26.336]
 Pozzi, Carlo (Habegger), Spezerei- u. Comestiblesgeschäft, Wachtelweg 15 [34.256]
 – Emilio, Masch.-Schlosser, Zeigerweg 8
-– G. A.. Coiffeurgeschäft. Flurstrasse 24
+– G. A., Coiffeurgeschäft. Flurstrasse 24
 – Giuseppina, Schneiderin, Birkenweg 44
 – L., Bureaulistin, Birkenweg 44
 – Olga, Beamtin, Gesellschaftsstrasse 14a
@@ -35505,7 +35449,7 @@ Prat, Andre Marie, Beamter, Effingerstr. 31 [21.104]
 Prati, Maria, Weissnäherin, Brunnhof weg 25
 – Oskar G., Tapez. u. Maler, Tscharnerstr. 5
 – Vittorina, Schneiderin, Brunnhofweg 25
-Prato, Cristoforo, Gipsermeister. Belpstr. 37
+Prato, Cristoforo, Gipsermeister, Belpstr. 37
 – Erwin, Hilfsmonteur, Bethlehemstrasse 116, ßümpliz
 – Hans E., Malermeister, in Fa. J. Prato & Sohn, Neubrückstrasse 74 [20.093]
 – Heinrich Hugo, Maler, Bethlehemstr. 116, Bümpliz
@@ -35525,7 +35469,7 @@ Preisig, Adolf, Vertreter, Bühlstr. 59 [24.112]
 – Otto, Reisender, Steigerweg 23 [35.340]
 Preiswerk, Esther, Muristrasse 72
 – H. (Bischoff), Dr. phil., Muristrasse 72 [35.421]
-Prelaz, Franqois Cesar, Bereiter. Rodtmattstrasse 89
+Prelaz, Franqois Cesar, Bereiter, Rodtmattstrasse 89
 — Ida (Lehmann), Wwe., Rosenweg 18
 Premoselli, Luigi, Bautechniker, Greyerzstr. 20 [36.123]
 — Liberata, Bureaulistin, Greyerzstrasse 20
@@ -35592,8 +35536,8 @@ Probst, Ella, Humboldtstrasse 37
 – Ernst, Schmied S. S. B., Hopfenweg 16
 – Erwin, Elektromechaniker, Flurstr. 17
 – Fr., Bankbeamter, Beundenfeldstrasse 16
-– Friedr.. Privatier, Wylerstr. 55 [25.906]
-– Friedr. Ernst, Hilfsarbeiter. Federweg 27
+– Friedr., Privatier, Wylerstr. 55 [25.906]
+– Friedr. Ernst, Hilfsarbeiter, Federweg 27
 – Friedr Otto, Koch, Hodtmattstrasse 60
 – Fritz, Handlanger, Kehrg. 55, Bümpliz
 – Fritz, Handlanger, Bottigenstrasse 59, Bümpliz
@@ -35607,13 +35551,13 @@ Probst, Ella, Humboldtstrasse 37
 – Hilda. Frl., Kramgasse 60
 – Tda Ther. (Bühler). Wwe., Breitfeldstr. 31a
 – Joh. Rud., Eisendreher, Bottigenstrasse 61, Bümpliz
-– Johanna. Ladentochter. Badgasse 37
+– Johanna. Ladentochter, Badgasse 37
 – Jul. E., Schuhmachermeister, Freiburgstrasse 70
 – Jules Alfr., Wärter, Bolligenstrasse 117
 – Julie, Lehrerin, Steinerstrasse 5
-– Juliette. Frl.. Nageligasse 7
+– Juliette. Frl., Nageligasse 7
 – Karl, Metzger, Stöckackerstr. 91, Bümpliz
-– Klara L. M, Frl.. Privatiere, Pavillonw. 12
+– Klara L. M, Frl., Privatiere, Pavillonw. 12
 – Lydia (Jäger), Wwe., Steinauweg 3 [33.368]
 – Marie Helena (Studer), Wwe., Privatiere, Humboldtstrasse 37 [36.245]
 – Marie, Wäscherin, Postgasse 24
@@ -35623,11 +35567,11 @@ Probst, Ella, Humboldtstrasse 37
 – Paul Aug., pens. Beamter, Altenbergstr. 110
 – Paul, Chemiker, Pavillonweg 12
 – Paul Osk., Dienstchef im eidg Volkswirtschaftsdepartement, Steinerstr. 5 [29.915]
-– Philipp, Hilfsarbeiter. Breitfeldstrasse 52
+– Philipp, Hilfsarbeiter, Breitfeldstrasse 52
 – Rene, Dr. phil., Gymnasiallehrer, Klaraweg 29
 – Rosa E., Damenschneiderin. Kornhausplatz 11t— Rud. G., Instruktionsoffizier. Steinauweg 3 [33.368]
 – Rud. Fr., Fürsprecher, Hochfeldstr. 98
-– Rud.. Dr., Zahnarzt (Ensingerstrasse 31 [35.622]), Hotelgasse 14 [33.837]
+– Rud., Dr., Zahnarzt (Ensingerstrasse 31 [35.622]), Hotelgasse 14 [33.837]
 – Th., Steinhauer, Haldenweg 1
 – Thekla (Scherb), Wwe., Humboldtstr. 25 [35.735]
 — Traugott, Uhrenmacher, Birkenweg 42
@@ -35684,20 +35628,20 @@ Pulfer, H. & F., Ing. [22.756] Ingenieurbüro u. Bauunternehmung für Eisenbeton
 – Hedwig, Bureaulistin, Dählhölzliweg 3
 – Heinrich, Buchdrucker, in Firma Lehmann & Pulfer, Buchdruckerei, Dählhölzliweg 3
 – Joh., Bauamtarbeiter, Aebistrasse 15
-– Joh.. städt Beamter, Pestalozzistrasse 14
+– Joh., städt Beamter, Pestalozzistrasse 14
 – Joh., Hilfsarbeiter, Kramgasse 55
 – Joh. Jak., Hilfsarbeiter, Freiburgstr. 172, Bümpliz
 – Joh., Reisender, Könizstrasse 33 [31.082]
 – Klara, Glätterin, Lentulusrain 28
 – Margr., Damenschneiderin. Tiefenaustr 94
 – Marie (Streit), Wwe., Kapellenstrasse 22 [22.756]
-– Marie (Remund), Wwe.. Wasserleitungsunternehmung, Murifeldweg 2 [35.641]
+– Marie (Remund), Wwe., Wasserleitungsunternehmung, Murifeldweg 2 [35.641]
 – Paul G., Schreiner, Holligenstrasse 33
 – Rud., Standstrasse 5
 Pult, Jar., Kassier. Zeigerweg 7
 Pulver, s. auch Pulfer
 – Adolf, Tiefbautechniker, Willadingweg 34
-– Alb.. Postangestellter. Tscharnerstr 21
+– Alb., Postangestellter, Tscharnerstr 21
 – Alex., Möbel- und Bettwarenhandlung, Sattler- und Tapez.-Werkstätte, Scheibenstrasse 13 [22.635]
 – Alex., jun., Tapezierer. Scheibenstrasse 13
 – Alice Hedwig, Schneiderin, Gerechtigkeitsgasse 48
@@ -35705,23 +35649,23 @@ Pulver, s. auch Pulfer
 – Alice, Damenschneiderin, Aehrenweg 20, Bümpliz
 – Anna (Hemmann), Wwe., Tillierstrasse 40
 – Arnold (Schwab), städt. Beamter, Kirchenfeldstrasse 32 [31.314]
-– Bernhard Joh.. Bankangestellter, Moserstrasse 13
+– Bernhard Joh., Bankangestellter, Moserstrasse 13
 – Christian (Burri), Moserstr. 13 [22.162]
 – Christ. Ad., kaufm. Angestellter, Greyerzstrasse 42
 – Christian, Schreiner, Greyerzstrasse 42
 – Emil Hugo, Elektriker, Berchtoldstr. 45
-– Emma (Arm). Wwe.. Neubrückstrasse 70
+– Emma (Arm). Wwe., Neubrückstrasse 70
 – Emma Lina (Schwarz), Haldenweg 6
 Ernst, kaufm. Angestellter, Werkgasse 9, Bümpliz
 – Ernst, Garagearbeiter, Murifeldweg 14
-Ernst Rud.. Handlanger, Gryphenhübeliweg 12
+Ernst Rud., Handlanger, Gryphenhübeliweg 12
 – Ernst (Peter), Hilfsarbeiter, Weissensteinstrasse 1
 Pulver, s. auch Pulfer
 – Ernst. Maler. Lorrainestrasse 69
 – Flora, Damenschneiderin, Neubrückstr. 70
 – Friedi., Bahnarbeiter, Weissensteinstr. 18
 – Friedr., Pferdewärter, Rodtmattstrasse 56
-– Friedr P.. Sohn, in Fa. Fritz Pulver’s Söhne, Optingenstrasse 1 [24.488]
+– Friedr P., Sohn, in Fa. Fritz Pulver’s Söhne, Optingenstrasse 1 [24.488]
 – Friedrich, Wegmeister, Murtenstrasse 220, Bümpliz
 – Friedrich, Kohlenarbeiter, Aehrenweg 20, Bümpliz
 – Fritz. Snitalackerstrasse 16 [24.411]
@@ -35745,11 +35689,11 @@ Muesmattstrasse 39 [36.824]
 – Hans, Maschinist, Wintermattweg 14, Bümpliz
 – Hans Robert (Marti), Postbeamter, Seidenweg 24
 – Ida Gertrud, Verkäuferin, Spitalgasse 9
-– Joh.. Hilfsarbeiter Tiefenaustrasse 94
+– Joh., Hilfsarbeiter Tiefenaustrasse 94
 – Joh., Hilfsarbeiter, Bümplizstrasse 60
 – Joh. Jak., Hilfsarbeiter, Freiburgstr. 174, Bümpliz
-– Karl, Bahnarbeiter. Werkgasse 9. Bümpliz
-– Karl, Fuhrhalter. Freiburgstrasse 82a [24.241]
+– Karl, Bahnarbeiter, Werkgasse 9. Bümpliz
+– Karl, Fuhrhalter, Freiburgstrasse 82a [24.241]
 – Karl, Kohlenarbeiter, Bümplizstrasse 60
 – Lina (Soltermann). Moserstrasse 18
 – Lina. Frau, Liniererin, Sodweg 5
@@ -35768,12 +35712,12 @@ Pulver, s. auch Pulfer
 – Rosa, gewes. Lehrerin der Mattenschule, Waldhöheweg 14 [21.560]
 – Rud., Dienstmann, Ulmenweg 4
 – Rud., Druckereigehilfe, Muldenstrasse 44
-– Rud., Hilfsarbeiter. Freiburgstrasse 121
+– Rud., Hilfsarbeiter, Freiburgstrasse 121
 – Rud. (Maumary), Kaufmann, in Fa. Fritz
 Pulver’s Söhne. Optingenstrasse 4 [32.863]
 – Rud., Schuhmacher, Metzgergasse 62
 – ’sche Apotheke (Dr. K. Heuberger), Spitalgasse 37 [21.945]
-– Walter, Fabrikarbeiter. Muldenstrasse 44
+– Walter, Fabrikarbeiter, Muldenstrasse 44
 – Walter Karl, Hilfsarbeiter, Fischermätteliw r eg 12
 – Werner, kant. Angest., Grüner Weg 5
 – Wilhelm, Maler, Zaunweg 18
@@ -35781,7 +35725,7 @@ Pulververwaltung, Zentral-, Bundeshaus-Nord [61.697]
 Pünter, Anna Maria (Bangerter), Erlachstr. 8
 – O., Journalist, Sennweg 7 [28.300]
 Punzo, Elena, BureauliStin, Monbijoustr. 18
-– G.. Schuhmachermeister. Monbijoustr. 18
+– G., Schuhmachermeister, Monbijoustr. 18
 Purator Akt.-Ges., Staubsaugapparate, Länggassstrasse 12 [26.354]
 Pürro, Christoph, Hilfsarbeiter, Burgunderstrasse 57, Bümpliz
 Pyros A.-G., Fabrikation von Zündstäbchen, Laupenstrasse 5
@@ -35794,7 +35738,7 @@ Quartier-Aufseher, s. Abtlg. II, pag. 53 u. 54.
 Quelos, Leon Viktor, Notar, Cäcilienstr. 46
 Queloz, Andre H. V., Kantonspolizist, Jägerweg 5
 – M. O., Fensterreiniger, Brunngasshalde 63
-Quenzer, Hedwig, Ladentochter. Genferg. 8
+Quenzer, Hedwig, Ladentochter, Genferg. 8
 – Heinrich (Wymann), Schneider, Genfergasse 8
 Querchfeld, Hugo E., Musiklehrer, Tiefenaustrasse 32 [34.191]
 de Quervain, Fr., Dr. med., Prof., Direktord. chirurgischen Poliklinik am Inselspital [65.331], Kirchenfeldstrasse 60 [22.443]
@@ -35825,7 +35769,7 @@ Bezirkes, Moserstrasse 11 [20.454]
 – Werner, Dr. med., Spezialarzt für Gynäkologie u. Geburtshilfe (Bolligen), Hirschengraben 10 [27.018]
 Raas, Emil, Fürsprecher, Balmweg 7 [32.980]
 – Joh., Steinhauer, Gerbergasse 7a
-– Samuel, Tuch- und Bettwarenhdlg.. Balmweg 7 [32.980]
+– Samuel, Tuch- und Bettwarenhdlg., Balmweg 7 [32.980]
 Rabaini, Battista, Hutmacher, Standstr. 31
 Rabatt-Sparverein Bern (u. Berner Haushaltungsblatt), Spitalgasse 30, Eingang Ryffligässchen [21.388]
 Räber, s. auch Reber
@@ -35860,7 +35804,7 @@ Racheter, Alfr., Handlanger, Jurastrasse 38
 – Walter, Maler, Belpstrasse 47
 Rachlin, Sal., Reklameakquisiteur, Gerechtigkeitsgasse 57
 Racine, Alb. P., Hilfsarbeiter, Neubrückstr. 81
-– R. A., Bankangestellter. Optingenstr. 29
+– R. A., Bankangestellter, Optingenstr. 29
 – Rene Arthur, Maschinentechniker, Bernstrasse 88, Bümpliz
 – Ruth Bertha, Bureaulistin, Monbijoustr. 95
 Rade, Fr. Chs., Handlanger, Steinhölzliw. 41
@@ -35888,7 +35832,7 @@ Raggenbass, Gertrud Olga, Bureaugehilfin d. S. B. B., Hallerstrasse 56
 – Paul, Telegraphenbeamter, Heimstrasse 19, Bümpliz [46.108]
 Raghib, Talaat Moh., ägypt. Attache, Viktoria-Strasse 63 [35.799]
 Ragonesi, Aldo, Maurer, Wachtelweg 17
-Ragula, Jos.. Hausierer. Altenbergstrasse 8a
+Ragula, Jos., Hausierer. Altenbergstrasse 8a
 Rahm, Ernst, kaufm. Angest., Monbijoustr. 92
 – Hermann, Zollaufseher, Felshaldenweg 10
 – Joh. Jak. (Schärer), Postbureauchef, Fischerweg 4
@@ -35901,7 +35845,7 @@ Rahm, Christ. Jak., Schuhmacher, Ulmenw. 5
 – Jak. W., Hilfsarbeiter, Ulmenweg 5
 Rainer, Anna, Schneiderin, Mühlenplatz 2
 Rais, Marc. Franc., Inspektor der kant. Justizdirektion, Beundenfeldstrasse 14
-Raissig, E. (Bircher), Metzgerei, Bümplizstrasse 167 . [46.002]
+Raissig, E. (Bircher), Metzgerei, Bümplizstrasse 167 [46.002]
 – Walter, Fürsprecher, Bümplizstrasse 167 [46.002]
 Ramelef, Anna Bertha Chr. (Kündig), Wwe., Waldhöheweg 15 [21.629]
 Ramer, Ad Georg. Reproduktions-Techniker, Wildermettweg 27
@@ -35945,7 +35889,7 @@ Ramseier, s. auch Ramseyer
 # Date: 1935-12-15 Page: 26020689/382
 Ramseier, s. auch Ramseyer
 – Joh., Handlanger, Turnweg 23
-– Joh.. Miichtrager, Zähringerstrasse 51
+– Joh., Miichtrager, Zähringerstrasse 51
 – Joh. W., Chauffeur, Weyermannsstr. 24a
 – Johanna, Ladentochter, Rohrweg 8
 – Margr., Modiste, Viktoriarain 21
@@ -35966,7 +35910,7 @@ Ramseyer, s auch Ramseier
 – Albert, Bahnangestellter, Viktoriarain 11
 – Albert, Baumeister, Ensingerstrasse 38 [35.664]
 – Alex., Handlanger. Studerstrasse 50
-– Alf.. Handlanger, Seidenweg 20
+– Alf., Handlanger, Seidenweg 20
 – Alfred’s Wwe., A.-G., Maschinen u. Furnituren f. d. graph. Industrie, Erlachstr. 16b [29.848]
 – Anna, Angestellte. Viktoriarain 21
 – Bertha Rosa, Ladentochter, Maulbeerstrasse 14
@@ -35980,7 +35924,7 @@ Ramseyer, s auch Ramseier
 – Elise, Verkäuferin, Rohrweg 8
 – Emil, Tramangest., Karl-Staufferstr. 20 [28.618]
 – Emilie (Lauber), Damensalon, Spitalackerstrasse 70
-– Emma Frieda, Ladentochter. Sennweg 3
+– Emma Frieda, Ladentochter, Sennweg 3
 – Ernst Otto, Chefpatissier, Freiburgstr. 344, Bümpliz
 – Ernst, Hilfsarbeiter, Weyermannsstr. 24a
 – Ernst, kaufm. Angest., Karl-Schenkstr. 3 [26.058]
@@ -35992,8 +35936,7 @@ Ernst, pens. Lok.-Führer, Siedlungsweg 3
 Ramseyer, s. auch Ramseier
 – Erwin Ernst, Dr. jur, Fürsprecher (Thormannstrasse 59 [23.394]), Schauplatzg 35 [21.864]
 – Eugen Jakob John, eidg. Beamter, Länggassstrasse 83
-– Ferd., in Fa. Ferd. Ramseyer & Söhne
-A.-G., Parkstrasse 9 [22.877]
+– Ferd., in Fa. Ferd. Ramseyer & Söhne A.-G., Parkstrasse 9 [22.877]
 – Ferd., & Söhne, Akt.-Ges., Hoch- u. Tiefbau, Parkstrasse 9 [22.877]
 – Ferd., & Co., Verwaltung von Liegenschaften, Parkstrasse 9 [22.877]
 – Frieda, Frau, Waisenhausplatz 27 [32.508]
@@ -36003,12 +35946,12 @@ A.-G., Parkstrasse 9 [22.877]
 – Gottfr., Hilfsarbeiter, Marzilistrasse 28
 – Gottfr., Milchwäger, Bottigenstrasse 380, Riedbach
 – Gottfr., Schreinermeister, Ulmenweg (5) 10 [27.897]
-– Gottfr.. Trambilletteur. Murifeldweg 81
-– Gust. .Ad., Ingenieur, Chutzenstrasse 41
-– Heinr Rob.. Schneider. Spitalackerstr. 70
+– Gottfr., Trambilletteur. Murifeldweg 81
+– Gust. Ad., Ingenieur, Chutzenstrasse 41
+– Heinr Rob., Schneider. Spitalackerstr. 70
 – Joh., Hilfsarbeiter, Jurastrasse 59
 – Joh. Unternehmer. Spenglerei, Installationen. Rodtmattstrasse 102 [32.481]
-– Jules Arn H.. Kaufmann. Tscharnerstr 37
+– Jules Arn H., Kaufmann. Tscharnerstr 37
 – K. Otto, Sanitäre Anlagen, Bauspenglerei (Wyttenbachstr. 18 [36.091]), Hofweg 5
 – Karl Aug. Automaler. Jägerweg 2
 – Karl, Spenglerei u. Installation, Ulmenweg 15 [22 740]
@@ -36022,11 +35965,11 @@ A.-G., Parkstrasse 9 [22.877]
 – Martha, Verkäuferin, Zieglerstrasse 45
 – Martha. Verkäuferin, Stockerenweg 32
 – Mina, Schneiderin, Neufeldstrasse 27f
-– Otto Wilhelm. Fabrikarbeiter. Seidenw. 20
+– Otto Wilhelm. Fabrikarbeiter, Seidenw. 20
 – Paul, Hilfsarbeiter, Sulgenbachstrasse 14
 – Rosa, Angestellte, Freiburgstr. 344, Bümpliz
 – Rosa, Reisende. Metzgergasse 46
-– Rosette (Jost), Wwe.. Liebeggweg 12b [33.821]
+– Rosette (Jost), Wwe., Liebeggweg 12b [33.821]
 – Rudolf, in Fa. Ramseyer Söhne A.-G., Ensingerstrasse 32 [20.761]
 – Samuel Gasarbeiter, Sandrainstrasse 7
 – Siegfried, Hilfsarbeiter, Morgenstrasse 79, Bümpliz
@@ -36051,9 +35994,10 @@ Rapoport. Ged. G., Kaufm. Schwarzenburgstrasse 2
 – Marie (Wischniak), Wwe., Marktkrämerin. Schwarzenburgstrasse 2
 – Michael, Marktkrämer, Schwarzenburgstr. 2
 – Rebekka, Bureaulistin. Schwarzenburgstr. 2
-Rapp. Karl, Angestellter. Morillonstrasse 6
+Rapp. Karl, Angestellter, Morillonstrasse 6
 – Moritz, Abwart der Knabensekundarschule Weissenstein, Munzingerstrasse 11
-— Walter, Güterarbeiter d. S. B. B., Viktoriarain 21van Rappard, Carel, niederländischer Gesandter, Sulgenbachstrasse 5 [31.695]
+— Walter, Güterarbeiter d. S. B. B., Viktoriarain 21
+van Rappard, Carel, niederländischer Gesandter, Sulgenbachstrasse 5 [31.695]
 Rappo, Cacilia. Postgehilfin, Seidenweg 4
 – Joh. Felix, Schneider, Optingenstrasse 35
 – Josephine, Telephonistin, Seidenweg 4
@@ -36065,7 +36009,7 @@ Rasmussen, Anna (Liechti), Wwe., Spitalackerstrasse 63 [32.8761
 – Gerda Anna, Spitalackerstrasse 63
 – Steen Emil (Christiensen), Missionssekretär. Muristrasse 65
 Räss, Alfred, Drechsler, Gruberstrasse 14
-– Friedr.. Mechaniker, Obstbergweg 12
+– Friedr., Mechaniker, Obstbergweg 12
 – Gottfr., gew. Materialverwalter der Lehrwerkst. d. Stadt Bern, Neubrückstrasse 75
 – Hans, Kaufmann. Brückfeldstrasse 38
 – Jakob, eidg. Beamter, Bantigerstrasse 28
@@ -36095,12 +36039,12 @@ Ratz, s. auch Räz
 – J. Rud., Verwalter, Muristr. 75 [36.058]
 – Joh., Maurer, Fischerweg 20
 – Joh Gottfr., jun., Möbelschreiner, Depotstrasse 46
-– Johann G.. Schreiner, Depotstrasse 46
+– Johann G., Schreiner, Depotstrasse 46
 – Karl, Maurer. Moserstrasse 10
 – Klara Damenschneiderin, Kramgasse 9
 – Magdalena (Moser), Wwe., Nydecklaube 9
 – Marie (Dellsperger), Wwe., Gerechtigkeitsgasse 30
-– Rud.. Münzarbeiter, Bantigerstrasse 29
+– Rud., Münzarbeiter, Bantigerstrasse 29
 – Rud., Schreiner. Schwarztorstrasse 95
 – Walter, Maurer, Moserstrasse 10
 Rätzer, Maria Ida, gew. Arbeitslehrerin, Bubenbergplatz 4
@@ -36109,7 +36053,7 @@ Rätzer, Maria Ida, gew. Arbeitslehrerin, Bubenbergplatz 4
 Rau, Rosina, Frau, Fabrikarbeiterin, Tunnelweg 11
 Räuber, Charles Arth., Bankangest., Brunnhofweg 4
 – Fritz, Beamter, Sennweg 5 [25.816]
-– Gertrud Lina, Ladentochter. Brunnhofw. 4
+– Gertrud Lina, Ladentochter, Brunnhofw. 4
 – J. G., Angestellter, Brunnhofweg 4
 – Otto, Postangestellter, Stalden 18
 Räuber, Emma (Sandoz), Wwe., Jubiläumsstrasse 9
@@ -36189,27 +36133,27 @@ Reber, s. auch Räber
 – Bertha, Fabrikarbeiterin,’ Bremgartenstr. 73
 – C. M., Kaufmann, Kapellenstr. 12 [21.636]
 – Chr., Spezereihdlg., Bottigenstr. 398, Riedbach
-– Christ.. Landwirt, Riedernstr. 40a. Bümpliz
+– Christ., Landwirt, Riedernstr. 40a. Bümpliz
 – Ed., Installateur, Bremgartenstrasse 73
 – El. (Lüthi), Wwe., Privatiere, Bäreng. 12, Bümpliz
 – Elsa M., Damenschneiderin, Morellweg 5
 – Emil, Liftkontrolleur, Belpstrasse 18
 – Ernst, Beamter S. B. B., Martiweg 24
-– Ernst. Direktor der Publicitas A.-G.. Monbijoustrasse 51 [28.819]
+– Ernst. Direktor der Publicitas A.-G., Monbijoustrasse 51 [28.819]
 – Ernst, Hilfsarbeiter, Freiburgstrasse 111
 – Ernst, Hilfsarbeiter, Wattenwylweg 21
 – Ernst F., Küfer, Depotstrasse 44
 – Ernst, Landwirt. Riedernstr. 40a, Bümpliz
 – Ernst, Masch.-Schlosser, Tiefenaustrasse 38
 – Ernst, Scbreinermstr. in Fa. H. & E. Reber, Bernstrasse 98. Bümpliz [46.277]
-– Friedr.. Postangestellter, Aebistrasse 17
+– Friedr., Postangestellter, Aebistrasse 17
 – Franz. Abwart. Bümplizstrasse 152
 – Franz Arnold, Gärtner, Federweg 31
 – Friedr., Angestellter, Gutenbergstrasse 31
-– Friedr., Bahnarbeiter. Kehrg 49. Bümpliz
-– Friedr.. kaufm. Angestellter, Tavelweg 8
+– Friedr., Bahnarbeiter, Kehrg 49. Bümpliz
+– Friedr., kaufm. Angestellter, Tavelweg 8
 – Friedr., Mechaniker, Bümplizstrasse 60a
-– Friedr.. Spengler. Federweg 29e
+– Friedr., Spengler. Federweg 29e
 – Fritz, Gärtner, Boiligenstrasse 117
 – Fritz, Gross- u. Schweinemetzgerei. Bümplizstrasse 108 [46.026]
 – G., Wagnermeister, Schwarztorstrasse 83 [34.220]
@@ -36222,7 +36166,7 @@ Reber, s. auch Räber
 – Hans, Spengler. Bremgartenstrasse 73
 – Herm., Bauschlosser, Tiefenaustrasse 38
 – Joh., Handlanger, Tiefenaustrasse 38
-– Joh., Hilfsarbeiter. Güterstrasse 8
+– Joh., Hilfsarbeiter, Güterstrasse 8
 – Joh. Gottfr., Portier, Metzgergasse 72
 – Johanna, Telegraphengehilfin, Brückenstrasse 23
 # Date: 1935-12-15 Page: 26020692/385
@@ -36253,7 +36197,7 @@ Reber, s. auch Räber
 – Rud., Typograph, Dorngasse 4
 – Samuel, amerik. Legationssekretär, Bernastrasse 4
 – Samuel, Hilfsarbeiter, Balmweg 32
-– Theresia, Ladentochter. Tiefmattstrasse 10
+– Theresia, Ladentochter, Tiefmattstrasse 10
 – Ulrich Peter W., Angest., Kalcheggweg 10
 – Walter, Ausläufer. Güterstrasse 8
 – Walter, Buchbinder, Konsumstrasse 11
@@ -36283,19 +36227,19 @@ Rechsteiner, Fritz, Beamter O. Z. D., Effingerstrasse 97
 – Rudolf, Beamter S. S. B., Länggassstr. 75 [27.679]
 Rechtsauskunftstelle für Kinder- u. Frauenschutz, Leiter: Dr. Zehnder, Fürsprecher, Marktgasse 17 [34.666]
 Reck, Aug., mechan. Werkstätte, Brunnmattstrasse 55 [23.976]
-– Eug. Arth.. Schriftsetzer, Viktoriarain 11
+– Eug. Arth., Schriftsetzer, Viktoriarain 11
 – Fritz Aug., Handel mit Radio-Apparaten, Brunnmattstrasse 55 [23.976]
 – Jakob, Maschinenmeister, Aebistrasse 19
-Recordon, Chs. Ad.. Vertreter, Bundesrain 16
+Recordon, Chs. Ad., Vertreter, Bundesrain 16
 Redard, Arth., Kanzleichef b. d. internat. Bureaux f. gewerbl., literar. u. künstl. Eigentum. Speichergasse 8
 – F. Albert, Sekretär-Adjunkt des Verbandes Schweiz. Post-, Telephon- u. Telegr.-Angestellter, Rohrweg 33 [45.423]
 Reding, AL, Dr., Ing., pens. Chef d. techn. Abt.d. O. T. D., Wyttenbachstrasse 2 [28.562]
 – Aloys (de Haan), Inspektor der Generaldirektion P. T. T., Zähringerstrasse 26 [25.241]
 – Anna, Gesanglehrerin, Wyttenbachstr. 2 [28.562]
-v. Reding, Alois (Biberegg), Dr. jur., Beamter. Bundesgasse 6 [35.819]
+v. Reding, Alois (Biberegg), Dr. jur., Beamter, Bundesgasse 6 [35.819]
 – Alois, Elektrotechniker der O. P. D., Zähringerstrasse 26
 – Rud. (Biberegg), Dr. jur., Sekr. d. Rundfunkgesellschaft, Alpenstrasse 19 [29.329]
-Reed; Jeanne (Hitz), Ladentochter. Militärstrasse 26
+Reed; Jeanne (Hitz), Ladentochter, Militärstrasse 26
 Regenass, Alice Marie, Bankangest., Güterstrasse 32
 – Emilie Olga, Bureaulistin, Kollerweg 7
 – Hilda Luise, Schneiderin, Schwarzenburgstrasse 36
@@ -36326,7 +36270,7 @@ Reichardt, Alb Karl, Geschäftsführer, Altenbergstrasse 53
 Reichen. Alb., Schlosser, Metzgergasse 20
 – Alice Ida. Bärenplatz 9
 – Ernst. Maler. Ladenwandstrasse 84
-– Ferd.. Kohlenarbeiter, Ladenwandstr. 88
+– Ferd., Kohlenarbeiter, Ladenwandstr. 88
 – Geschwister, Privatpension, Schanzenbergstrasse 32 [31.184]
 – Hanna Frieda, Weissnäherin, Krippenstrasse 24
 – Hans. Mechaniker, Thunstrasse 5
@@ -36335,10 +36279,10 @@ Reichen. Alb., Schlosser, Metzgergasse 20
 – Joh., Kaminfeger, Mattenhofstrasse 25
 – Lucie, Frau, Spezereihandlung, Seidenweg 52 [31.075]
 – Samuel. Schneider, Freiburgstrasse 63
-– Walter. Ausläufer, Krippenstrasse 24
+– Walter, Ausläufer, Krippenstrasse 24
 Reichenbach, Frieda, Ladentochter, Kasernenstrasse 34
 – Georg Adolf, Handlanger, Brünnenstr. 76, Bümpliz
-– Math Jos.. Optiker, Murifeldweg 83
+– Math Jos., Optiker, Murifeldweg 83
 – Phil., Schuhmachermeister, Jurastr. 58
 – Reinhold, Missionsarbeiter, Allmendstr. 39
 Reichenwallner, Stephan, Buchbinder. Scheibenstrasse 22a
@@ -36350,11 +36294,11 @@ Reimann, Emil. Maschinenschlosser, Wiesenstrasse 34
 – G. H., Kartograph d. Landestopographie, Heinrich-Wildstrasse 2 [27.266]
 – Herm., gew. Kaufmann, Wyttenbachstr. 8 [32.605]
 – Joh. (Milcher), Vertreter, Seidenweg 2
-– Josef R. (Prim), Dr.. eidg. Beamter, Wabernstrasse 16
+– Josef R. (Prim), Dr., eidg. Beamter, Wabernstrasse 16
 – Karl, Architekt, Moserstrasse 20, ab 1. Mai
 1936: Greyerzstrasse 50
 – Paul, Tapezierer, Wiesenstrasse 34
-– Walter. Dreher, Wiesenstrasse 34
+– Walter, Dreher, Wiesenstrasse 34
 Reimers, Adele Rosa, Bureaulistin. Murifeldweg 33
 Rein, Aline, Modistin, Cäcilienstrasse 27
 – Bertha (Iseli), Spezereihandlung, Cäcilienstrasse 27
@@ -36368,13 +36312,13 @@ Reinert, Charles (Howald), Effingerstr. 101
 – Paul K., Dr., akadem Seelsorger (Sulgeneckstrasse 7), Wallgasse 2 [21.776]
 Reinfried, Karolina. Frau. Bundesgasse 36
 Reinhard, s. auch Reinhardt
-– Albi. Leonh., Retoucheur. Cäcilienstr.27 .
+– Albi. Leonh., Retoucheur. Cäcilienstr. 27
 – Alice, Zeughausgasse 26
 – —Alice, Hilfsarbeiterin, Breitfeldstrasse 63
 – Charlotte Alice, Bureaulistin, Ensingerstrasse 30
 – Chr., Postangestellter, Länggassstrasse 38
 – E. (Käsermann), Notar, städt Wertschriftenverwalter, Greyerzstrasse 24 [31.579]
-– El., Gemeindeschwester. Finkenrain 5
+– El., Gemeindeschwester, Finkenrain 5
 – Elise, Strickerin, Kramgasse 50
 – Elsa Marg., Philatelistin, Helvetiastr. 19
 – Emil, Buchbinder, Breitfeldstrasse 63
@@ -36391,11 +36335,11 @@ Reinhard, s. auch Reinhardt
 – Friedr., Lackierer, Bremsartenstrasse 39
 – Fritz, Materialverwalter der städt. L. W., Neufeldstrasse 129
 – Fritz, Lehrer, Brünnenstr. 4, Bümpliz
-– Fritz. Metallbilfsarbeiter. YVylerfeldstr. 78
+– Fritz. Metallbilfsarbeiter, YVylerfeldstr. 78
 – Gertrud, Glätterin, Flurstrasse 38
 – Gottfr., Einleger. Weberstrasse 12
-– Gottfr., Hilfsarbeiter. Aarstrasse 76
-– Gottfr.. Kommis, Postgasse 46
+– Gottfr., Hilfsarbeiter, Aarstrasse 76
+– Gottfr., Kommis, Postgasse 46
 – Gottfr., Briefträger. Bundesrain 14
 – Gottfr., Schriftsetzer. Berchtoldstrasse 27
 – Hedwig Gertrud. Npuengasse 26
@@ -36416,7 +36360,7 @@ Reinhard, s. auch Reinhardt
 – Joh., Schreiner Gerechtigkeitsgasse 42
 – Joh. Jak., Vertreter, Frohbergweg 9
 – Karl Alfred, Güterarbeiter, Sägehofweg 3, Bümpliz
-– K Fr.. Schreiner, Breitfeldstrasse 63
+– K Fr., Schreiner, Breitfeldstrasse 63
 # Date: 1935-12-15 Page: 26020694/387
 Reinhard, s. auch Reinhardt
 – Lina (Fischer), Wwe., Holzikofenweg 5
@@ -36458,7 +36402,7 @@ Reinmann, Fritz, Angestellter, Karl-Staufferstrasse 30
 Reisch, Wilhelmine, Damenschneiderin, «Maison Ada», Schwanengasse 4 [34.687]
 Reisinger, Jean (Ruppe), kaufm. Angestellter, Laubecktstrasse 59 [34.236]
 – Lina (Werren), Wwe., Monbijoustr. 19 [22.819]
-Reiss, Jul., Dr. med. dent.. Zahnarzt (Bollwerk 33 [22.819]), Bubenbergplatz 9 [20.965]
+Reiss, Jul., Dr. med. dent., Zahnarzt (Bollwerk 33 [22.819]), Bubenbergplatz 9 [20.965]
 – Martha (Schmidt), Wwe., Viktoriastr. 41 [25.841]
 – Max, A.-G., Abzahlungsgesch., Bollwerk 23
 Reisse, E. J., Kaufmann. Viktoriastrasse 69 [22.573]
@@ -36485,7 +36429,7 @@ Krankheiten, Seilerstrasse 3 [23 456]
 Reitinger, Th., Maschinist b. Kasino, Kramgasse 46 [33.381]
 Reitschule Bern (Peter & Mory), Neubrückstrasse 8 [21.886]
 Rektorat der Universität, Hochschulstrasse 4 [21.723]
-Rekurskommission, kant., Rathausplatz .2 [24.343]), Inspektorat, Postg 68 [23 781]
+Rekurskommission, kant., Rathausplatz 2 [24.343]), Inspektorat, Postg 68 [23 781]
 Relief-Druck A.-G., Relief-Druckerei, Effingerstrasse 39 [36.485]
 Reilstab, Alb., Angest. d. E. W. B., Länggassstrasse 82
 – Carolina (Ermatinger), Mittelstrasse 19
@@ -36498,15 +36442,15 @@ Remington-Schreibmaschine, Anton Waltisbühl & Co., Filiale Bern, Kornhauspl. 14
 Remmele, Emil Alfr., Postangest., Balmweg 11
 – Max, Bautechniker, Balmweg 11
 – Otto, rrech Werkstätte, Freiburgstrasse 48 [36.561]
-– Paul Arth.. Bankangest., Weissensteinstrasse 106
+– Paul Arth., Bankangest., Weissensteinstrasse 106
 – Wilh. Ed., Mechaniker, Holligenstrasse 34
-Remund, Ad.. Zugführer S. B. B., Waldheimstrasse 10b
+Remund, Ad., Zugführer S. B. B., Waldheimstrasse 10b
 – Albr., Landwirt, Buchweg 4, RiecLbach
 – Cecile, Laborantin, Falkenplatz 16
 – Chr., Sackflickerei, Tiefenaustrasse 91 [36.862]
 – Christ., Schmied, Murtenstrasse 42
-– Emil Alfr.. Hilfsarbeiter, Murtenstrasse 42
-– Emma M.. Hilfsarbeiterin. Murtenstr. 42
+– Emil Alfr., Hilfsarbeiter, Murtenstrasse 42
+– Emma M., Hilfsarbeiterin. Murtenstr. 42
 – Franz, Milchhandlung, Kasernenstrasse 41 [28.808]
 # Date: 1935-12-15 Page: 26020695/388
 Remund, Franz, Spengler, Brunnmattstr. 46
@@ -36521,7 +36465,7 @@ Remund, Franz, Spengler, Brunnmattstr. 46
 — Karl, Techniker, Brünigweg 29 [45.193]
 – Otto, Schlosser, Freiburgstrasse 52
 – Rud., Zimmermann, Oberbottigenweg 20, Oberbottigen
-– Rud., jun., Zimmermeister. Oberbottigenweg 20, Oberbottigen
+– Rud., jun., Zimmermeister, Oberbottigenweg 20, Oberbottigen
 – Walter, kaufm. Angest., Tiefenaustr. 91
 Remy, Bernhard, Bäckermeister, Muesmattstrasse 41 [28.024]
 — Emil, Hilfsarbeiter, Sulgeneckstrasse 62
@@ -36530,7 +36474,7 @@ Remy, Bernhard, Bäckermeister, Muesmattstrasse 41 [28.024]
 Renan, Adr., Schneider, Kramgasse 38
 Renaud, A., Distelweg 9 [21.961]
 – Charles, Topograph, Thunstr. 43a [20.893]
-– Georges, Telegraphist, Muldenstrasse 1i—Hermann, Versich.-Beamter. Gesellschaftsstrasse 19d [24.472]
+– Georges, Telegraphist, Muldenstrasse 1i—Hermann, Versich.-Beamter, Gesellschaftsstrasse 19d [24.472]
 — Klara, Teeroom Astoria, Genfergasse 5 [20.977]
 Marc A. (Mancini), Abwart-Elektriker b.eidg. Gesundheitsamt, Wyttenbachstr. 33
 5 — Marg. Emilie, Bureaulistin. Thunstr. 43a
@@ -36618,7 +36562,7 @@ Rettenmund, Alfred, Notariatsbureau (Falkenhöheweg 2), Aarbergergasse 46 [29.97
 Rettungsanstalt Brunnadern (verbunden mit
 Wäscherei), Elfenauweg 16 [32.554]
 Rettig, Louis Kurt (Jäggle), Musiker, Liebeggweg 12b
-Reubi, Bertha. Krankenschwester, Gryphenhübeliweg 55
+Reubi, Bertha, Krankenschwester, Gryphenhübeliweg 55
 – Jak. Ed., Handlanger, Freieckweg 11, Bümpliz
 – Jak. Ed., Sohn, Schmied, Freieckweg 11, Bümpliz
 – Rob. Alfr., Bautechn., Seilerstrasse 22 [28.593]
@@ -36648,7 +36592,7 @@ Reusser, Ida Hedwig, Damenschneiderin, Münzrain 1 [35.798]
 – Joh., Kondukteur S. B. B., Römerweg 22
 – Joh., pens. Lok.-Führer d. B. L. S., Aehrenweg 15. Bümpliz
 – Joh., Kontrolleur W.-F., Birkenweg 40
-– Joh. Alb.. Schlosser, Aehrenw. 15, Bümpliz
+– Joh. Alb., Schlosser, Aehrenw. 15, Bümpliz
 – Johanna Emma, Coiffeuse, Veilchenweg 4, Bümpliz
 – Karl, Buchhalter der Depositokasse, Spitalackerstrasse 15
 – Lina Luise, Modiste, Höheweg 13
@@ -36659,11 +36603,11 @@ Reusser, Ida Hedwig, Damenschneiderin, Münzrain 1 [35.798]
 – Paul Arn., Schriftsetzer. Greyerzstr. 30
 – Rudolf, Webermeister, Aarbergergasse 29
 – S., Fürsprecher. Kammerschreiber b. Obergericht. Tscharnerstrasse 12 [29.002]
-– Walter. Bureauli«t. Römerweg 22
+– Walter, Bureauli«t. Römerweg 22
 – Walter Rud., Schlosser, Wylerfeldstr. 41
 – W., Dachdeckermstr. (Spiegel am Gurten), Elisabethenstrasse 17 [34.551]
 Reust, Ernst, Metzger, Breitenrainstrasse 21
-Reuteler, Joh.. Karrer. Nydeckhof 31
+Reuteler, Joh., Karrer. Nydeckhof 31
 – Werner, Sek.-Lehrer, Gotthardweg 23 [45.061]
 Reuter und Reuther
 – Friedr., Pflästerer, Distelweg 5
@@ -36674,7 +36618,7 @@ Reuter und Reuther
 – Louis, Postbeamter, Beaulieustrasse 17
 – Rosina, Wwe., Freiburgstrasse 119
 – Werner, Vertretungen f. d. graph. Gewerbe, Genfergasse 5 [20.977]
-– & Co.. A., Strassenbau-Beläge u. Handel in Strassenbaumaterialien, Bümplizstr. 192h (Station Bümpliz-Süd) [46.561]
+– & Co., A., Strassenbau-Beläge u. Handel in Strassenbaumaterialien, Bümplizstr. 192h (Station Bümpliz-Süd) [46.561]
 Reutlinger, Dora Erika, Bureaulistin, Zieglerstrasse 35
 – Heinrich, Kaufmann, Monbijoustrasse 17
 – Maria Anna (Wirth), Schwarztorstr. 30
@@ -36707,7 +36651,7 @@ Rezzonico, Gerardo, Postkommis, Vennerw, 4
 – Giuseppe, Maurer, Länggassstrasse 44
 – Ulisse Ant., Beamter S. B. B., Hallerstr. 53de Rham, Jean, eidg. Beamter, Jubiläumsstrasse 77 [26.394]
 Rhyn, Ad. Max, Postchauffeur, Gewerbestr. 22
-– D., Buchbinderei, Vergoldeanstalt u Einrahmungsgesch.. Mattenhofstr 10 [21.754]
+– D., Buchbinderei, Vergoldeanstalt u Einrahmungsgesch., Mattenhofstr 10 [21.754]
 – Hans, Postangestellter, Lentulusrain 24
 – Hs., Dr., Gymn.-Lehrer. Sonnenbergrain 39
 – Herm., jun., Buchbinder. Lentulusrain 24
@@ -36727,15 +36671,15 @@ Riard, Alice Amanda, Bureaulistin, Effingerstrasse 99
 Riat, Paul Josef, Prokurist d. L. v. Roll’schen Eisenwerke, Giesserei Bern, Seilerstr 25 [27.879]
 de Ribaupierre, Suzanne L. (Daumont), Wwe., Kursaalstrasse 6 [35.429]
 Ribi, s. auch Hybi
-– Alfr. W.. Bankbeamter, Waisenhauspl. 25 [34.5951
+– Alfr. W., Bankbeamter, Waisenhauspl. 25 [34.5951
 – Chs., eidg. Beamter, Weststr. 19 [25.081]
 – Emma, Bankangestellte, Donnerbühlweg 10 [32.815]
 – Margr. Bertha, Ladentochter, Weststr. 19
 Ribinski, Emil Wilh., Schlosser, Gerberg. 5
 Ribolzi, Pietro, Postkommis, Gesellschaftsstrasse 86
 Rieh, Josef. Prokurist d. Schweiz. Nationalbank, Hauensteinweg 23
-Richard, A. H , Gärtnermstr.. Weihergasse 4 [34.899], Epicerie, Früchte- und Gemüsehandlung, Käfiggässchen 10 [20.946]
-– A. L., Beamter S. B B.. Brückfeldstr. 35
+Richard, A. H , Gärtnermstr., Weihergasse 4 [34.899], Epicerie, Früchte- und Gemüsehandlung, Käfiggässchen 10 [20.946]
+– A. L., Beamter S. B B., Brückfeldstr. 35
 Richard, Arnold, Bankprokurist, Beundenfeldstrasse 2
 – Charles Ingenieur, Ensingerstrasse lßa
 – E. (Hänni), Wwe., Effingerstrasse 55
@@ -36743,12 +36687,12 @@ Richard, Arnold, Bankprokurist, Beundenfeldstrasse 2
 – Emma (Walser), Wwe., Muristrasse 20 [27.477]
 – Ernest. CaiA-Restaurant u. Grill-Room z. Käfigturm [29004]
 – Fernand, pens. eidg. Beamter, Belpstr 65 [29 9441
-– Fernand A.. kaufm. Angest., Brückfeldstrasse 35
-– Fritz. Metzgermstr.. in Fa. Gebr. Richard, Zwiebelngässchen 14
+– Fernand A., kaufm. Angest., Brückfeldstrasse 35
+– Fritz. Metzgermstr., in Fa. Gebr. Richard, Zwiebelngässchen 14
 – Fritz. Polizeikorporal, Brunnadernstr 106 [20.510]
-Gottfr . gew. Müllermeister. Wernerstr 12 [32.978]
+— Gottfr., gew. Müllermeister, Wernerstr 12 [32.978]
 – Gottl. (Schweizer), Tavelweg 35 [36.435]
-– Gottl., Telephonarbeiter. Muesmattstr 38
+– Gottl., Telephonarbeiter, Muesmattstr 38
 – Hans. Wirt, Zeughausgasse 25 [23.751]
 – Hedwig Marg., Ladentochter, Zwiebelngässchen 14
 – Irma, Sekretärin der Vereinigung weiblicher Geschäftsangestellter der Stadt Bern (Mittelstrasse 44 [34.724]). Zeughausg 31 [21.241]
@@ -36757,11 +36701,11 @@ Gottfr . gew. Müllermeister. Wernerstr 12 [32.978]
 – Luise (Schertenleib). Wwe., Mittelstr 44 [34.724]
 – Marg., Damenschneiderin, Gerechtigkeitsgasse 7S
 – Marie Bertha, Laborantin, Gutenbergstr. 5
-– Max. Metzgermstr.. in Fa. Gebr Richard, Zwiebelngässrhen 14
+– Max. Metzgermstr., in Fa. Gebr Richard, Zwiebelngässrhen 14
 – Paul. Bankangestellter, Chutzenstrasse 41
-– Paul Karl, Bankangestellter. Mittelstr. 44
+– Paul Karl, Bankangestellter, Mittelstr. 44
 – R. Chs. Fred., Musiker, Belpstrasse 65
-– Walter Eug.. kaufm. Angest., Wernerstr. 12
+– Walter Eug., kaufm. Angest., Wernerstr. 12
 – W Theophil (Feldmann). Pfarrer am Diakonissenhaus, Nydeckgasse 13 [28.0881
 – Willy Edwin, Kommis, Liebeggweg 8
 – Gebr Metzgerei u Wursterei. Zwiebelngässchen 14 [27.092], Filiale: Monbijoustrasse 67 [29.003]
@@ -36774,9 +36718,9 @@ Richiger, Marie, Pension, Bierhübeliweg 33
 – Martha, Ladentochter, Tavelweg 2
 Richli, Albertine (Huber), Wwe., Haller– Franz, Beamter S. B. B., Berchtoldstr. 58
 – Friedr., Kommis, Elisabethenstrasse 39
-– Jakob. Beamter S B B.. Viktoriarain 2
+– Jakob. Beamter S B B., Viktoriarain 2
 – Maria R. (Bischoff), Wwe., Schwarztorstrasse 21
-– Max Jak.. Elektromonteur, Viktoriarain 12
+– Max Jak., Elektromonteur, Viktoriarain 12
 # Date: 1935-12-15 Page: 26020698/391
 Richner und Richener, s. auch Rychener und Rychner
 – Ad., Gross- u. Schweinemetzgerei, Aarhergergasse 3 f21.1671. Monbijoustrasse 26 [28.380] u. Länggassstrasse 36 [31.916]
@@ -36792,7 +36736,7 @@ Richner und Richener, s. auch Rychener und Rychner
 – Frieda, Postgehilfin, Tscharnerstrasse 41
 – Gottfr., Sattler, Monbijoustrasse 99
 – Gottl., Mechaniker, Gewerbestrasse 31
-– Hans, kaufm. Angestellter. Tscharnerstrasse 41
+– Hans, kaufm. Angestellter, Tscharnerstrasse 41
 – Hedwig, Coiffeuse, Schöneggweg 28
 – Hedwig, Tapeziererin, Tscharnerstrasse 41
 – Herm. Otto, Garagechef, Sägehofweg 18, Bümpliz
@@ -36811,7 +36755,7 @@ Richters, Bernh., Schreiner, Tillierstrasse 22
 – Fr. Ad., Heizer, Hochfeldstrasse 47
 – Paul Hans, Bäckermeister, Brunnmattstrasse 69 [36.457]
 Ricken, Frieda (Müller), Sulgenauweg 32 [33.645]
-Rickenbach, Jakob, Pferdewärter. Breitenrainplatz 27
+Rickenbach, Jakob, Pferdewärter, Breitenrainplatz 27
 – Jos., Schreiner, Wintermattweg 8, Bümpliz
 – Konrad, Pfardewärter, Rodtmattweg 83
 Rickenbacher, Alb Friedr., Magaziner, Kehrgasse 54, Bümpliz
@@ -36819,7 +36763,7 @@ Rickenbacher, Alb Friedr., Magaziner, Kehrgasse 54, Bümpliz
 – Otto, Bahnangestellter S. B. B., Bridelstr. 96
 – Roland. Telegraphist, Schulweg 4
 Rickli, s auch Rikli
-Alb., Ausläufer, Lorrainestrasse 49
+— Alb., Ausläufer, Lorrainestrasse 49
 – Alfred. Buchdrucker, Flurstrasse 33
 – Alfred, Feinmechaniker, Belpstrasse 20b
 – Alfred. Steinbrecher, Güterstrasse 8
@@ -36827,12 +36771,12 @@ Alb., Ausläufer, Lorrainestrasse 49
 – Arnold, Buchdrucker, Moserstrasse 48
 – Bernh. Frz., Masch.-Schlosser, Quartierhof 1
 Rickli, s. auch Rikli
-– E. Otto, Postangestellter. Breitenrainstr. 7
+– E. Otto, Postangestellter, Breitenrainstr. 7
 – Elisabeth (Aerni), Kniislihubelweg 17
 – Elisabeth (Haueter), Wwe., Moserstr. 48
 – Elise, Frau, Hausiererin. Gerechtigkeitsgasse 76
 – Emil, Patissier, Neubrückstrasse 72
-– Ernst Paul, Postbeamter. Beundenfeldstr.54
+– Ernst Paul, Postbeamter, Beundenfeldstr.54
 – Fritz, Buchdrucker, Meisenweg 19
 – Hans, Buchdrucker, Moserstrasse 48
 – Hans. Handlanger. Wiesenstrasse 35
@@ -36875,7 +36819,7 @@ Rieder, Albert, Schlosser, Kehrg. 9, Bümpliz
 – Arthur, Mechaniker, Schläflirain 11
 – Christ., Postbeamter, Höheweg 4
 – Chr., Zimmermann Kehrg. 35, Bümpliz
-– Christ.. Schlosser, Meisenweg 27
+– Christ., Schlosser, Meisenweg 27
 – E. (Bell), Wwe., Kirchbühlweg 4 [32.361]
 – Elise (Gurtner), Wwe., Rodtmattstr. 114 [32.650]
 # Date: 1935-12-15 Page: 26020699/392
@@ -36917,7 +36861,7 @@ Rieder, Emil, Bauschlosser, Altenbergstr. 102
 ; —Walter, Vertreter, Freiburgstrasse 51
 – Werner, Fabrikarbeiter, Murifeldweg 3
 – Willy, Elektriker, Spitalackerstrasse 5
-– & Cie.. Zivil- u. Uniformschneiderei, Neubrückstrasse 17 [33.145]
+– & Cie., Zivil- u. Uniformschneiderei, Neubrückstrasse 17 [33.145]
 Riederer, Reinhard, Telephonarbeiter, Birkenweg 40
 Riedi, Elisabeth J., Schneiderin, Papiermühlestrasse 9
 — Franz, Beamter, Papiermühlestrasse 9
@@ -36940,7 +36884,8 @@ Ries, s. auch Ris.
 – Hans, kant. Beamter, Muristrasse 56
 – Henry, franz. Attache, Viktoriastrasse 69 [20.638]
 – Karl, Techniker, Weberstrasse 10
-– Paul, Maler, Genossenweg 8v. Ries, Julius, Dr. med., Dozent, Beaulieustrasse 15 [22.512]
+– Paul, Maler, Genossenweg 8
+v. Ries, Julius, Dr. med., Dozent, Beaulieustrasse 15 [22.512]
 Riese, Hanna, Frau, Pension, Gutenbergstr. 14 [23.597]
 Riesen, Adele Luise, Frau, Privatiere, Sulgenheimweg 3 [33.497]
 – Ad., Mechaniker, Birkenweg 40
@@ -36992,7 +36937,7 @@ Riesen, Emilie (Baumgartner), Wwe., Sandrainstrasse 35
 – Friedr., Hilfsarbeiter, Bottigenstrasse 265, Oberbottigen
 – Friedr., Hilfsarbeiter, Steigerweg 19
 – Friedr. (Wegmüller), Dienstchef b. d. Oberzolldirektion, Aebistrasse 14 [34.147]
-– Friedr. W,, Stationsgehilfe, Lentulusrain 9
+– Friedr. W., Stationsgehilfe, Lentulusrain 9
 – Fritz, Architekt, Stauffacherstrasse 27
 – Fritz, Karrer, Quartierhof 9
 – Gottfr., Bäckermeister, Lenzweg 2 [23.547]
@@ -37022,7 +36967,7 @@ Johannes, Bahnarbeiter der S. B. B., Pestalozzistrasse 10
 — Karl, Handlanger, Eggimannstrasse 21
 — Karl, Monteur, Marzilistrasse 2
 – Karl, Abwart, Kirchgasse 1 [32.038]
-— Karl Friedr., Vorarbeiter. Erikaweg 9tt , t. .. [36.057]
+— Karl Friedr., Vorarbeiter, Erikaweg 9 [36.057]
 — Karl, Pferdewärter, Rodtmattstrasse 39
 – Karl, städt. Beamter, Lentulusrain 24
 Riesen, Klara, Bureaulistin, Effingerstr. 97
@@ -37084,7 +37029,7 @@ Rieser, Kurt, A.-G. [27.911] Bauunternehmung (Brunnadernrain 15 [21.968]), Thuns
 – Werner, dipl. Ingenieur B. K. W., Viktoriastrasse 65 [25.921]
 Riesterer, Carl’s Erben. Bürstenfabrikation u. Bürstenhandel. Kramgasse 80 [21.087]
 – Hs., Bürstenfabrikation (Lentulusstr. 38), Blockweg 8 [34.171]
-– Karoline F , Ladentochter. Lentulusstr. 38
+– Karoline F , Ladentochter, Lentulusstr. 38
 – Ludwig, Bürstenmacher, Federweg 59
 – Mina Johanna, Kramgasse 80
 Rietmann, August. Monteur, Mühlemattstr. 68
@@ -37112,15 +37057,15 @@ van Rijbroek, Theodor (Vogel), Frohbergw. 11
 Rikii, s. auch Rickli
 – Benjamin, gew Pfarrer a. d. Nydeckkirche, Präsident der Sektion Bern-Stadt des Vereins « Für das Alter », Kleiner Muristalden 26 [33.3581
 – Franz Georg, Ing., Anshelmstr. 16 [27.783]
-– Hanna Margr.. Kl. Muristalden 26
+– Hanna Margr., Kl. Muristalden 26
 Rima, Carlo, Kartograph. Freiburgstrasse 143
 – Enrico, Kaufmann, Brückfeldstrasse 35
 Rimella, Antonio, Maler, Hubelmattstr. 12
 – G., Malermeister, in Fa. Rimella & Rossi, Hubelmattstrasse 12
 – & Rossi, Gipser- u. Malergeschäft, Belpstrasse 53 [32.783]
-Rimoldi, A.. Mechaniker, Breitfeldstrasse 19
+Rimoldi, A., Mechaniker, Breitfeldstrasse 19
 Rinderknecht, Anna (.Christen), Wwe., Schwarztorstrasse 28
-– Ernst Jak.. Monteur. Kornhausplatz 6
+– Ernst Jak., Monteur. Kornhausplatz 6
 – Friedr. Jak., Drogerie (Schwarztorstr. 28), Könizstrasse 71 [20.314]
 – Joh. Hch., Masch.-Techn., Hopfenrain 16
 – Max Aug., Bauzeichner, Schwarztorstr. 28
@@ -37156,7 +37101,7 @@ Rindlisbacher, Alb., Postangest., Kyburgstr.6
 – Georges, Schreiner, Landoltstrasse 63
 – Gertrud, Rureauangest., Bethlehemstr. 120, Bümpliz
 – Gertrud, Coiffeuse, Stöckackerstrasse 75, Bümpliz
-– Gottfr.. städt. Beamter, Simonstrasse 5
+– Gottfr., städt. Beamter, Simonstrasse 5
 – Gottfr., Stricker, Bahnhofplatz 3
 – Hans Olgar. Ingenieur, Scheuermattw. 14 [32.848]
 – Hans Walter, in Fa. Rindlisbacher & Co., Falkenhöheweg 24 [23.650]
@@ -37179,8 +37124,8 @@ Rindlisbacher, Alb., Postangest., Kyburgstr.6
 # Date: 1935-12-15 Page: 26020702/395
 Rindlisbacher, Klara (Wolfensberger), Wwe., Simonstrasse 3
 – Margaretha (Ruekstuhl), Wwe., Falzerin, Seidenweg 64
-– Margr.. Gertr., Ladentochter, Brückenstrasse 15
-– Margrit, Rotkreuz-Schwester. Neueng. 28 (Ryfflihof), ab 30. Juni 1936: Sonnenbergrain 2a [27.724]
+– Margr., Gertr., Ladentochter, Brückenstrasse 15
+– Margrit, Rotkreuz-Schwester, Neueng. 28 (Ryfflihof), ab 30. Juni 1936: Sonnenbergrain 2a [27.724]
 – Marie Margr. (Zimmermann), Strickerin, Greyerzstrasse 35
 – Martha, Ladentochter, Brückenstrasse 15
 – Oskar, Kaufmann Konsumstrasse 14b
@@ -37220,7 +37165,7 @@ Ris, s auch Ries.
 – Ernst (Krähenbühl), Steinhauer, Holiigenstrasse 70
 – Erwin (v. Dach), Reisender, Brunnadernstrasse 63
 – Fr., Frau, Kolonialwarenhandlung, Holligenstrasse 7a
-– Friedr.. Dr. med., Spezialarzt für Hals-Nasen- und Ohren-Krankheiten, Falkenplatz 18 [27.683]
+– Friedr., Dr. med., Spezialarzt für Hals-Nasen- und Ohren-Krankheiten, Falkenplatz 18 [27.683]
 Ris, s. auch Ries
 – Friedr., pens Lehrer, Dorng. 10 [34.737]
 – Fritz (Häseli), Kunststeinhauer, Könizstrasse 67
@@ -37321,7 +37266,7 @@ Rochat, Charles Chr., Dr. med., Fischerweg 14
 – Pierre Andre, Architekt, Thunstrasse 2
 Roche, Jeanne A. L., Wwe., Zahnärztin, Landoltstrasse 32 [29.394]
 de Roche, Charles (Eidenbenz), Dr. phil., Seminarlehrer und Lektor an der Hochschule, Klaraweg 6 [23.659]
-Roches, M A., Bankbeamter. Anshelmstr. 14
+Roches, M A., Bankbeamter, Anshelmstr. 14
 Rod, Antoine A. G., Ingen., Alpeneckstrasse 5 [36.280]
 – Emil, Postbeamter, Stauffacherstrasse 35
 – Jeanne Eug. (Bourdillaud), Wwe., Zähringerstrasse 26 [34.023]
@@ -37390,11 +37335,12 @@ Rohr, Albert, Bäckermeister, Kesslergasse 44 [34.618]
 – Max Erwin, Kaufmann, Brunnhofweg 22
 – Otto. Photogeschäft (Brunnhofweg 22), Neuengasse 9 [36.1981
 – Peter Paul Otto, Architekt, Bümplizstr. 38 [46.629]
-– Werner (Leuenberger), Magaziner, Murtenstrasse 133v. Rohr, Ernst, Elektriker, Murifeldweg 77
+– Werner (Leuenberger), Magaziner, Murtenstrasse 133
+v. Rohr, Ernst, Elektriker, Murifeldweg 77
 Rohrbach, Adolf, Gärtner, Wyttenbachstr. 34
 – Adolf, Schreiner, Gewerbestrasse 18
 – Alb., Handlanger, Gerbergasse 38
-– Alb.. Landjägerfourier. Mühlemattstr. 59
+– Alb., Landjägerfourier. Mühlemattstr. 59
 – Alb. T., pens. Polizist, Beundenfeldstr. 37
 – Alex., Bauhandlanger, Badgasse 4a
 – Alex., Kunststeinfabrik (Brünnenstr. 103, Bümpliz), Fischermätteliweg 2 [34.435]
@@ -37508,7 +37454,7 @@ Rohrer, Elisabeth Julia R., Frl., Junkerngasse 33
 Roll, Ed., Camionneur, Eggimannstrasse 21
 – Eduard, Coiffeur, Eggimannstrasse 21
 – Josephine, Glätterin, Bollwerk 21
-– Martha, Ladentochter. Eggimannstrasse 21
+– Martha, Ladentochter, Eggimannstrasse 21
 Rolladenfabrik Bern, J. Senn, Lagerhausweg 16, Bümpliz [46.061]
 Rolle, Marie, Kunstmalerin, Steinerstrasse 14
 – Otto, Kirchenfeldstrasse 34a [31.387]
@@ -37518,7 +37464,7 @@ Rolli, Adolf, kant. Angest., Breitfeldstr. 4
 – Albert, Maurer, Metzgergasse 64
 – Alfred, Chef des eidg. Kassen- und Rechnungswesens, Pestalozzistrasse 44 [36.740]
 – Alfr. Chr. (Althaus), Stationsbeamter der
-B. L S.. Morellweg 4
+B. L S., Morellweg 4
 – Armin Emil, Heliograph, Schreinerweg 3
 – Emil, Bereiter, Militärstrasse 46
 – Ernst. Jurastrasse 51
@@ -37532,7 +37478,7 @@ B. L S.. Morellweg 4
 – Franz, Kässalzer u. Handlung, Bümplizstrasse 19
 – Fr., pens. Bahnarbeiter, Frohbergweg 4
 – Fred., Dr. med., Arzt, Pestalozzistrasse 44
-– Friedr.. Polizist, Gesellschaftsstrasse 76
+– Friedr., Polizist, Gesellschaftsstrasse 76
 – Fr., pens. Telephonarb., Altenbergstr. 82
 – Fritz, Karrer, Sulgenrain 22b
 – Fritz, Kässalzer, Brunnmattstrasse 67
@@ -37560,7 +37506,7 @@ B. L S.. Morellweg 4
 – — Rosina (Streit), Wwe., Humboldtstr. 43 [28.437]
 – Walter, Drogist. Morillonstrasse 7
 – Walter, Altmöbelhändler. Gerbergasse 9a
-– Walter. Sattler, Hochfeldstr. 41 [29.047]
+– Walter, Sattler, Hochfeldstr. 41 [29.047]
 – Werner, Metallgiesser. Wiesenstrasse 67
 – Willi Paul, Hilfsangestellter, Bottigenstrasse 391, Riedbach
 # Date: 1935-12-15 Page: 26020706/399
@@ -37588,17 +37534,17 @@ Kirche, Herrengasse 13 [31.922]
 – Otto. Chef der Fremdenpolizei, Kirchenfeldstrasse 29 [20.460]
 – Werner, Wagenführer S. S. B., Bridelstr. 86
 Rometsch, Karl Werner, Zahnarzt, Seminarstrasse 27
-Rominq, Joh. G.. Bäcker. Aarbergergasse 17
+Rominq, Joh. G., Bäcker. Aarbergergasse 17
 Römisch-kathol. Pfarramt, Taubenstrasse 4, Eingang durch den Turm [21.584]; Bümpliz, Burgunderstrasse 124 [46.221]
 Rommel, Anna, Knabenschneiderin, Höheweg 17
 – August, Elektromonteur, Berchtoldstr. 48
 – Curt. Dr. jur., Versieh.-Beamter (Marktgasse 11), Bundesgasse 20
-– Lina (Eggimann). Wwe.. Abwartin, Höheweg 17
+– Lina (Eggimann). Wwe., Abwartin, Höheweg 17
 Rommler, Fritz. Hilfsarbeiter, Mattenhofstr. 29
-Romy, Ferd.. (Dürst), Kunstmaler, Schwarztorstrassc 78
+Romy, Ferd., (Dürst), Kunstmaler, Schwarztorstrassc 78
 Roncaglioni, Marcello. Maurer, Steckweg 13
 Ronco, Guido, Hutmacher, Kasernenstr. 41
-Roncoroni, Gius Ant.. Maurer. Centralweg 20
+Roncoroni, Gius Ant., Maurer. Centralweg 20
 – Luigi, Marmorist. Effingerstrasse 53
 Rondi, Carlo, Versieh.-Beamter, Effingerstrasse 94
 — Maria E., Kanzlistin, Sickingerstrasse 5
@@ -37634,11 +37580,11 @@ Rösch, Alb., Cafe Ryffli-Bar (Herzogstr. 12), Ryffligässchen 4 [20.599]
 – Ella. Masseuse. Zähringerstrasse 52
 – Franz (Lieehti), pens. Kreispostdirektor, Hallerstrasse 37 [22.766]
 – Gertrud. Säuglingspflegerin, Hallerstr. 37
-– Hans. Vorarbeiter. Bümplizstrasse 56
+– Hans. Vorarbeiter, Bümplizstrasse 56
 – Hans, Grubenarb., Keltenstr. 97, Bümpliz
 – Rosalie. Privatiere, Kornhausstrasse 14 [32.759]
 – W. Paul, Schreibmaschinenreparaturwerkstätte (Lentulusstrasse 69), Spitalgasse 4, Karl-Schenk-Haus [36.188]
-– Walter.. Buchdrucker, in Fa. Rösch, Vogt & Co., Monbijoustrasse 9 [35 362]
+– Walter., Buchdrucker, in Fa. Rösch, Vogt & Co., Monbijoustrasse 9 [35 362]
 – Walter (Triebold), Uhren- und Bijouteriehandlung (Humboldtstrasse 17), Marktg 44 [24.970]
 – Werner, Möbelzeichner, Gutenbergstr. 21
 – Vogt & Co., Buchdruckerei, Monbijoustr 9 [29.331]
@@ -37688,7 +37634,7 @@ Rosenzweig, Primus B., Hausierer, Neuengasse 9
 Roser, Alfr., Schriftsetzer, Lorrainestrasse 4
 – Anna (Hofmann), Damenschneiderin, Lorrainestrasse 4 [32.941]
 – Wilhelm. Kaufmann, Lenzweg 10
-Röser, Fritz (Rebholz), Beamter. Studerstr. 68
+Röser, Fritz (Rebholz), Beamter, Studerstr. 68
 – Hedwig Alice, Bureaulistin, Optingenstr. 44
 – Hugo Fr., kaufm. Angest., Studerstr. 68
 – Max Rud., kaufm. Angest., Kramgasse 49
@@ -37707,7 +37653,7 @@ Rossel, Eugen, in Fa. Ernst Häfliger & Rossel, Terrassenweg 16 [23.003]
 Rosseiet, Berthe, Bureaulistin, Sulgenbachstrasse 14
 – Jean, Bankbeamter, Landoltstrasse 77 (ab
 1. Mai: Tillierstrasse 53)
-– Louise Mad.. Ladentochter, Luisenstr. 14
+– Louise Mad., Ladentochter, Luisenstr. 14
 Rösser, Elisabeth (Gyseler), Wwe., Gerechtigkeitsgasse 3
 – Fritz, Kondukteur, Waldheimstrasse 53
 – Joh., Vater, Linienmonteur S. B. B., Burgunderstrasse 67, Bümpliz
@@ -37774,7 +37720,7 @@ Roth, s. auch Rod und Rodt
 – Armand O., Kaufmann, in Fa. Roth & Co., Mättenhofstrasse 13 [33.868]
 – Armin, Postchauffeur, Kursaalstrasse 13
 – Arnold. Bauführer. Birkenweg 44
-– Aug.. Angestellter, Mittelstrasse 23
+– Aug., Angestellter, Mittelstrasse 23
 – Charles G. Maurice, Fürsprecher, Fischerweg 20
 – Charlotte, Ladentochter, Zwyssigstrasse 18
 – Christ. Friedr., eidg. Angest., Thunstr. 10
@@ -37846,7 +37792,7 @@ Eicher & Roth, Hallerstrasse 50 [33.097]
 # Date: 1935-12-15 Page: 26020709/402
 Roth, 8. auch Rod und Rodt
 – Jeanne Elise (Ducommun), Handweberei (Grüneckweg 12 [33.593]), Hotelgasse 6 [23.148]
-– Joh,, Chauffeur, Maulbeerstrasse 17
+– Joh., Chauffeur, Maulbeerstrasse 17
 – Joh. Friedr. (Straub), Ing., Mittelstr. 32 [31.371]
 – Joh. Alfr., Lampist. Breitfeldstrasse 59
 – Joh., Wirt, Lorrainestrasse 23 [22.203]
@@ -37900,13 +37846,13 @@ Roth, s. auch Rod und Rodt
 – Walter Oskar, Eisendreher, Allmendstr. 28
 – Walter Alfr., Verw.-Rat, Falkenplatz 8
 – Walter Rudolf, Zähringerstrasse 23
-– Walter. Trambilletteur, Waisenhauspl. 27
+– Walter, Trambilletteur, Waisenhauspl. 27
 – Werner H., Kaufmann, Freiburgstr.il [33.868]
 – Werner, Schreiner. Speichergasse 29
 – Werner Arthur, Schreiner, Allmendstr. 42a
 – Werner, Wagenvisiteur, Freiestrasse 50
 – Yvonne Erna. Bureaulistin. Sickingerstr 9
-– & Co.. Weinhandlung, Spirituosen en gros, Mattenhofstrasse 13 [33.868]
+– & Co., Weinhandlung, Spirituosen en gros, Mattenhofstrasse 13 [33.868]
 – Ruef & Joss, Advokaturbureau, Bahnhofplatz 5 [23.615]
 Rothacher, Christian, Mechaniker, Berclitoldstrasse 39
 – Friedr., Maurer, Bümplizstrasse 18
@@ -37941,7 +37887,7 @@ Rothen, Alb., Schlosser, Meieenweg 29
 – Friedr., Desinfektor, Brunnmattstrasse 30
 – Friedr., pens. Gasarbeiter, Murifeldweg 21
 – Friedr., Sesselflechter, Kesslergasse 11
-– Friedr., Genossenweg 23 .
+– Friedr., Genossenweg 23
 – Fritz, Angest., Genossenweg 23 [24.989]
 – Fritz, Aktuar, Berchtoldstrasse 9
 – Fritz (Spurling). Prokurist der Schweiz. Kreditanstalt. Tillierstrasse 34 [36.718J
@@ -37960,25 +37906,25 @@ Rothen, Georges A., Kaufm., Optingenstr. 9
 – Herm. Otto, Abwart, Bahnhofplatz 7
 – Ida Flora, Damenschneiderin, Dammweg 9
 – Ida (Bracher), Wwe., Packerin, Eggimannstrasse 26
-– J.. Lithographieangest., Schöneggweg 12
+– J., Lithographieangest., Schöneggweg 12
 – Jak., Buchdrucker, Hochfeldstrasse 26
 – Jakob, Installateur, Fischermätteliweg 19
-– Jos. Alfr.. Magaziner, Studerstrasse 58
+– Jos. Alfr., Magaziner, Studerstrasse 58
 – Julie Emma, Damenschneiderin, Meisenweg 29
 – Karl, Garagearbeiter d. S. O. B., Bümplizstrasse 13
 – Karl. Bereiter, Beundenfeldstrasse 19
 – Klara Johanna, Beundenfeldstrasse 19
 – Margr., Einlegerin, Brunnmattstrasse 30
-– Margr.. Speditionsgehilfin Schöneggweg 12
+– Margr., Speditionsgehilfin Schöneggweg 12
 – Marie (Rothen), Wwe., Flurstrasse 26
 – Otto (Zehnder). Metzgerei und Wursterei, Neufeldstrasse 32 [36.860]
 – Paul A., eidg. Beamter, Seftigenstrasse 23
 – Paul, Beleuchtungskörper, Rütlistrasse 4
 – Paul, Mechaniker, Eggimannstrasse 26
 – Paul, Schreiner, Dammweg 9
-– Reinhard Pferdewärter. Rabbentalstr. 41
+– Reinhard Pferdewärter, Rabbentalstr. 41
 – Rud., pens Zugführer, Könizstrasse 31
-– Samuel, Hilfsarbeiter. Murtenstrasse 320, Bümpliz
+– Samuel, Hilfsarbeiter, Murtenstrasse 320, Bümpliz
 – Wilh. Gottfr., Kaufmann, Steinauweg 9 [35.521]
 Rothenbach, Alfred Emil, Ingenieur, Maltenhofstrasse 41 [26.135]
 Rothenbühler, Alb. E., eidg. Beamter, Sennweg 9
@@ -38042,9 +37988,9 @@ Anna M., Mercerie - Bonneteriegeschäft, Rickenweg 17
 – Bertha Elise, Arbeitslehrerin. Tulpenweg 4
 – Bertha Marg., Korrespondentin. Tulpenweg 4
 – Bianca C., Dr. phil., Engeriedweg 9 [33.674]
-– Christ., Bureauangestellter. Liebeggweg 5b
+– Christ., Bureauangestellter, Liebeggweg 5b
 – Christ., Fabrikarbeiter, Frohbergweg 8
-– Christ., Postangestellter. Randweg 9
+– Christ., Postangestellter, Randweg 9
 – Elise, Weissnäherin, Flurstrasse 30
 – Elsa, Bureaulistin, Kasernenstrasse 34
 # Date: 1935-12-15 Page: 26020711/404
@@ -38122,7 +38068,7 @@ Röthlisberger, Karl Ferd., Chauffeur, Waldheimstrasse 16
 – Rosa (Dennler), «Modes Rose», Breitenrainstrasse 65
 – Rud. Walt., Fabrikarbeiter, Seftigenstr. 25
 – Rudolf, pens. Gärtnerhandlanger, Krippenstrasse 24
-– Rudolf, Hilfsarbeiter. Stauwehrrain 4
+– Rudolf, Hilfsarbeiter, Stauwehrrain 4
 – Walter, Autosattler, Talweg 13
 – Walter Karl (Hügli), Kaufmann, Viktoriastrasse 39 [26.108]
 – Walter, Spengler, Breitfeldstrasse 52
@@ -38180,9 +38126,8 @@ Roy, Andre Phil., Schneidermeister, Seilerstrasse 12
 – Jos. V. H., Postaushelfer, Hochfeldstr. 73
 – Rene, Postangestellter, Nordweg 10
 Rub, Peter, Dienstmann, Breitfeldstrasse 35
-Rubeli, Oskar, pens. Prof. Dr., Alpeneckstr. 7o . . [33.348]
-Hubenstein, Heinz, Handlungsgehilfe, Gartenstrasse 10
-Umbauten erfordern den Rat des erfahrenen u. gewissenhaften Architekten
+Rubeli, Oskar, pens. Prof. Dr., Alpeneckstr. 7o [33.348]
+Rubenstein, Heinz, Handlungsgehilfe, Gartenstrasse 10
 Rubi, Armand Edgar, Elektrotechn., Schwarztorstrasse 1 [25.160]
 – Christ. (Moser), Lehrer, Humboldstrasse 5
 – Fritz, Kaufmann, Bühlstrasse 25a
@@ -38270,7 +38215,7 @@ Ruch, s. auch Ruh und Rauch
 Ruchat, Rene Ch. Ls., Telegraphist, Greyerzstrasse 47
 Ruchti, B., Frau, Milchhdlg., Brunngasse 32 [33.504]
 – Ed., Magaziner, Brunngasse 28
-– E. Chr., Hilfsarb.. Eymattstr 142, Bümpliz
+– E. Chr., Hilfsarb., Eymattstr 142, Bümpliz
 – Ed. Aug., pens. Fabrikarbeiter, Schöneggweg 16
 – Emmy (Berger), Wwe., Neubrückstr. 75
 – Ernst, Lok.-Führer S. B. B., Hochfeldstr. 94 [24.726]
@@ -38303,16 +38248,16 @@ Rückversicherungs - Verband kant. - Schweiz.
 Feuer-Versicherungsanstalten, Bundesg. 20 [23.242]
 Rüdiger, Ed Karl, Uebersetzer, Allmendstrasse 36
 Rudigier, Carl, Polierer, Länggassstrasse 14
-Rudin, G.. in Fa. G. Rudin & Cie., Muristr. 27 [31.425]
+Rudin, G., in Fa. G. Rudin & Cie., Muristr. 27 [31.425]
 – Gustav, Ausläufer, Kapellenstrasse 7
 – Heinr. Werner, Steindrucker. Rütlistr. 20
 – Luise, Gemüse- u. Früchtehdlg. (Effingerstrasse 43), Mittelstrasse 70 [32.877]
 – Max, Angestellter, Belpstrasse 16
 – Siegfried Guido, Kaufmann, Muristrasse 27
-– Walter. Kaufmann. Heinr.-Wildstrasse 10 [36.174]
+– Walter, Kaufmann. Heinr.-Wildstrasse 10 [36.174]
 – G., & Cie., Import- u. Kommissionsgesch., Muristrasse 27
 Rüdlinger, Eduard, eidg. Beamter, Gäcilienstrasse 18
-– Ernst. Hilfsarbeiter. Kasthoferstrasse 22
+– Ernst. Hilfsarbeiter, Kasthoferstrasse 22
 – Jak. Henri, Damencoiffeur (Seidenw. 34), Neuengasse 26, Ryfflihof [25.662]
 Rudolf, Alf., Dr. jur., Regierungsrat, Schanzeneckstrasse 11 [34.587]
 – Christian. Abwart, Spitalgasse 3
@@ -38325,7 +38270,7 @@ Rudolf, Alf., Dr. jur., Regierungsrat, Schanzeneckstrasse 11 [34.587]
 – F. A., Baüsehlosserei, Elisabethenstr. 19 [23.227]
 – Fr Ernst, Schlosser. Schöneggweg 12
 – Friedr. (Zwahlen), Kanzleisekretär bei der O. Z. D., Optingenstrasse 44 [23 108]
-– Gottfr.. Sattler. Bernstrasse 4, Bümpliz
+– Gottfr., Sattler. Bernstrasse 4, Bümpliz
 – Hans. Ausläufer, Sandrainstrasse 18
 – Hans, Cantine Gaswerk (Sandrainstr. 84), Sandrainstrasse 18
 – Heidi Anna, Ladentochter, Schöneggweg 12
@@ -38351,7 +38296,7 @@ Rüedi, Anna (Baumberger), Muristrasse 36 [28.865]
 — Ernst Niklaus, Milchträger, Eymattstr. 95, Bümpliz
 – Fritz. Schriftsetzer, Weingartstrasse 51
 – Hans Werner, Schreiner, Lorrainestr. 53
-– Ida (Widmer), Wwe.. Gross- und Kleinmetzgerei. Bantigerstrasse 35 [31.019]
+– Ida (Widmer), Wwe., Gross- und Kleinmetzgerei. Bantigerstrasse 35 [31.019]
 – Joh. Fr., Küfer, Schwalbenweg 26
 – Karl Emil, Angestellter, Stauffacherstr. 1
 – K. R., Küfer, Beundenfeldstrasse 44
@@ -38360,7 +38305,7 @@ Rüedi, Anna (Baumberger), Muristrasse 36 [28.865]
 – Kurt A., Kaufmann, Muristrasse 36
 – Marie, Hilfsarbeiterin, Eymattstrasse 95, Bümpliz
 – Paul, Eisenwaren, Haushaltungsartikel, Werkzeuge u. Maschinen (Anshelmstr. 16 [33.081]), Marktgasse 17 [24.875]
-– R. F R.. Kaufmann, Niggelerstrasse 16
+– R. F R., Kaufmann, Niggelerstrasse 16
 – Susanna M., Sekretärin, Muristrasse 36
 – Walter Rud., eidg. Beamter, Beundenfeldstrasse 44
 Ruedin, Henri Fr. X., Vertreter, Gutenbergstrasse 8
@@ -38383,11 +38328,11 @@ Roth, Ruef & Joss (Humboldtstrasse 5 [36.469]), Bahnhofplatz 5 [23.615]
 Ruefer, s. auch Rufer
 – Ernst, Mech. Bau- und Möbelschreinerei, (Hochfeldstrasse 98 [33.787]), Zähringerstrasse 45 [22.520]
 Rüefli und Rüfli
-Albert, Zollbeamter, Tulpenweg 3
+— Albert, Zollbeamter, Tulpenweg 3
 – Ewald Rud, Packer, Mattenhofstrasse 1
 – Fanny. Bankangestellte, Effingerstr. 41d
 Rüefli und Rüfli
-– Fernand M.. Bureaulist. Gerechtigkeitsg. 41
+– Fernand M., Bureaulist. Gerechtigkeitsg. 41
 – Josef, Angestellter, Optingenstrasse 42
 – Joseph, Postangestellter, Müslinweg 12
 – Pauline Johanna, Lingere, Mattenhofstr. 1
@@ -38409,14 +38354,14 @@ Kreuzes. Erlachstrasse 28 [34.527]
 – Joh. Adelbert, Postkommis, Flurstrasse 31
 – Joh Jsk. Vertr. Lagerweg 9 [27,881]
 – Rud., Eisendreher, Pestalozzistrasse 34
-– W & Cie.. Papeterie. Couverts- u. mech.
+– W & Cie., Papeterie. Couverts- u. mech.
 Papiersackfabrik, Schwaneng. 5 [22.097]
 – Walter, kaufm. Angest., Statthalterstr. 42, Bümpliz
 – Werner, Elektromechan., Freiburgstr. 385, Bümpliz
 – Wilh., Kaufmann, in Fa. W. Rüegg & Cie., Kramburgstras.se 10 [24.250]
 – Willy P., Kaufmann, Thunstrasse 4
-Rüegger, A., Bankangestellter. Könizstr. 37
-– Alb. Herm.. Polizist. Kramgasse 77
+Rüegger, A., Bankangestellter, Könizstr. 37
+– Alb. Herm., Polizist. Kramgasse 77
 – Adrian, Beamter, Landoltstrasse 51
 – Armin. Maschinenschlosser. Fährstrasse 8
 – Erh. Edw., Fabrikarbeiter, Tunnelweg 9
@@ -38424,7 +38369,7 @@ Rüegger, A., Bankangestellter. Könizstr. 37
 – Hans, Schreiner, Tunnelweg 5
 – Herm. O., Kommis, Attingliausenstr. 29
 – Hermann, Lehrer, Reichenbachstrasse 80 [36.698]
-– Julius Ernst. Kondukteur S. B. B.. Trachselweg 13 [45.072]
+– Julius Ernst. Kondukteur S. B. B., Trachselweg 13 [45.072]
 – Klara. Ladentochter, Tunnel weg 5
 – Samuel, Fabrikarbeiter, Tunnelweg 5
 Rüegsegger, Adolf, Apparatemonteux, Standstrasse 70
@@ -38466,7 +38411,7 @@ Rüesch u. Ruesch
 – Emil, Lok.-Heizer, Freiburgstrasse 167
 – Fritz, kaufm. Angest., Optingenstrasse 31
 – Gertrud, Damenschneiderin, Marktgasse 39
-– Karl Ludw.. Beamter der S. B. B., Weissensteinstrasse 120 [20.972]
+– Karl Ludw., Beamter der S. B. B., Weissensteinstrasse 120 [20.972]
 – Max, Bankbeamter, Hallerstrasse 29
 – Rob., Metalldrückerei (Rosenweg 28), Sulgenauweg 31 [35.795]
 Ruesi, W., Pelzwaren, Zeughausgasse 23
@@ -38529,9 +38474,6 @@ Rüfenacht, Albert, Reisender, Wylerstrasse 83
 – Fritz, eidg. Beamter, Beaumontweg 36 [23.423]
 – Fritz, Handlanger, Freiburgstrasse 157
 – Fritz, Kommis, Graffenriedweg 12
-Das moderne Badzimmermacht Ihnen sicher
-Freude. Lassen Sie sichberaten durchstettbacher
-Gerechtigkeitsg. 59 Telephon 21.040
 # Date: 1935-12-15 Page: 26020716/409
 Rüfenacht, Fritz (Müller), Maurer, Freiburgstrasse 147
 – Fritz Wilh. (Thöni). Sekretär der Oberzolldirektion, Hochfeldstrasse 26
@@ -38540,7 +38482,7 @@ Rüfenacht, Fritz (Müller), Maurer, Freiburgstrasse 147
 – Gottfr., Dachdeckermeister, Breitfeldstr. 57 [35.488]
 – Gottl., Bahnvorarbeitcr, Murifeldweg 15
 – Gust. Emil (Hoesch), Privatier, Beundenfeldstrasse 2 [32.173]
-– Hans, pens. Beamter. Viktoriastrasse 94
+– Hans, pens. Beamter, Viktoriastrasse 94
 – Hans E., Dreher, Rütlistrasse 10
 – Hans Walter, Chauffeur, Kniislihubelw. 22
 – Hans Fr., Elektromechaniker, Murifeldw.15
@@ -38550,7 +38492,7 @@ Rüfenacht, Fritz (Müller), Maurer, Freiburgstrasse 147
 – Helene Hedw., Verkäuferin, Seidenweg 35
 – Herm., Architekt S. I. A. (Florastrasse 2 [22.807]), Zeughausgasse 26 [29.050]
 – Herm. Ad., Lehrer, Hallerstrasse 24
-– Herm. W.. Dr. jur., Kalcheggweg 20
+– Herm. W., Dr. jur., Kalcheggweg 20
 – Irma, Ladentochter, Moserstrasse 24
 – Jakob, Chauffeur, Genfergasse 8
 – Jakob, Mechaniker, Hallerstrasse 20
@@ -38659,12 +38601,12 @@ Ruggli, Klara, Näherin, Haldenweg 18
 Ruh, Bernh., Bereiter, Breitfeldstrasse 22 [36.246]
 – E., Schokoladier. Archivstrasse 12
 – Emma, Angestellte, Zähringerstrasse 53
-– Marg. (Seiler). Wwe.. Zeughausgasse 22
+– Marg. (Seiler). Wwe., Zeughausgasse 22
 – Maria, Damenschneiderin. Neubrückstr. 71
 – Martha, Ladentochter, Zähringerstrasse 53
 – Walter, Bureauangest., Zähringerstr. 53
 Ruhier, Oskar (Brügger). Insp. der. kant. Gemeindedirektion, Blumensteinstrasse 1 [20.902]
-Rühl, Fritz, Beamter S. B. B.. Hotelgasse 8
+Rühl, Fritz, Beamter S. B. B., Hotelgasse 8
 Rui, Paul, Bankangestellter, Effingerstr. 41b
 Ruiz-Guinazu, Enrique, argentinischer Gesandter, Muristrasse 68 [20.161]
 Rumänische Gesandtschaft, Kanzlei, Schlösslistrasse 5 [24.117]
@@ -38685,7 +38627,7 @@ Ruof u Ruoff, s auch Ruef
 – Friedr., Bahnbeamter, Weissensteinstr. 22a
 – Hedwig Emma, Schneiderin, Tillierstr. 7
 – Hotel, Aarbergergasse 1 u. Waisenhausplatz 24 [23.788]
-– J. J.. gew. Abwart der Hypothekarkasse, Lentulusrain 26
+– J. J., gew. Abwart der Hypothekarkasse, Lentulusrain 26
 – Paul, Postangestellter, Lorystrasse 4
 – Joh. (Gisiger), eidg. Beamter, Tillierstr. 7 [32.259]
 Ruoss, Ferd., Dienstchef der O. T. D., Finkenrain 9 [35.197]
@@ -38719,7 +38661,7 @@ Rupp, Adolf, Postbeamter, Nünenenweg 21
 – Lucie Hedwig, Bureaugehilfin d. O. P. D., Lentulusstrasse 77
 – M. Johanna. Lehrerin, Kirchenfeldstr. 42
 – Marg., Bureaulistin, Kasthoferstrasse 67
-– Otto Paul, Mech . Fischermätteliweg 13
+– Otto Paul, Mech., Fischermätteliweg 13
 – Otto, Postangestellter, Holligenstrasse 70
 – Paul (Stämpfli), Postverwalter, Lentulusstrasse 77 [2L106]
 – Rosina (Lauener), Hausiererin, Weissensteinstrasse 20a
@@ -38747,7 +38689,7 @@ Vereinsweg 13
 – Wilh., Automechaniker, Schwarztorstr. 28
 Rusca, Emilia (Kahlenberg), Bureaulistin, Marktgasse 40
 – Lydia, FrL, Dorngasse 2 [29.962]
-– Olivio. Beamter. Könizstrasse 33
+– Olivio. Beamter, Könizstrasse 33
 – Paolo. Maler. Kramgasse 37
 – Ugo, Buchhalter, Greyerzstr. 38 [31.046]
 Rusch, Anna L., Coiffeuse, Ferd.-Hodlerstr. 16
@@ -38761,7 +38703,7 @@ Rust, Hans Wilh,. Bürstenmacher, Berchtoldstrasse 2
 – Jos Ant., Ghefmonteur, Brunnmattstr. 15
 – Lydia Klara, Einlegerin, Brunnmattstr. 15
 – Marie Th., Pelznäherin, Brunnmattstr. 15
-– Peter. Rereiter, Stauffacherstrasse 41
+– Peter, Rereiter, Stauffacherstrasse 41
 – Rud., Malermstr., Freiburgstr. 78 [36.951]
 Rüst, Karl Arthur, Maschinenschlosser, Kasernenslrasse 45
 Rusterholz, Flora (Bischofsberger), Wwe., Kasthoferstrasse 6
@@ -38794,12 +38736,13 @@ Rütschi, Alfr. Jul., Abwart der Brunnmattschule, Brunnmattstrasse 16
 – M. (Lehmann), Wwe., Sandrainstrasse 10 [31.153]
 – Werner, Drogist, Sandrainstrasse 10
 Rutschi, Hans, Melker, Matzenriedstr. 130, Oberbottigen
-– Jak. (Schweizer), Schreiner, Murtenstr. 28v. Rütte, Pauline (v. Greyerz), Wwe., Liebeggweg 15
+– Jak. (Schweizer), Schreiner, Murtenstr. 28
+v. Rütte, Pauline (v. Greyerz), Wwe., Liebeggweg 15
 – Rosa, FrL, Priv., Bubenbergpl. 4 [34.961]
 Rüttenauer, Benno, in Fa. Schönmann, Rüttenauer & Co., Laupenstrasse 27
 Rütter, Wilh. Balth. (Dold), Magaziner, Turnweg 11
 Rüttimann, Alfred, kaufm. Angestellter, Allmendstrasse 39
-– Harry. Bankbeamter. Flurstr. 31 [35.213]
+– Harry. Bankbeamter, Flurstr. 31 [35.213]
 – Heinrich Rob. (Ringeisen), Vertr., Erlenweg 18
 – Jos., Kaufmann, Könizstrasse 55
 – Karl. Prokurist. Tscharnerstrasse 11
@@ -38871,7 +38814,7 @@ Ryffe, Klara Pauline, Postangest., Bühlpl. 3
 Ryffel und Riffel
 – Caspar, pens. Sektionschef S. B. B., Riedweg 2 [23.739]
 – Doris, Bankangestellte, Riedweg 2
-– Georg, eidg. Beamter. Wyttenbachstr. 4 [25.3671
+– Georg, eidg. Beamter, Wyttenbachstr. 4 [25.3671
 – Hans, Direktor der eidg. Finanzkontrolle, Hubelmattstrasse 24 [31.589]
 Ryffel und Riffel
 – Heinrich. Beamter S. B. B. t Müslinweg 5 [33.235]
@@ -38880,7 +38823,7 @@ Ryffel und Riffel
 – Margr., Lehrerin, Riedweg 2
 – Ryffli-Bar (Scheib, Alb., & Rösch, Alb.), Ryffligässchen 4 [20.599]
 Ryser, s. auch Rieser und Riser
-– Ad.. Abwart, Muesmattstrasse 27
+– Ad., Abwart, Muesmattstrasse 27
 – Adolf, Metalldreher, Mindstrasse 3
 – Albert, Sohn, Ausläufer, Alleeweg 30
 – Albert Alfred, Elektriker, Breitfeldstr. 3
@@ -38895,7 +38838,7 @@ Blauen Kreuzes, Steinerstr. 17 [33.532]
 – Alfred, Gross- und Kleinmetzgerei, Zähringerstrasse 35 [22.846]; Filiale; Murtenstr. 1 [29.327]
 – Alfred, Konfiseur, Spitalgasse 29
 – Anna Hedwig, Bureaulistin, Waffenweg 18
-– Anna Bertha. Einlegerin, Hopfenweg 42
+– Anna Bertha, Einlegerin, Hopfenweg 42
 – Anna Gertr. (Ryser), Wwe., Viktoriastr. 51
 – Berthold, Handlanger, Muesmattstrasse 41
 – Blanche H., Bureaulistin, Seidenweg 8
@@ -38975,8 +38918,8 @@ Ryser, s. auch Rieser und Riser
 – William, Klavierlehrer, Eschmannstr. 7 [27.258]
 – Willy O., Metzger, Zähringerstrasse 35
 Ryter, Alfred (Grünenwald), Brauereiarbeiter, Monbijoustrasse 51
-Arnold, Spengler, Kasthoferstrasse 16
-Charles Alb., kant. Angestellter, Stapfenackerstrasse 40, Bümpliz
+— Arnold, Spengler, Kasthoferstrasse 16
+— Charles Alb., kant. Angestellter, Stapfenackerstrasse 40, Bümpliz
 – David, Maschinist, Freiburgstrasse 184, Bümpliz
 Ryter, Fernande Alice, Lehrerin, Burgunderstrasse 93, Bümpliz
 – Gottfr., Chauffeur, Freiburgstrasse 51
@@ -39023,13 +38966,13 @@ Sägesser, s. auch Segesser
 – Paul, Kaufmann, Lötschbergweg 5
 # Date: 1935-12-15 Page: 26020721/414
 Sägesser, s. auch Segesser
-– Walter (Schneiter), städt. Beamter. Waldheimstrasse 10b
+– Walter (Schneiter), städt. Beamter, Waldheimstrasse 10b
 – Werner, kaufm. Angest., Länggassstr. 38
-Sagne, William, Vertreter. Greyerzstr. 47
+Sagne, William, Vertreter, Greyerzstr. 47
 « Sahev », Genossenschaft Schweiz. Alters-, Hinterbliebenen- u. Erwerbslosenversicherung, Schwanengasse 4 [33.181]
 Sahli, Adolf, Angest. S. S. B., Ahornweg 7
 – Adolf, Handlanger, Brunngasse 46
-– Adolf (Tschäppat), eidg. Beamter. Viktoriastrasse 37 [27.391]
+– Adolf (Tschäppat), eidg. Beamter, Viktoriastrasse 37 [27.391]
 – Alb., städt. Baukontrolleur, Holligenstr. 92
 – Albert Joh., Chauffeur, Kehrg. 33, Bümpliz
 – Alfred, Fabrikarbeiter, Friedheimweg 24
@@ -39039,11 +38982,11 @@ Sahli, Adolf, Angest. S. S. B., Ahornweg 7
 – Ami, Gasarbeiter, Wylerringstrasse 57
 – Anna Margrit, Lehrerin, Rabbentaltreppe 10 [32.330]
 – Anna El., Schneiderei-Atelier, Berchtoldstrasse 54
-– Anna (Bachmann), Wwe.. Einlegerin, Birkenweg JO
+– Anna (Bachmann), Wwe., Einlegerin, Birkenweg JO
 – Anton, Coiffeurgeschäft. Scheibenstr. 25
 – Anton, jun., Coiffeur, Scheibenstrasse 25
 – Arnold, Schriftsetzer, Berchtoldstrasse 54
-– Bertha. Ladentochter, Steinhauerweg 3
+– Bertha, Ladentochter, Steinhauerweg 3
 – Elise (Reber), Diesbachstrasse 21 [31.275]
 – Emil, Mechaniker, Birkenweg 10
 – Emma. Frl., Kanzlistin der städt. Schuldirektion. Turnweg 16
@@ -39057,7 +39000,7 @@ Sahli, Adolf, Angest. S. S. B., Ahornweg 7
 – F. Herm., Einzieher b. städt. Elektrizitätswerk, Drosselweg 23
 – Fr. Alb., Kunstziegelfabrik, Kehrgasse 24, Bümpliz
 – Frieda, Kanzl. d. Stadtkanzlei, Turnw. 16
-– Friedr.. Handlanger, Freiburgstrasse 52
+– Friedr., Handlanger, Freiburgstrasse 52
 – Friedr. (Steck), Maurer, Neubrückstr. 206
 – Friedr. Walter, Kaufm, Turnweg 17
 – Friedr., Postangestellter, Turnweg 17
@@ -39126,7 +39069,7 @@ Sulgeneckstrasse 33 [23.370]
 – Hans (Meier), Architekt. Stellvertreter deseidg. Baudirektors, Bubenbergstrasse 15 [32.282]
 # Date: 1935-12-15 Page: 26020722/415
 Salchli, Marg., Wwe., Mittelstrasse 54
-Salchrath, Chs.. Buchdrucker, in Firma Neukomm & Salchrath, Lentulusstrasse 53
+Salchrath, Chs., Buchdrucker, in Firma Neukomm & Salchrath, Lentulusstrasse 53
 Salem, Krankenhaus, Schänzlistrasse 39 [24.333]
 Salera, Sisto, Handlanger, Ulmenweg 5
 – Vinc., Maurer, Viktoriastrasse 91
@@ -39149,7 +39092,7 @@ Salm, Alb., Ausläufer, Gerechtigkeitsg. 54
 – Fritz, Sohn, Tapezierer, Breitfeldstr. 44
 – Gustav, Schlosser, Rodtmattstrasse 64
 – Hans, Reisender, Gerechtigkeitsgasse 54
-– Hans Ernst, Mechan,, Wyttenbachstr. 15
+– Hans Ernst, Mechan., Wyttenbachstr. 15
 – Hedwig, Rodtmattstrasse 64
 – Heinr., Magazinarbeiter, Rodtmattstr. 64
 – Jak., Schuhmaehermeister, Gerechtigkeitsgasse 54 [34.847]
@@ -39161,15 +39104,15 @@ Salm, Alb., Ausläufer, Gerechtigkeitsg. 54
 – Otto, Postangestellter, Breitfeldstrasse 44
 – Walter, Buchbinder, Metzgergasse 43
 Salonion, Sally. Kaufmann. Weissenbühlw. 32
-Salquin, Ad.. Kaufmann. Aarbergergasse 22
+Salquin, Ad., Kaufmann. Aarbergergasse 22
 – Ad. Aug., Mech. Werkst. (Landoltstr. 53), Bollwerk 31 [20.219]
-– Henri (Näf), Beamter. Südbahnhofstr. 10
+– Henri (Näf), Beamter, Südbahnhofstr. 10
 — Lilly Iröne, Kunstgewerblerin, Südbahnhofstrasse 10
 – Paul (Mück), Beamter u. Stenographielehrer für deutsche und französische Stenographie, Scheibenstrasse 15
 Salute, Alba, Verkäuferin, Felsenaustrasse 26
 – Carolina, Fabrikarbeiterin, Felsenaustr. 26
 Saluz, R. Fritz., Bureaulist, Hochfeldstr. 63
-Salva A.-G,, b. Notar v. Graffenried, Amthausc S a sse 14 [22.383]
+Salva A.-G., b. Notar v. Graffenried, Amthausc S a sse 14 [22.383]
 Salvador, Elisa Aug., Verkäuferin, Brückenstrasse 57
 Salvi, Angelo, Rohprodukten-, Alteisen- und Metallhandlg., Engehaldenstr. 22 [27.240]
 Salvi, Rosa (Blum), Wwe., Handel mit Metall, Stoffabfällen etc., Engehaldenstrasse 53
@@ -39183,7 +39126,7 @@ Salvisberq, Adolf, Post-Obergehilfe, Lorrainestrasse 38
 – Christ., Melker, Glockenstrasse 3, Bümpliz
 – Ernst (Zielili), Architekt (Humboldtstr. 47 [28.186]), Bundesgasse 16 [24.897]
 – Ernst, Ingenieur, Bauunternehmer, Sandrainstrasse 96 [23.051]
-– Fritz, Landarbeiter. Glockenstr. 5. Bümpliz
+– Fritz, Landarbeiter, Glockenstr. 5. Bümpliz
 – Fritz, Melker, Niederbottigenweg 84, Bümpliz
 – Gertrud, Ladentochter, Bümplizstrasse 140
 – Gottfr., Tramkondukteur, Moserstrasse 52 [36.307]
@@ -39205,7 +39148,7 @@ Salvisberq, Adolf, Post-Obergehilfe, Lorrainestrasse 38
 – Paul, Experte des kant. Strassenverkehrsamtes, Bühlstrasse 14 [27.465]
 – Paul, Bäcker, Seftigenstrasse 23
 – Rob., Bäckermeister, Turnweg 26 [29.516]
-– Sus. (Pfänder), Wwe.. Turnweg 26
+– Sus. (Pfänder), Wwe., Turnweg 26
 – Theodor, Bubenbergplatz 4
 – Viktor, Transportgeschäft, Forstweg 67 [24.683]
 – Walter, Knecht, Matzen riedstrasse 98, Bümpliz
@@ -39220,12 +39163,12 @@ Salzfaktorei, kt., Südbahnhofstr. 14d [35.559]
 Salzmann, Albert, Billetteur S. S. B., Burgunderstrasse 59, Bümpliz
 # Date: 1935-12-15 Page: 26020723/416
 Salzmann, Albert, Tramangestellter, Burgunderstrasse 59, Bümpliz
-– Alfr. Friedr.. Hilfsarbeiter, Parkstrasse 15
+– Alfr. Friedr., Hilfsarbeiter, Parkstrasse 15
 — Alfr., pens. Angestellter, Parkstrasse 15
 – Alfr., Notar, in Fa. Henzi-v. Graffenried (Sulgenbachstr. 12 [29.574]), Bundesg. SO [21.107]
 – Alice, Hilfsarbeiterin, Murtenstrasse 155p
 – Chr., eidg. Angestellter, Bundesgasse 8
-– Ed.. Mechaniker W. F.. Schützenweg 20
+– Ed., Mechaniker W. F., Schützenweg 20
 – El. (Haldimann), Wwe., Wäscherei, Maulbeerstrasse 11
 – Elise Martha, Einlegerin, Stalden 20
 – Emil. Chauffeur, Schönburgstrasse 36
@@ -39289,9 +39232,9 @@ Salzmann, Margaritha, Verkäuferin, Schwarzenburgstrasse 73
 – Rudolf Erwin, Mechaniker, Standstr. 13
 – Rudolf, Hilfsarbeiter, Morgenstrasse 70, Bümpliz
 – Rud., Spezierer, Standstrasse 13 [34.240]
-– Rud., Tramangestellter. Schöneggweg 17
+– Rud., Tramangestellter, Schöneggweg 17
 – S. (Gasser), Frau, Glätterin u. Goffriererin. Polygonweg 11
-– Walter, Fabrikarbeiter. Felsenaustr. 16
+– Walter, Fabrikarbeiter, Felsenaustr. 16
 – Walter Bernh., Prokurist, Dählhölzliweg 18 [33.682]
 – Walter, Modellschreiner, Waffenweg 27
 – Werner, Drogist, in Fa. Salzmann. Söhne.
@@ -39333,9 +39276,7 @@ Sanitas A.-G., sanit. Apparate en gros, Effingerstrasse 18 [21.243]
 Sanitasverlag A.-G., Buchhandlung, Murtenstrasse 1 [22.739]
 Sanitätsabteilung des eidg. Militärdepartements. Laupenstrasse 11, Suvahaus [61]
 Sanitätsdirektion, kant., Postg. 68 [21.555]
-Sanitätsgeschäft E. E. Benz, en gros u. detail
-Chirurg. Instrumente, Sterilisier-Apparate, Verbandstoffe, ärztl. Bedarfsartikel aller
-Art, Sprechzimmer-, Operationssaal-, Krankenhaus-Mobiliar, Laupenstr. 9/11, Suvahaus [27.196]
+Sanitätsgeschäft E. E. Benz, en gros u. detail, Chirurg. Instrumente, Sterilisier-Apparate, Verbandstoffe, ärztl. Bedarfsartikel aller Art, Sprechzimmer-, Operationssaal-, Krankenhaus-Mobiliar, Laupenstr. 9/11, Suvahaus [27.196]
 Sanitätsmagazin, eidg., Papiermühlestr. 21a [24.961]
 Sanitätspolizei, Predigergasse 5 [20.421]
 Sannmann, A., Mechaniker. Lentulusstr. 67
@@ -39366,9 +39307,9 @@ Sarbach, Paula Gertrud, Bureaulistin, Breitenrainstrasse 41
 Sarepta, Erholungshaus, Schänzlistrasse 19 [25.031]
 Sargenti, Florindo, Farben, Lacke u. Pinsel, Werdtweg 1 [24.107]
 – Florindo Bruno, jun., Kaufmann. Werdtweg 1
-Sartorio, A., Maurer, Flurstrasse la
-– Angelo, Heizungstechniker. Flurstrasse la
-– Eleonore A., Bureaulistin, Flurstrasse la
+Sartorio, A., Maurer, Flurstrasse 1a
+– Angelo, Heizungstechniker. Flurstrasse 1a
+– Eleonore A., Bureaulistin, Flurstrasse 1a
 – Theresia, Frau, Fabrikarbeiterin, Gesellschaftsstrasse 24
 Sartorius, Peter (Freivogel), Forstingenieur, Landhausweg 30
 Sasdelli, Lucia, Näherin, Neubrückstrasse 70
@@ -39378,17 +39319,16 @@ Sattler, Gertrud, Dr. phil., Buchhändlerin, Zähringerstrasse 14
 «Satus», Sportartikelhandlg., Monbijoustr. 10 [24.671]
 Säuberli, Hans J., Monteur, Statthalterstr. 22, Bümpliz
 Sauer, Gh., Vertreter, Bollwerk 33
-– Hch . Buchbinder. Lentulusstrasse 69
+– Hch., Buchbinder, Lentulusstrasse 69
 Sauerbeck, Emmy, Schule für Bewegung, Viktoriastrasse 63 [31.295]
 Sauerer, Anna El., Nägeligasse 7
 – Joh. Chr., Buchbinder, Nägeligasse 7
 – Rosa, Bureaulistin, Nägeligasse 7
-Sauerer, Wolfgang 23.980
-Buchbinderei, Nägeligasse 7 (Wohnung: Tel. 32 . 228 )
+Sauerer, Wolfgang 📞 23.980 Buchbinderei, Nägeligasse 7 (Wohnung: Tel. 32.228)
 Säuglingsfürsorgestelle der Stadt Bern, und Milchküche, Bundesgasse 17 [31.856]
 Säuglings- u. Mütterheim, kant.-bern., Elfenauweg 98 [23.458]
 Saugy, Elise (Morf), Wwe., Kirchgasse 12
-– Ernst, Handlanger, Kirchgasse 12 .
+– Ernst, Handlanger, Kirchgasse 12
 – Hans Gottfr., Schlosser, Parkstrasse 15
 – Louis Walter (Kneubühl), Chauffeur, Freiburgstrasse 157
 Saurer, Arthur O., Hilfsarbeiter, Bundesg. 36
@@ -39403,11 +39343,11 @@ Saurer, Arthur O., Hilfsarbeiter, Bundesg. 36
 – Lina, Lingere, Flurstrasse 30
 – Rosa, Fabrikarbeiterin, Brunnhofweg 27
 Sauser, Elsa Louise, Verkäuferin, Feilenbergstrasse 21
-– Emilie (Zaugg), Wwe.. Speziererin, Turnweg 27
+– Emilie (Zaugg), Wwe., Speziererin, Turnweg 27
 – Emma, Einlegerin, Badgasse 45
 – Ernst, Installateur. Badgasse 45
 – Ernst, Maurer, Badgasse 45
-– Ernst H., Angestellter. Fellenbergstr. 21
+– Ernst H., Angestellter, Fellenbergstr. 21
 – Erwin Ed., kaufm. Angestellter, Fellenbergstrasse 21
 Sanitäre Anlagenfür alle Zwecke erstelltfach- und sachgemässunter billig. Berechnung Gerechtigkeitsg.59 Telephon21.040sfetfbacher
 4t?
@@ -39423,16 +39363,16 @@ Sauser, Frz. Adolf, Kommis, Schwarzenburgstrasse 14b
 – Hans Ernst. Beamter, Breitenrainstr. 67
 – Heinr., Polizeikorporal, Fellenbergstr. 21
 – Huldy, Burgernzielweg 4
-– P Alb.. Buchbinder. Seidenweg 8
+– P Alb., Buchbinder. Seidenweg 8
 – Rene Arth., Milchträger, Bümplizstr. 118
 – Rosa Klara, Bureaulistin, Seidenweg 8de Saussure, Rene, Dr., Prof., Lombachweg27 [27 792]
 Sautebin, Emil (Schoch), Plastique-Maler, Gerechtigkeitsgasse 24
-Sauter, Friedr., Beamter. Böcklinstrasse 12
+Sauter, Friedr., Beamter, Böcklinstrasse 12
 – Fr. A. G., Basel, Fabrik elektr. Apparate, Büro Bern, Zeigerweg 3 [23.683]
 – Otto, Requisiteur, Zeughausgasse 5
 – Walter, Mechaniker, Wylerstrasse 77
 Sauteref, P., Bäckerei u Konfiserie, Schulweg 2 [20 188]
-Sauiin, Maurice F., Angestellter. Mühlemattstrasse 70
+Sauiin, Maurice F., Angestellter, Mühlemattstrasse 70
 Sauvain, Lydia, Lehrerin, Gerechtigkeitsg. 50
 Savary, Leon (Gharmot), Journalist, Brunnadernstrasse 5 [31.363]
 – Marcel E., Kondukteur S. B. B., Hochfeldstrasse 24
@@ -39442,7 +39382,7 @@ Savioli, Enrico, Gemüsehdlg., Neubrückstr. 94
 – Maria. Kartonnagearbeiterin, Neubrücksträsse 94
 Savioz, Andre, Mechaniker, Berchtoldstr. 25
 – Rob., Kondukteur S. B. B., Gesellschaftsstrasse 78
-Savoia, Ferd.. Magaziner, Wankdorfweg 11
+Savoia, Ferd., Magaziner, Wankdorfweg 11
 – Giuseppe. Musiker, Schauplatzgasse 33
 – Luigi, Gemüse- und Früchtehändler, Wankdorfweg 11
 – V. N., Magaziner, Hallerstrasse 20
@@ -39500,7 +39440,7 @@ Schädeli, Adolf Ernst, Monteur, Klaraweg 5 [31.122]
 – Ernst, mech. Schlosserei (Dalmaziweg 77), Thunstrasse 4 [31.610]
 – Franz, Beamter S B. B., Seidenweg 24
 – Frieda, Filialleiterin, Murtenstrasse 222, Bümpliz
-– Friedr.. Bahnarbeiter, Eggimannstrasse 41
+– Friedr., Bahnarbeiter, Eggimannstrasse 41
 – Gottl., Mechaniker, Hubelmattstrasse 50a
 – Hans, Holzer, Wohlenstrasse 50
 # Date: 1935-12-15 Page: 26020726/419
@@ -39538,7 +39478,7 @@ Schäfer, s. auch Schäffer, Schefer u. Schaefer
 – Fridolin, Schreiner, Maulbeerstrasse 9
 – Friedr., Gartenarbeiter, Rodtmattstr 75
 – Gottfr., Marchand-Tailleur, Belpstrasse 24
-– Hans. Bankangest.. Brückfeldstrasse 42
+– Hans. Bankangest., Brückfeldstrasse 42
 – Heidi, Bankangestellte, Hopfenrain 21
 – Heinr., Mechaniker-Vorarbeiter, Weissensteinstrasse 27
 – Joh., Dessinateur, Muristrasse 33
@@ -39548,7 +39488,7 @@ Schäfer, s. auch Schäffer, Schefer u. Schaefer
 – Klara (Moser), Damenschneiderei-Atelier, Maulbeerstrasse 9 [20.276]
 – Kurt, Ingenieur S. B. B., Diesbachstr. 3 [27.402]
 Schuise, Packerin, Brückfeldstrasse 42
-Schäfer, s. auch Schäffer, Schefer u.. Schaefer
+Schäfer, s. auch Schäffer, Schefer u., Schaefer
 – Martha, Angestellte, Hochfeldstrasse 65
 – Mathilde, Bureaulistin, Diesbachstrasse 3
 – Otto G. (Zaugg), kaufm. Angest., Konsumstrasse 10
@@ -39576,7 +39516,7 @@ Schaffer, s. auch Schäfer u. Schaffter
 – Lydia (Hintermann), Wwe., Holligenstr. 43
 – Margrit, Sekretärin des bern. Blindenfürsorgevereins, Neufeldstrasse 97 [33.961]
 – Paul, Herren- u Damenschneiderei, Breitenrainstrasse 23 [31.351]
-– Paul Rob.. Schriftsetzer. Schönburgstr. 40
+– Paul Rob., Schriftsetzer. Schönburgstr. 40
 – Rob., Handlanger, Metzgergasse 78
 – Rosina (Burkhard). Wwe., Schneiderin, Militärstrasse 39
 – Rud., Maurer, Jurastrasse 99
@@ -39662,7 +39602,7 @@ Schalter, Adolf, Glas-, Porzellan- und Haushaltungsartikel (Lentulusstr. 26), Ne
 – Hans, Nelkenweg 8 [29.137]
 – Hans Jak., Drogist, Nelkenweg 8
 – Hedwig Gertrud, Bureaulistin, Erikaw.3
-– J. Arnold, Bauamtarbeiter. Alleeweg 8
+– J. Arnold, Bauamtarbeiter, Alleeweg 8
 – Jean, Hilfsarbeiter, Krippenstrasse 38
 – Niklaus, Fabrikarbeiter, Hohgantweg 14
 – Otto, städt. Beamter, Melchthalstrasse 11
@@ -39766,7 +39706,7 @@ Schär, Joh., Fabrikarbeiter, Burgfeldweg 20
 – Joh. Rud., Handlanger, Eggimannstr. 36
 – Johann (Jauner), pens. Bahnangestellter, Holligenstrasse 72
 – Johann Jakob, Notar, Bernastrasse 47 [35.513]
-– Joh. Jak.. Schwarztorstrasse 19
+– Joh. Jak., Schwarztorstrasse 19
 – Klara M., Damenschneiderin. Archivstr. 20
 – Kurt Paul, kaufm Angest., Greyerzstr. 37
 – Lina, Hilfsarbeiterin, Scheibenstrasse 35
@@ -39837,7 +39777,7 @@ Schären, Anna Marie (Beeri), Wwe., Länggassstrasse 70c
 – Rosa (Wasem), Wwe., Vereinsweg 23
 – Rosa, Ladentochter, Brückfeldstrasse 41
 – Rud. Alb., Ausläufer, Scheibenstrasse 25a
-– Rud.. Kupferschmied, Eggimannstrasse 20
+– Rud., Kupferschmied, Eggimannstrasse 20
 – Walter E , Maler, Scheibenstrasse 25a
 – Walter, Schlosser, Rütlistrasse 10
 – Walter, Schlossermeister, Melchthalstr. 15
@@ -39845,10 +39785,10 @@ Schären, Anna Marie (Beeri), Wwe., Länggassstrasse 70c
 – Willy Gody, Dekorationsmaler, Matzenriedstrasse 33, Oberbottigen
 Schärer, s. auch SebereT u. Scberrer
 – A. Martha (Lauber), Wwe., Damenschneiderin, Zähringerstrasse 22 [35.416]
-– Adolf, Hauswart S. E. V.. Effingerstr. 19
+– Adolf, Hauswart S. E. V., Effingerstr. 19
 – Albertine (Hug), Wwe., Sulgenauweg 34
 – Alfred, Korrektor. Beundenfeldstrasse 19
-– Anna El.. Bureaulistin. Maulbeerstr.il
+– Anna El., Bureaulistin. Maulbeerstr.il
 – Anna, Wäscherei u. Glätterei, Postg. 54
 – Anna Hedwig (Fäs), Wwe, Alpenstr. 5
 – Arnold. Reisender, Ulmenweg 13
@@ -39856,7 +39796,7 @@ Schärer, s. auch SebereT u. Scberrer
 – Bertha (Jaun), Arbeitslehrerin, Erikaw. 2 [27.716]
 – Bertha, Coiffeuse, Lenzweg 12
 – Christ., Hausknecht im Inselspital, Freiburgstrasse 18.
-– Ed., Schlossermeister, in Fa. Ed, Schärer & Co.. Beaumontweg 18 [32.193]
+– Ed., Schlossermeister, in Fa. Ed, Schärer & Co., Beaumontweg 18 [32.193]
 – Eduard, Effingerstrasse 90
 – Eduard, jun. Schlosser, Beaumontweg 18
 – Elise. Fabrikarbeiterin. Waffenweg 23
@@ -39873,18 +39813,18 @@ Schärer, s. auch Scherer u Scberrer
 – Ernst, Tramführer, Hopfenrain 19
 – Ernst, Werkzeugmacher, Breitfeldstr. 22
 – Fr. E., Zugführer, Muesmattstrasse 20 [28.904]
-– Frieda A.. Schneiderin, Weberstrasse 12
+– Frieda A., Schneiderin, Weberstrasse 12
 – Friedr. W., Mechaniker, Hopfenrain 19
-– Friedr.. Spezerei- u. Milchhdlg., Denzlerstrasse 6 [34.973]
+– Friedr., Spezerei- u. Milchhdlg., Denzlerstrasse 6 [34.973]
 – Fritz, Oberdorfstr. 376b, Ostermundigen
 – Fritz, Handlanger, Weberstrasse 12
-– Fritz J . Handlanger. Wylerfeldstrasse 44
+– Fritz J., Handlanger. Wylerfeldstrasse 44
 – Fritz, Hilfsarbeiter, Waffenweg 23
 – Fritz Cäsar, Koch, Länggassstrasse 30
 – Fritz, Telegr.-Angestellter, Kasernenstr. 45
 – Fritz, Kanzlist, Weberstrasse 12
 – Fritz, Kaufmann, Tscharnerstrasse 39a [28.729]
-– G. E. Rob,, Mechaniker, Sulgenauweg 34
+– G. E. Rob., Mechaniker, Sulgenauweg 34
 – Gottfr., Elektrotechniker. Muristrasse 31
 – Gottfr. Otto, Postbeamter, Felshaldenw.20
 – Gottlieb, Schreiner, Polygonweg 13
@@ -39892,16 +39832,16 @@ Schärer, s. auch Scherer u Scberrer
 – H. Otto, Organist. Terrassenw. 18 [26.288]
 – Hans, Angestellter, Muesmattstrasse 20
 – Hans, Glaser, Lorrainestrasse 67
-– Hs., Hilfsarbeiter. Bottigenstr. 67. Bümpliz
+– Hs., Hilfsarbeiter, Bottigenstr. 67. Bümpliz
 – Hans. Mechaniker, Keltenstr. 108, Bümpliz
 – Hedwig, Weihergasse 20
-– Hans O.. Schreiner, Bottigenstrasse 348, Riedbach
+– Hans O., Schreiner, Bottigenstrasse 348, Riedbach
 – Heidi, Einlegerin, Polygonweg 11
 – Helene Rosa, Klavierlehrerin, Sulgenrain 10
 – Hermann, Mechaniker, Sulgenbachstr. 28a
 – Ida. Lehrerin, Muristrasse 31
 – Ida. Privatiere. Bubenbergplatz 4
-– J. Heinrich, Masch.-Ing.. Beamter S. B. B., Bundesbahnweg 27
+– J. Heinrich, Masch.-Ing., Beamter S. B. B., Bundesbahnweg 27
 – J. J., Beamter d. S. B. B., Tracheelweg 29 [45 457]
 – Jakob, TramführeT, Brunnmattstrass« 53
 – Jean J., Handlanger. Scheibenstrasse 33
@@ -39964,7 +39904,7 @@ Schärer, s. auch Scherer u. Scherrer
 – Werner, Hilfsarbeiter, Bahnhöheweg 98, Bümpliz
 – Wilh., Konsumangestellter, Quartiergasse 17
 – Wilhelm (Amrein), Kaufmann, Lagerweg 8 [20.216]
-– Wilhelm (Pozzi), in Fa. W. Schaerer & Cie.. Terrassenweg 18
+– Wilhelm (Pozzi), in Fa. W. Schaerer & Cie., Terrassenweg 18
 – & Co., Ed., Bau- und Kunstschlosserei, Sulsrenbachstrasse 28a [33.426]
 – & Cie., Messerschmiedwaren- und Haushaltungsartikelgeschäft, Marktgasse 63 [21.594]
 – & Co., W., vorm. Otto Schaerer, Knopf- u. Storenfabrik, Terrassenweg 18 [22.066]
@@ -39973,7 +39913,7 @@ Schärli, Arnold, Buchhändler, Neufeldstr. 118
 – Karl, Chauffeur, Jubiläumsstrasse 79
 – Rosa, Pension, Laupenstrasse 57
 Schärlig, Hans, -Handlanger, Badgasse 53
-– Joh.. Hilfsarbeiter,-Postgasse 34
+– Joh., Hilfsarbeiter,-Postgasse 34
 – Rudolf, Metzgermeister, Gerechtigkeitsg.il [31.726]
 Schärmeli, Franz Jos., Zeichner, Armandw. 8
 – Hugo, Koch, Schöneggweg 34
@@ -39983,7 +39923,7 @@ Schärz, s. Scherz
 Schätti, Ernst, Käser, Seilerstrasse 22
 – Rudolf C. (Müller), Geschäftsführer, Viktoriastrasse 35 [26.360]
 Schaetz, Adrien, Ingenieur, Engestrasse 15 [33.669]
-Schatzmann, Alb.. Buchdrucker (Rainmattstrasse 1 (34.827]), Monbijoustrasse 9 [29.331]
+Schatzmann, Alb., Buchdrucker (Rainmattstrasse 1 (34.827]), Monbijoustrasse 9 [29.331]
 – Alfred, Sektionschef Gen.-Dir. P. T. T., Hubelmattstrasse 20 [33.238]
 – Anna Maria (Kummer), Wwe., Kirchenfeldstrasse 55
 – Elsa. Bureaulistin. Schwarzenburgstr. 18
@@ -40014,8 +39954,8 @@ Schäublin, Ernst, pens. Beamter d. S. B. B., Opingenstrasse 37
 Schauenberg, Ernst Paul, Ing., Vizedirektor des eidg. Amtes für geistiges Eigentum, Ostring 32 [36.252]
 Schaufelberger, Ernst, Maschinenzeichner, Muesmattstrasse 34
 – Heinr., horloger, pendulier, Schwaneng. 7
-Schäuffele, Anna, Beamte S. B. B.. Neufeldstrasse 155
-– Elise, Beamte S. B. B.. Neufeldstrasse 155
+Schäuffele, Anna, Beamte S. B. B., Neufeldstrasse 155
+– Elise, Beamte S. B. B., Neufeldstrasse 155
 – Lisette (Gerber), Wwe., Neufeldstr. 155
 Schaupp, Franz (Hagnauer), Postgaragechef, Reichenbachstrasse 1
 Schauwecker, Walter, Vertreter, Mittelstr. 32 [21.794]
@@ -40103,7 +40043,7 @@ Scheidegger, Hans, Postangestellter, Gerechtigkeitsgasse 60
 – Herm., Bureaulist, Pestalozzistrasse 1
 – Herm. E., Schriftsetzer, Schwalbenweg 6
 – Jakob, Drogist, Junkerngasse 1
-– Jakob, pens. Pferdewärter. Breitenrainplatz 37
+– Jakob, pens. Pferdewärter, Breitenrainplatz 37
 – Joh., Sattler, Murifeldweg 60
 – Joh. Ulr., Schneidermeister, Standstr. 60
 – Joh., Wagenführer S. S. B., Unt. Villettenmattstrasse 11
@@ -40125,9 +40065,9 @@ Scheidegger, Hans, Postangestellter, Gerechtigkeitsgasse 60
 – Olga, Schneiderin, Wiesenstrasse 50
 – Otto, Packer, Schöneggweg 34
 – Robert, Friedhofverwalter, Ostermundigenstrasse 60 [41.095]
-– Rob., Maßschneiderei Robinson, Brunnhofweg 5 . [26.004]
+– Rob., Maßschneiderei Robinson, Brunnhofweg 5 [26.004]
 – Rosa (Mosimann), Damenschneiderin, Spitalgasse 3 [28.121]
-Rosa E.. Strickerin, Elisabethenstrasse 17
+Rosa E., Strickerin, Elisabethenstrasse 17
 – Rud. Alb., Färber, Wasserwerkgasse 4
 – Rud., Fabrikarbeiter, Felsenaustrasse 20
 – Rud., Fensterreiniger, Hopfenweg 31a
@@ -40199,7 +40139,7 @@ Schenk, E. Alb., in Fa. J. Schenk Söhne, Blumenbergstrasse 49 [22.392J
 – Ernst, jun., Orthopädiemechaniker, Jungfraustrasse 20
 – Ernst W., Hilfsarbeiter, Pestalozzistr.il
 – Ernst, Schreiner, Greyerzstrasse 29
-– Felix (Vacheron), Bandagist, Orthopädist,, Er. Schenk’s Nachf., Kornhausstrasse 4 [23.404]
+– Felix (Vacheron), Bandagist, Orthopädist., Er. Schenk’s Nachf., Kornhausstrasse 4 [23.404]
 – Fr., Schreinerei-Lehrmeister, Jubiläumsstrasse 56 [31.329]
 – Fr. Alb., Dr. phil., Sek.-Lehrer, Sulgenauweg 15
 – —Fr.’s Wwe., Stadtmühle (Gerbergasse 39 [21.261]), Mühlenplatz 11/15 [21.261]
@@ -40209,7 +40149,7 @@ Schenk, E. Alb., in Fa. J. Schenk Söhne, Blumenbergstrasse 49 [22.392J
 – Friedr. Rob., Chauffeur, Lentulusrain 30
 – Friedr., Handlanger, Murtenstrasse 250, Bümpliz
 – Friedr. (Binggeli), Hilfsarb., Waffenw. 19
-– Friedr.. Landarbeiter, Niederbottigenw. 84, Niederbottigen
+– Friedr., Landarbeiter, Niederbottigenw. 84, Niederbottigen
 – Friedr Al., Maler, Polygonweg 4
 – Friedr. O., Maler, Wylerstrasse 74
 – Friedr. Hans, Pferdewärter, Gerechtigkeitsgasse 20
@@ -40228,7 +40168,7 @@ Schenk, E. Alb., in Fa. J. Schenk Söhne, Blumenbergstrasse 49 [22.392J
 – Hans, Dr., Chem., Stockerenweg 23 [28.220]
 – Hans, Buchdruckerei (Stockerenweg 23 [28.220]), Allmendstrasse 9 [28.220]
 – Hans (Bangerter), Dr. med., Luisenstr. 41 [31.873]
-– Hans W., Hilfsarbeiter. Breiteweg 14
+– Hans W., Hilfsarbeiter, Breiteweg 14
 – Hans, Kaufmann, Gryphenhübeliweg 5 [27.345]
 – Hans E., Monteur, Niesenweg 10
 — Hans, Spengler, Aegertenstrasse 54
@@ -40299,8 +40239,8 @@ Schenk, Marie (Frey), Butter- u. Käsehdlg., Tulpenweg 3
 – Sophie Marie, Schneiderin, Jurastrasse 14
 – Walter Gottfr., Hilfsarbeiter, Hochfeldstr.61
 – Walter, Hilfsarbeiter, Schärerstrasse 19
-– Walter Friedr.. Kommis, Jubiläumsstr. 56
-– Walter. Kaufmann, Bottigenstr. 243, Qberbottigen
+– Walter Friedr., Kommis, Jubiläumsstr. 56
+– Walter, Kaufmann, Bottigenstr. 243, Qberbottigen
 – Walter, Postangest., Länggassstrasse 88
 – Werner, Wagenmaler, Kesslergasse 38
 – Wilhelm (Ehrsam). Kaufmann, Luternauweg 12 [21.054]
@@ -40312,9 +40252,9 @@ Schenkel, Alexander, Vertreter, Läuferplatz 8
 – Berta. Angestellte. Ob. Villettenmattstr. 6
 – Emil, Disponent, Spitalackerstrasse 27
 – Emil. Magazinchef P. T. T., Wiesenstr. 7 [35.148]
-– Ernst Rud.. Postangest. Pestalozzistr. 20
+– Ernst Rud., Postangest. Pestalozzistr. 20
 – Frieda (Bader 1 ), Wwe., Flurstrasse 33
-– Friedr.. Handlanger, Haldenweg 18
+– Friedr., Handlanger, Haldenweg 18
 – Hans G., Dr. oec. publ., Angestellter, Wernerstrasse 20 [26.104]
 – Hans Walter, Buchbinder, Schwarztorstr.82
 – Hans Armin, Kaufmann, Greyerzstr. 69
@@ -40328,19 +40268,19 @@ Schenker, Alb., pens Reparateur d. S. S. B., Bridtlstras.se 31
 – Ernst, Vertreter, Sickingerstr. 5 [27.567]
 – Kurt, Dr. jur., Direktor, Munstrasse 65lf [22.817]
 – Marg. M., kaufm. Angest., Wylerstr. 67
-– Otto. Dr., Beamter. Brunnadernstr 63a
+– Otto. Dr., Beamter, Brunnadernstr 63a
 – Otto, Dekorateur, Brunnadernstrasse 63
 Schenker, Rosa, Fabrikarbeiterin, Bridelstrasse 31
 – Theodor W., kaufm. Angest., Heckenweg 25
 – Viktor, pens. Lokomotivführer der S. B. B., Mittelstrasse 12
 – Walter, Handlanger, Bridelstrasse 31
 – Werner, Mechaniker, Weissensteinstr. 104
-– Werner (Jakob), Tramangestellter. Heckenweg 25
+– Werner (Jakob), Tramangestellter, Heckenweg 25
 Scheps, Paul, Vertreter, Wildermettweg 18 [28.003]
 Scherb, Emil (Moser), alt Zahnarzt, Kirchbühlwcg 43 [24.863]
 — Emma, Laborantin, Kirchbühlweg 43
 – -Gertrud, Kirchbühlweg 43
-– H.. Dr med. Arzt und Zahnarzt (Hallwylstrasse 26 [31.656]), Bärenplatz 2 [33.036]
+– H., Dr med. Arzt und Zahnarzt (Hallwylstrasse 26 [31.656]), Bärenplatz 2 [33.036]
 – Martha. Kirchbühlweg 43
 – Rita Sus., Bureaulistin, Hallwylstrasse 26
 Scherbart, Emma (Fuss), Wwe., Seilerstr. 27
@@ -40350,7 +40290,7 @@ Scherer, s. auch Schären, Schärer u Scherrer
 – E Max. Bankprokurist, Emanuel-Friedlistrasse 31
 – Emil, gewes. Abteilungschef b. d. Generaldirektion P. T. T., Erikaweg 7 [36.995]
 – Ida Hedwig, Bureaulistin. Erikaweg 7
-– Jos. O.. Mechaniker, Brückfeldstrasse 23
+– Jos. O., Mechaniker, Brückfeldstrasse 23
 – Margaritha S., Empfangsfräulein, Bühlplatz 4
 – Otto, Bundesbeamter, Beundenfeldstrasse 5 [26.022]
 – Otto, Kaufmann, Wylerstrasse 57
@@ -40358,8 +40298,8 @@ Scherer, s. auch Schären, Schärer u Scherrer
 – RenA Eisendreher Seidenweg 3
 Scherff, Johanna (Müller), Privatiere, Kapellenstrasse 6 [33.544]
 Scherl, Siegfr. E., Schriftsetzer, Elisabethenstrasse 37
-Scherler. Ad Alb.. Heizer S. B. B., Blumensteinstrasse 18
-– Alex.. Architekt in Fa. Scherler & Berger, Humboldtstrasse 53 [23.668]
+Scherler. Ad Alb., Heizer S. B. B., Blumensteinstrasse 18
+– Alex., Architekt in Fa. Scherler & Berger, Humboldtstrasse 53 [23.668]
 – Ernst, pens Abwart des Observatoriums, Forstweg 65 [32.453]
 – Ernst. Chauffeur S. 0 B., Sonneggring 12
 – Ernst, pens. Standesweibel, Viktoriastr. 47
@@ -40381,7 +40321,7 @@ Scherler, Louis, Autotransporte, Brunnhofweg 16 [34.237]
 — Sophie (Sommer), Wwe., Mercerie, Beundenfeldstrasse 51 [34.505]
 – & Berger, Architekturbureau, Schauplatzgasse 35 [28.321]
 – & Co., A.-G., elektr. Unternehmungen, Burgdorf, Filiale Bern, Viktoriastr. 47 [21.833]
-Schermann-Buchhaltung, Verlag Vereinfachte Buchhaltung A.-G.. Vertretung in Bern, Neuengasse 28 [23.336]
+Schermann-Buchhaltung, Verlag Vereinfachte Buchhaltung A.-G., Vertretung in Bern, Neuengasse 28 [23.336]
 – David, Kaufmann, Wyttenbachstrasse 13 [33.909]
 – Leo, Buchhaltungsbüro, Wyttenbachstr. 13
 – Wladimir, Schauspieler, Wyttenbachstr. 13
@@ -40390,7 +40330,7 @@ Scherrer, s. auch Schärer und Scherer
 – Hans, Treuhand-Revisions- und Verwaltungsbüro, Kapellenstrasse 28 [23.603]
 – Joh. (Widmer), kaufm. Angest., Könizstrasse 41
 – Joseph Paul, kaufm. Angest., Engestr. 1
-– Karl Fr.. Kioskhalter, Lorrainestrasse 63
+– Karl Fr., Kioskhalter, Lorrainestrasse 63
 – Louis Alph., Verbandssekretär, Altenbergstrasse 78
 – Max, Bauamtarbeiter, Langmauerweg 17
 – Max, Vernicklungsanstalt, Belpstrasse 47
@@ -40412,12 +40352,12 @@ Schertenleib, Albert, Gasarbeiter, Schönauweg 10a
 – Hans V., Geschäftsleiter, Länggassstr. 36 [31.373]
 – Jak., Elektromonteur, Scheihenstrasse 27
 – Joh., Schlosser, Brunngasse 44
-– Margr. L., Ladentochter. Marktgasse 37
+– Margr. L., Ladentochter, Marktgasse 37
 – Marie (Dellenbach), Wwe., Angestellte, Brückenstrasse 15
 – Olga, Bureaulistin. Brünigweg 28
 – Robert, Wärter, Murifeldweg 67
 – Walter, Postangestellter, Zähringerstr. 59
-Scherz, Ad.. Bundesweibel. Freiestrasse 4
+Scherz, Ad., Bundesweibel. Freiestrasse 4
 — Adolf, Wwe., Velo-Zentrale, Monbijoustrasse 10 [29.443]
 – Alfr., Buchhändler, i. Fa. Alfr. Scherz & Co., Kirchenfeldstrasse 52a [35.267]
 Scherz, Arnold G., pens. Kondukteur, Breitenrainstrasse 67 [27.107]
@@ -40439,7 +40379,7 @@ Scherz, Arnold G., pens. Kondukteur, Breitenrainstrasse 67 [27.107]
 – Hermann, Dr. med., Arzt, Adjunkt d. Generalsekretariats d. Schweiz. Roten Kreuzes, Beundenfeldstrasse 12 [29.089]
 – Herm. A. W., Kaufmann, Schwarztorstr. 7 [29.597]
 – Hulda M., Bureaulistin, Bridelstrasse 56
-– Joh.. Kaufmann, Zielweg 27
+– Joh., Kaufmann, Zielweg 27
 – Joh., Postangestellter, Falkenweg 5
 – Lina Emma, pens. Posthalterin, Lorbeerstrasse 7, Bümpliz
 – Marg., Bureaulistin, Breitenrainstrasse 67 [27.107]
@@ -40486,13 +40426,13 @@ Scheurer, Alexander E., Kaufmann, Jubiläumsstrasse 73 [34.274]
 – Emil, Beamter, Florastrasse 26
 – Emil, Drogist, Florastrasse 26
 – Emil, Monteur, Wylerringstrasse 86
-– Friedr.. eidg. Beamter, Effingerstrasse 59
+– Friedr., eidg. Beamter, Effingerstrasse 59
 – Fritz, Elektriker, Keltenstr. 95, Bümpliz
 – Hans R., Bankprokurist, Balmweg 23 [34.419]
-– Hans O.. Masch.-Zeichner, Schützenw. 15
+– Hans O., Masch.-Zeichner, Schützenw. 15
 – Helene A. (Demmler), Ob. Dufourstr. 31
 – Karl H., Velomechan., Maulbeerstrasse 5
-– Kurt Rob.. Fürsprecher, Ob. Dufourstr. 31
+– Kurt Rob., Fürsprecher, Ob. Dufourstr. 31
 – Marie, Frl., Arbeitslehrerin, Diesbachstr. 9
 – Marie Magd., Zigarrengeschäft, Aegertenstrasse 73. [29.871]
 – Marie, Strickerin, Schauplatzgasse 29
@@ -40551,7 +40491,7 @@ Schiess, Albert, Schuhmacher, Hallerstr. 22
 – Robert, Spengler. Moritzweg 28
 – Sophie Hedwig (Tanner), Wylerstr. 83
 – Walter, Telegraphist, Thunstr. 5 [32.056]
-Schiesser, Anna El., Ladentochter. Murifeldweg 5
+Schiesser, Anna El., Ladentochter, Murifeldweg 5
 – Anna Barbara, Wwe., Hopfenweg 33
 – David (Glauser), Murifeldweg 5
 – Ernst, Chauffeur S. O. B., Hopfenweg 33
@@ -40568,7 +40508,7 @@ Schiferli, Schifferli u Schieferli
 – Marie (Howald), Wwe., Turnweg 18
 – Otto Paul, Elektromonteur, Zentralweg 16
 Schiffleuten, Zunfthaus, Kramgasse 68
-Schiff mann, Jul. Christ., eidg. Beamter. Liebeggweg 22 [32.315]
+Schiff mann, Jul. Christ., eidg. Beamter, Liebeggweg 22 [32.315]
 – Marg. Kl., Sekretärin, Sennweg 11
 – Rosa, Damenschneiderin, Neuengasse 14
 Schild, s. auch Schilt
@@ -40596,14 +40536,14 @@ Schilling, Ernst, Registrierkassen, Jubiläumsstrasse 53 [33.329]; Musterlager: 
 – Frieda Damenschneiderin, Wildhainweg 12
 – Hans (Nagat), Sekretär, Schwarztorstr. 21 [25.826]
 – Helmut, Dr. phil., «Weltwoche», Jubiläumsstrasse 53 [33.329]
-– Joh.. Schuhhandlung und Massgesohäft.
+– Joh., Schuhhandlung und Massgesohäft.
 Belpstrasse 67 [23.153]
 – Jos. A., Photograph, Genfergasse 8
 – K. A., Coiffeur. Lorrainestrasse 11
-– Marie (Münger). Wwe.. Wyttenbachstr. 36
+– Marie (Münger). Wwe., Wyttenbachstr. 36
 – Thomas. Schneider. Wildhainweg 12
 – Wilh., Dr. oec., Tillierstrasse 50
-– Wilh K.. Bankbeamter. Falkenböhew. 16
+– Wilh K., Bankbeamter, Falkenböhew. 16
 Schillinger, Friedr., Schneider. Moserstr. 24
 Schilt, s. auch Schild
 – Emma R., Bureaulistin, Humboldtstr. 29
@@ -40641,14 +40581,14 @@ E. Zingg (Alleew. 19), Karl-Schenk-Haus, Spitalgasse 4 [34.664]
 – Ernst, Wäscher, Aareggweg 7
 – Fridolin, Hotelier, Seidenweg 8
 – Frieda (Schilt), Damenschneiderin, Brünnenstrasse 41, Bümpliz
-– Friedr., eidg. Beamter. Weingartstrasse 43
+– Friedr., eidg. Beamter, Weingartstrasse 43
 – Friedr. Nikl., städt. Beamter, Wylerstr. 55
 – Friedr. Alex., Klaviermacher, Länggassstrasse 108 [20.619]
 – Friedr., Kolonialwaren-, Früchte- und Gemüsehandlung, Tillierstrasse 17 [24.423]
 – Friedr., Maler, Eggimannstrasse 21
 – Friedr., pens. Telephonarb., Schreinerw. 13
 – Friedr. R., Gipser und Maler, Eggimannstrasse 21
-– Friedr.. Magaziner, Breitenrainstrasse 31
+– Friedr., Magaziner, Breitenrainstrasse 31
 – Fritz, Hilfsarbeiter, Wylerringstrasse 45
 – Fritz (Köhli), Materialchef, Postgasse 18
 – Gustav Ad., Schlosser, Herzogstrasse 6
@@ -40664,7 +40604,7 @@ Schindler, Hans Ernst, Wäscherei, Neuhäuserweg 8 [35.929]
 – Ida, Kinderwagen u. Säuglingsausstattung (Zähringerstrasse 31), Kramg. 59 [32.589]
 – Ida, Rudolf-Wyssweg 8
 – Jb., pens. Lok.-Führer, Sennweg 5
-– Jb.. Dr., Dozent, Zahnarzt (Alpenstrasse 32 [35.963]), Spitalgasse 4 (Karl-Schenk-Haus) [22.543]
+– Jb., Dr., Dozent, Zahnarzt (Alpenstrasse 32 [35.963]), Spitalgasse 4 (Karl-Schenk-Haus) [22.543]
 – Joh. Kondukteur, Falkenplatz 7
 – Joh., priv., Gryphenhübeliweg 39 [26.216]
 – Joh. Gottl., Sekuritaswächter, Kehrg. 10, Bümpliz
@@ -40675,13 +40615,13 @@ Schindler, Hans Ernst, Wäscherei, Neuhäuserweg 8 [35.929]
 – Maria (Lysser), Wwe., Erlenweg 18
 – Marie, Coiffeuse, Grundweg 14
 – Marie, Falzerin, Gerbergasse 18
-– Marie Lse.. Jackettmacherin, Beundenfeldstrasse 12
+– Marie Lse., Jackettmacherin, Beundenfeldstrasse 12
 – Marie Luise. Engehaldenstrasse 91 [20.094]
 – Martha, Bureaulistin, Fischermätteliweg 17
 – Max, Bankangest., Wylerstr. 10 [33 146]
 — Paul, kant. Angestellter, Stauffacherstr. 46
-– Paul. Bahnarbeiter. Kehrg 10. Bümpliz
-– Rob., Hilfsarbeiter. Gerechtigkeitsgasse 46
+– Paul. Bahnarbeiter, Kehrg 10. Bümpliz
+– Rob., Hilfsarbeiter, Gerechtigkeitsgasse 46
 – Röb. (Anker). Bandagist. Inhaber der Fa.
 Schindler-Probst’s Sohn, Wylerstrasse 10 [33.1461
 – Rosa. Sekundarlehrerin, Rudolf-Wyssweg 8 [34 150]
@@ -40689,7 +40629,7 @@ Schindler-Probst’s Sohn, Wylerstrasse 10 [33.1461
 – Rosa (Rüfenacht), Wwe., Weissnäherin, Stockerenweg 11
 – Rosine Sehreinerweg 13
 – Rud., Maler. Stalden 16
-– Rud., in Fa. Rud. Schindler & Co.. Bollwerk 31 [32 701]
+– Rud., in Fa. Rud. Schindler & Co., Bollwerk 31 [32 701]
 – Rud., Schuhmacher. Neufeldstrasse 38
 – & Co Rud., Spezialhaus für Berufskleider, Bollwerk 31 [33.4331
 — -Probst’s Sohn. Sanitätsgeschäft, Bandagist, Orthopädist, Amthausg. 20 [21.656]
@@ -40702,13 +40642,13 @@ Schltlowsky, Marie, Fürsprecherin, Wernerstrasse 14 [20.773]
 Schittll, Emma, Krankenschwester, Niesenweg 3
 Schlachter, J. Ferdinand, Architekt, Morellweg 4
 – Maria, Sprachlehrerin, Schosshaldenstr. 23 [35.495]
-– Marie (Jakob), Wwe.. Schosshaldenstr. 23 [35.495]
+– Marie (Jakob), Wwe., Schosshaldenstr. 23 [35.495]
 Schlachthaus, altes, Metzgergässchen 1 und Motziiorirasse 22
 Schlachthof (Zentral- und Gemeinde-), Stauffacherstrasse 80-100 Verwaltung u. Kasse: [20.4621. Schlachthallen: [20.464]
 Schladitz, Arthur Gustav, Direktor, Cäcilienstrasse 38 [32.275]
 — Gust Ad Musiker. Cäcilienstrasse 46
 Schlaefli, Fritz [23.849] (vorm. Carl Grüring), Sachwalter, Liegenschaftsvermittlung, Verwaltungen etc., Spltalgasse 14
-Schläfli, Alb.. Metzger. Gerbergasse 14
+Schläfli, Alb., Metzger. Gerbergasse 14
 – Alb., Postkommis, Bubenbergstrasse 34
 – Alfred, Speditionsfakteur, Waldheimstr. 21
 – Bertha, Flau, Rest. Länggasse, Kesslerg. 7 [22.412]
@@ -40722,11 +40662,11 @@ Schläfli, Alb.. Metzger. Gerbergasse 14
 – Ernst, Kaufmann, Greyerzstrasse 30
 – Ernst Paul, Lentulusstrasse 53
 – Frieda Anna. Angestellte. Oerhergasse 14
-– Frieda (Srhmid). Angest.. Freiestrasse 33
+– Frieda (Srhmid). Angest., Freiestrasse 33
 – Frieda. Pflegerin, Kehrgasse 57. Bümpliz
 – Frieda. Frau. Kunsthdlg., Einrahmungsgeschäft u. Glaserei (Berchtoldstrasse 7), Marktgasse 44 [28.686]
 – Frieda H., Bureaulistin, Kanonenweg 16
-– Fr.. Kaufmann. Kanonenweg 16 [33.353]
+– Fr., Kaufmann. Kanonenweg 16 [33.353]
 – Friedr., Kellermeister, Murifeldweg 11
 – Fritz, Schneidermeister, Rodtmattstr. 66
 – Fritz, Maschinist E. W. B., Frohbergweg 7
@@ -40752,13 +40692,13 @@ Schläfli, Otto, Hilfsarbeiter, Freiburgstr. 440, Bümpliz
 – Rudolf, Konditor, Marktgasse 20
 – W., Messerschmied, Neuengasse 16
 – Walter, Hilfsarbeiter, Militärstrasse 26
-– Walter E.. kaufm. Angest., Zähringerstr. 43
+– Walter E., kaufm. Angest., Zähringerstr. 43
 – Walter, Maler, Freiburgstr. 440, Bümpliz
 – Walter, Spenglerei u. Installat. (Mühlemattstrasse 14a), Schwarztorstr. 27 [27.520]
 – Willy, Postbeamter, Feilenbergstrasse 5a
 Schlafwagengesellschaft, Internation., Bubenbergplatz 9 [20.022]
 Schlanser, Andreas, Dr. jur., eidg. Beamter, Schwarztorstrasse 32
-Schlapbach, Ernst H., Bäckermeister. Bierhübeliweg 29 [20.315]
+Schlapbach, Ernst H., Bäckermeister, Bierhübeliweg 29 [20.315]
 – Ernst Bauarbeiter, Stöckackerstrasse 83, Bümpliz
 – Ernst, Maschinenschlosser, Wylerfeldstr. 44
 – Hans, Tapezierermeister u. Polsterer, Gewerbestrasse 31
@@ -40828,7 +40768,7 @@ Schlegel, Agnes P. E., Jubiläumsstrasse 58
 – Alb., Giesser, Gruberstrasse 20
 – Alb., Weichenwärter, Eggimannstrasse 27
 – Alice, Mützenmacherin, Attinghausenstr. 21
-– Anna Luise (Frutig), Wwe.. Lentulusstrasse 41
+– Anna Luise (Frutig), Wwe., Lentulusstrasse 41
 – Dorothea M., Bureauangestellte, Sulgenbachstrasse 14
 – Ernst, Schneidermeister, Werkgasse 25, Bümpliz
 – Ernst, Postangestellter, Beaumontweg 1
@@ -40882,7 +40822,7 @@ Schlosser, Armin J., Feinmechaniker, Wagnerstrasse 24
 – Gottfr., pens. Beamter S. B. B., Seidenw. 49 [25.889]
 – Gottfr., Elektrotechniker d. S. B. B., Engeriedweg 5 [20.339]
 – Hans, Typograph, Niggelerstrasse 12
-– Heinr.. Redaktor, Freieckweg 5, Bümpliz
+– Heinr., Redaktor, Freieckweg 5, Bümpliz
 – Joh., Ghefmonteur, Wagnerstr. 24 [20.351]
 – Josef, Schuhmachermeister, Kramgasse 47
 – Karl, Dr. med., Kinderarzt, Effingerstr. 8 [23.822]
@@ -40965,11 +40905,11 @@ Schmalz, Adr. W., Mechan., Kasernenstr. 44
 – Alb., Notar, gew. Beamter d. Hypothekarkasse, Jubiläumsstrasse 49
 – Alice Frieda, Damenschneiderin, Seftigenstrasse 71
 – Alois (Hertig), Kartograph, Jubiläumsstrasse 56
-– Anna (Grogg), Wwe., Lorrainestrasse la
+– Anna (Grogg), Wwe., Lorrainestrasse 1a
 – Gh. Klara, Ladentochter, Kasernenstr. 44
 – Erika, Bureaulistin, Seftigenstrasse 71
 – Fritz, Angestellter, Schützenweg 23
-– Gertrud, Ladentochter. Lorrainestrasse la
+– Gertrud, Ladentochter, Lorrainestrasse 1a
 – Hans, Chef des Baudienstes der K. T. D., Hochfeldstrasse 94 [25.154]
 – Hans W., Journalist, Hochfeldstrasse 94 [25.154]
 – Hedwig, Nachf. von P. Glauser, Modengeschäft (Jubiläumsstrasse 49), Marktg. 41 [21.845]
@@ -40977,9 +40917,9 @@ Schmalz, Adr. W., Mechan., Kasernenstr. 44
 – Jules (Honegger), Kommis, Wyttenbachstrasse 30
 – Klara Ida, Lehrerin, Heimstr. 26, Bümpliz
 – Margaretha Lina, Bureaulistin, Hochfeldstrasse 94 [25.154]
-– Rosa (Graf). Wwe.. Wyttenbachstrasse 29
+– Rosa (Graf). Wwe., Wyttenbachstrasse 29
 – Rosalie V., Bureaulistin, Kasernenstr. 44
-– Walter, Postangest.. Beundenfeldstr. 19
+– Walter, Postangest., Beundenfeldstr. 19
 Schmehl, Ehe Maria (Butti), italien. Sprachlehrerin, Schwarztorstrasse 17 [36.853]
 – Fr. Wilh., Kaufmann, Schwarztorstr. 17 [36.853]
 Schmid und Schmied, siehe auch Schmidtund Schmitt
@@ -40987,8 +40927,8 @@ Schmid und Schmied, siehe auch Schmidtund Schmitt
 – A. M. K. (Steiner), Wwe., Pension, Falkenplatz 3 [27.296]
 – Abundi, eidg. Beamter, Lorystrasse 8
 – Adele, Damenschneiderei-Atelier. Wyderrain 1
-– Adelheid B.. Bankangest., Ob. Dufourstr. 11
-– Adolf. Depotchef S. B. B.. Depotstrasse 33
+– Adelheid B., Bankangest., Ob. Dufourstr. 11
+– Adolf. Depotchef S. B. B., Depotstrasse 33
 – Ad., Sekretär d. O. T. D., Finkenrain 13 [22.925]
 – Adolfs Erben, A.-G., Fabrikation techn
 Fette und Oele. Strassenbauprodukte. Murtenstrasse 135 [27.140], Bureaux: Effingerstrasse 17 [27.844]
@@ -40996,7 +40936,7 @@ Schmid und Schmied, siehe auch Schmidtund Schmitt
 – Alb Bauamtarbeiter, Wylerringstr 52d
 – Albr., Grubenarbeiter, Freiburgstr. 505 c, Bümpliz
 – Alb., Handlanger, Lorrainestrasse 2a
-– Albert E.. Maler, Wylerringstrasse 52d
+– Albert E., Maler, Wylerringstrasse 52d
 – Albert, Gärtner, Gruberstrasse 10
 – Albr., Pferdewärter, Breitfeldstrasse 52
 – Alex. (Bigler). Mass- u. Konfektionsgesch., Hotelgasse 6 [32.125]
@@ -41004,7 +40944,7 @@ Schmid und Schmied, siehe auch Schmidtund Schmitt
 – Alfr., Dr. med., Spezialarzt für Nieren- n.
 Blasenkrankheiten. Elektro- und Strahlen-Therapie, Thormannstrasse 48 [23.197]
 – Alfr. W. M., Hilfsarbeiter, Läuferplatz 6
-– Alfr., kaufm. Angestellter. Lentulusstr 79
+– Alfr., kaufm. Angestellter, Lentulusstr 79
 – Alfr. Gottl., Mechaniker, Mattenhofstr. 35
 – Alfred, Notar, Notariats- u. Verwaltungsbureau (Seftigenstr. 10h [35.544]), Waaghausgasse 1 [24.649]
 – Alfr., & Cie., Buchdruckerei, Schwarztorstrasse 36 [28.242]
@@ -41019,7 +40959,7 @@ Blasenkrankheiten. Elektro- und Strahlen-Therapie, Thormannstrasse 48 [23.197]
 – Anna (Rychener), Wwe., Länggassstr. 12 [34.957]
 – Anna, Pensionsinhaberin, Kapellenstr. 6
 – Anna (Mader), Wwe., Klösterlistutz 4
-– Anna (Müller). Wwe.. Obstbergweg 10
+– Anna (Müller). Wwe., Obstbergweg 10
 – Anna. Wwe., Schwanengasse 7
 – Antoine, fils, Kürschnerei, Pelzwaren und Felle, Kornhausplatz 2 [27.932]
 – Anton, Techniker, Pestalozzistrasse 13
@@ -41027,18 +40967,18 @@ Blasenkrankheiten. Elektro- und Strahlen-Therapie, Thormannstrasse 48 [23.197]
 – Arthur, Schuhmachermeister, Mattenhofstrasse 10
 – Bend. Friedr., Frikartweg 6
 – Bernhard, Dr., Bibliothekar, Kramgasse 14 [29.913]
-– Bertha. Tapezierer-Atelier, Römerweg 13
+– Bertha, Tapezierer-Atelier, Römerweg 13
 – Cecile, Gehilfin, Kesslergasse 32
 – Christ., Lederzuschneider. Finkenrain 7
 – Christ. Alfr., Schlosser, Alleeweg 31
 – Daniel Fritz, Buchbinder. Dalmazirain 40
-– Daniel, Maschinenarbeiter. Gerbergasse 22
+– Daniel, Maschinenarbeiter, Gerbergasse 22
 – Dora Judith, Apothekerin, Kramgasse 21 [21.728]
 – Dora KL, Bureaulistin, Länggassstr. 68d
 – Edmund, Dr. med., Arzt, Holligenstrasse 3
 – Ed., eidg. Beamter, Klösterlistutz 10 [32.615]
 – Ed., eidg. Beamter, Greyerzstrasse 45
-– Ed.. Hilfsarbeiter. Papiermühlestrasse 11a
+– Ed., Hilfsarbeiter, Papiermühlestrasse 11a
 – Ed., Maler, Scheibenstrasse 17
 – Eduard Robert. Kondukteur, Länggassstrasse 106
 – Eduard, Regierungsrat, Monbijoustr. 134
@@ -41061,7 +41001,7 @@ Schmid und Schmied, siehe auch Schmidtund Schmitt
 – Emil, Beamter d. O. P. D., Brückfeldstr. 21
 – Emil. Hilfsarbeiter, Jurastrasse 77
 – Emil. Krankenwärter, Postgasse 32
-– Emil. Pferdewärter. Wiesenstrasse 44
+– Emil. Pferdewärter, Wiesenstrasse 44
 – E. (Arn), gew. Prokurist der Ziegelei Tiefenau A.-G., Ob Aareggweg 38 [21.812]
 – Emil, Schuhmachermstr. (Bethlehemstr. 115, Bümpliz), Chalet Tramhalt Brunnhof, Brunnmattstrasse
 – Emma (Keller), Glätterei, Greyerzstr. 36 [32.307]
@@ -41071,7 +41011,7 @@ Schmid und Schmied, siehe auch Schmidtund Schmitt
 – Ernst Alb, Angest., Ladenwandstrasse 84
 – Ernst, Architekturbureau, Sulgenauweg 18 [23.670]
 – Ernst M., Automechaniker, Kramgasse 24
-– Ernst Hs.. Chauffeur. Scheibenstrasse 32
+– Ernst Hs., Chauffeur. Scheibenstrasse 32
 – Ernst Osk., Dr. jur., Fürsprecher (Jubiläumsstrasse 33 [28.589]), Bundesplatz 2 [25.651]
 – Ernst, Dr. med. vet., Stadttierarzt, Tillierstrasse 38 [34.106]
 – Ernst. Eigerdrogerie (Werdtw. 11 [36.276]), Eigerplatz [23.210]
@@ -41132,9 +41072,9 @@ Schmid & Co., Bahnhof-Drogerie, Effingerstrasse 101 [36.046]
 – Fritz, Redaktor, Kirchgasse 12
 – Fritz, Südfrüchtehändler, Seidenweg 20
 – Germaine L., Ladentochter, Fischerweg 16
-– Gottfr.. Apotheker, Kramg. 21 [21.728]
+– Gottfr., Apotheker, Kramg. 21 [21.728]
 – Gottfr. W., Maschinenmeister, Lorrainestrasse 18
-– Gottfr., Postangestellter. Bundesrain 14
+– Gottfr., Postangestellter, Bundesrain 14
 – Gottfr., Zimmermann, Sulgenauweg 18
 – Gottl., Bahnangest.,. Ghaletweg 6, Bümpliz
 # Date: 1935-12-15 Page: 26020743/436
@@ -41149,7 +41089,7 @@ Schmid und Schmied, siehe auch Schmidtund Schmitt
 – Hans, Fabrikarbeiter, Falkenplatz 5
 – Hans A. (Amsler), Insp. der Hypothekarkasse d. Kts. Bern, Tillierstr. 56 [35.870]
 – Hans, Kanzlist, Chaletweg 6, Bümpliz
-– Hans, Mechaniker, Flurstrasse la
+– Hans, Mechaniker, Flurstrasse 1a
 – Hans, Pferdewärter, Rodtmattstrasse 97
 – Hans, Polisseur, Tscharnerstrasse 27
 – Hans, Schlosserei u. Drahtwarenfabrikation, Junkerngasse 28 [35.560]
@@ -41194,17 +41134,17 @@ Schmid und Schmied, siehe auch Schmidtund Schmitt
 – Joh. Friedr., Schuhmacher, Ouartierhof 1
 – Joh. Friedr., Zimmermann, Lerchenweg 20
 – Johanna Emma, Bureaulistin der O. T. D., Obstbergweg 10
-– Jos.. Damencoiffeur, Neubrückstrasse 70
+– Jos., Damencoiffeur, Neubrückstrasse 70
 – Jos. Ludw., Oberingenieur, Neufeldstr. 120 [24.232]
 – Jos., Weissenbühl-Apotheke und Drogerie, Seftigenstrasse 23 [22.282]
 – Jos. (Zingg), Cafe Kornhausplatz, Kornhausplatz 5
 – Josef, Steindrucker, Scheibenstrasse 22
 – Joseph, Mechaniker, Metzgergasse 35
 – Josephine (Weber), Manuelstrasse 83
-– Jul. A.. Hausierer, Metzgergasse 78
+– Jul. A., Hausierer, Metzgergasse 78
 – Karl, Coiffeur, Lorrainestrasse 18
 – Karl, Heizungstechn., in Fa. Schmid & Böhlen, Wylerstrasse 43 [26.286]
-– Karl, Hilfsarbeiter. Schöneggweg 34
+– Karl, Hilfsarbeiter, Schöneggweg 34
 – Karl, Kaufm., Friedheimweg 53 [20.992]
 – Karl, Masch -Techn., Standstrasse 4
 – Karl,. Monteur, Hirschengraben 10
@@ -41216,8 +41156,7 @@ Schmid und Schmied, siehe auch Schmidtund Schmitt
 – Lina, Zigarrenhandlung, Kesslergasse 21
 – Lina Sophie, Damenschneiderin, Freiburgstrasse 350, Bümpliz
 – Louis, kaufm. Angest., Aarbergergasse 11
-– Ludwig, Fürsprecher, Gerichtspräsident.
-Wiesenstrasse 24 . [25.044]
+– Ludwig, Fürsprecher, Gerichtspräsident, Wiesenstrasse 24 [25.044]
 – Luise, Militärschneiderin, Breitfeldstr. 33
 – Luise, Aufseherin, Brunnmattstrasse 38a
 – Lydia E., Tapeziererin, Turnweg 12
@@ -41232,7 +41171,7 @@ Wiesenstrasse 24 . [25.044]
 – Maria., Vorsteherin, Zeughausgasse 39
 – Maria M., Stickerin. Viktoriarain 12
 – Marie (Günter), Abwartin, Kramgasse^
-– Marie (Weber), Wwe., Gesellschaftsstr.. 19
+– Marie (Weber), Wwe., Gesellschaftsstr., 19
 # Date: 1935-12-15 Page: 26020744/437
 Schmid und Schmied, siehe auch Schmidtund Schmitt
 – Martha, Bureaulistin, Greyerzstrasse 37 [20.067]
@@ -41272,8 +41211,8 @@ Schmid und Schmied, siehe auch Schmidtund Schmitt
 – Rob., Schneider, Bitziusstrasse 33
 – Rosa, Klavierlehrerin, Junkerngasse 15
 – Rosa, Ladentochter, Chaletweg 6, Bümpliz
-– Rosa M., Ladentochter. Lorrainestr. 18
-– Rosa E.. Verkäuferin, Engestrasse 54
+– Rosa M., Ladentochter, Lorrainestr. 18
+– Rosa E., Verkäuferin, Engestrasse 54
 – Rosa, Falzerin, Maulbeerstrasse 9
 – Rosa (Wyder), Wäscherei u. Feinglätterei, Turnweg 12 [32.551]
 – Rosalie Frieda, Bureaulistin, Trachselw. 17
@@ -41390,7 +41329,7 @@ Schmidt, s. auch Schmid und Schmitt
 – Max A., Klaviermacher, Münzrain 1
 – Max Emil. Schreiner. Weihergasse 7
 – Max O., Musiker, Greyerzstrasse 49
-– -Moritz L., Schlosser, Unt. Aareggweg la
+– -Moritz L., Schlosser, Unt. Aareggweg 1a
 – R. (Herzig), Wwe., Marzilistrasse 2a
 – Rieh. Hugo, Kellner, Greyerzstrasse 34
 – Robert, Portefeuille-Verwaltung der Norwich-Union (Gurten-Gartenstrasse 7, Wabern [45 643]), Laupenstrasse 2 [21.699]
@@ -41400,7 +41339,7 @@ Schmidt, s. auch Schmid und Schmitt
 – Walt. Ernst, Maler, Freieckw. 16, Bümpliz
 – Walter, Tiefbautechniker, Jurastrasse 5
 – Wilh., Schreiner, Landweg 8
-– & Co.. H., Automobile, Belpstrasse 30b [23 233]
+– & Co., H., Automobile, Belpstrasse 30b [23 233]
 Schmidt-Flohr, A. [23.75?] A.-G. Ausstellung u. Verkauf: Marktg. 34 [22.848], Fabrik u. Bureau: Fabrikstrasse 13/19. Pianos u. Flügel. Reparaturen sämtl. Marken. Transporte, Stimmungen
 Schmidter, Lina (Müller), Wwe., Schänzlistrasse 19
 Schmieden, Zunftgebäude, Marktgasse 10 und Zeughausgasse 5
@@ -41435,7 +41374,7 @@ Schmitz, Fanny (Zweig), Wwe., Privatiere, Effingerstrasse 48 [31.214]
 – Gertrud M., Hilfskassierin, Länggassstr.70c [28.918]
 – Paul. Maler. Moserstrasse 22
 – Pauline (Haag), Wwe., Knabenschneiderin, Moserstrasse 22
-– Robert Aug., Dr. phil.. Kunstmaler und Bildhauer, .Kramgasse 83 [27.529]
+– Robert Aug., Dr. phil., Kunstmaler und Bildhauer, Kramgasse 83 [27.529]
 Schmocker, Adolf, Handlanger, Rodtmattstrasse 110
 – Alfred. Portier, Bolligenstrasse 117
 – Charles Emile, Vertreter, Gutenbergstr. 11 [22 1731
@@ -41456,12 +41395,12 @@ Schmuki, Ad., Installateur, Murifeldweg 59
 – Joh. Heinr., Malermeister, Postgasse 20 [34.063]
 Schmutz, Ad., Milchhändler, Breitfeldstr. 32
 – Ad. W., Bäcker, Metzgergasse 57
-– Alb.. Restaurant. Aarbergerg. 52 [22.253]
+– Alb., Restaurant. Aarbergerg. 52 [22.253]
 – Alfred, Asphalter, Weissensteinstrasse 24b
 – Alfred, Hilfsarbeiter, Alleeweg 2
 – Anna, Pensionshalterin, Monbijoustr. 24 [24.489]
 – Chs. G., Mech. S. B. B., Zähringerstr. 25
-– E.. Schlosser, Brünnenstr. 106, Bümpliz
+– E., Schlosser, Brünnenstr. 106, Bümpliz
 – Elise, Pension, Monbijoustr. 24 [24.489]
 – Emil, pensionierter Beamter der S. B. B., Postgasse 44
 – Emilie (Buchs), Wwe., Zieglerstrasse 66
@@ -41475,11 +41414,11 @@ Schmutz, Ernst, Telegr.-Angestellter, Weissensteinstrasse 24b
 – Ernst, Wasserleitungs-Installateur, Thunstrasse 105a
 – Ferd., Hauswart, Bernastrasse 23
 – Franz, Buchhalter, Mühlemattstrasse 43
-– Frieda, Ladentochter. Breitfeldstrasse 32
+– Frieda, Ladentochter, Breitfeldstrasse 32
 – Frieda, Schneiderin, Wylerringstrasse 59
 – Friedr., Obermüller, Gerbergasse 39
 – Friedr., pens. Wegmeister, Moritzweg 22
-– Friedr.. Wegmeister, Wylerringstrasse 59
+– Friedr., Wegmeister, Wylerringstrasse 59
 – Fritz. Magaziner, Hopfenweg 43
 – Fritz, Bauarbeiter, Herrengasse 25
 – Fritz, Polizist. Weingartstrasse 57
@@ -41505,16 +41444,16 @@ Schmutz, Ernst, Telegr.-Angestellter, Weissensteinstrasse 24b
 – Magdalena, Postgasse 58
 – Marie Ida, Lingere, Hopfenweg 43
 – Martha E. Bureaulistin. Zieglerstrasse 66
-– Oskar Aug.. Bremser der S. B. B., Waldheimstrasse 10a
+– Oskar Aug., Bremser der S. B. B., Waldheimstrasse 10a
 – Otto, Chauffeur, Chutzenstr. 41 [20.329]
 – Paul Jakob, Gärtner, Turnweg 18
 – Paul. pens. Sekretär d. Handelsabtlg. d.eidg. Volkswirtsehaftsdepart., Breitenrainstrasse 15 [32.683]
 – Robert, Reisender, Zieglerstrasse 66
 – Robert, Automechaniker, Metzgergasse 46
 – Rosa, Ladentochter, Monbijoustrasse 24
-– Rosa. Ladentochter. Moritzweg 22
+– Rosa. Ladentochter, Moritzweg 22
 – R. (Soltermann), Wwe., Zentralweg 22
-– Rudolf, kant. Beamter. Cäcilienstrasse 4
+– Rudolf, kant. Beamter, Cäcilienstrasse 4
 – Rudolf, gew. Wagenführer S. S. B., Alleeweg 2
 – Walter, Hilfsarbeiter, Gesellschaftsstr. 16
 – Walter, Ausläufer, Alleeweg 2
@@ -41619,7 +41558,7 @@ Schnegg, Ernst Rudolf, Bierleitungs-Reinigungsgeschäft, Aarbergergasse 5
 – Gebr., Wirtschaft, Aarbergerg. 5 [27.461]
 Schneider, s. auch Schneiter und Schnyder
 – A., Bureauangestellter, Sonneggsteig 6
-– A., Liegenschaftsverwalter der B. K. W,, Neubrückstrasse 104 [31.499]
+– A., Liegenschaftsverwalter der B. K. W., Neubrückstrasse 104 [31.499]
 – Ad. (Meyer), Zeichenlehrer am städt. Progymnasium, Stauffacherstrasse 31
 – Adele, Frau, Berchtoldstrasse 31
 – Adelheid, Hilfsarbeiterin, Polygonweg 15
@@ -41629,8 +41568,7 @@ Schneider, s. auch Schneiter und Schnyder
 – Alb., Hilfsarbeiter, Schönburgstrasse 26
 – Alb., kaufm. Angestellter, Muristrasse 54
 Für Touren und Reisenist der Touristen-Fahrplan (Verlag
-Hallwag, Bern) ein zuverlässiger Begleiter, der Ihnen auch interessante Vorschläge für
-Ausflüge vermittelt.
+Hallwag, Bern) ein zuverlässiger Begleiter, der Ihnen auch interessante Vorschläge für Ausflüge vermittelt.
 # Date: 1935-12-15 Page: 26020748/441
 Schneider, s. auch Schneiter u. Schnyder
 – Alb., Bureauangestellter, Sonneggsteig 6
@@ -41644,7 +41582,7 @@ Jura, Murifeldweg 69 [20.7413]
 – Alfr., Chauffeur, Gerbergasse 7b
 – Alfr. (Schiffmann), Hilfsmonteur, Wittigkofenweg 23
 – Alfr., Koch, Sennweg 7
-– Alfr.. Monteur, Gewerbestrasse 21
+– Alfr., Monteur, Gewerbestrasse 21
 – Alfr. W. R., Dr. med. dent., Zahnarzt (Haspelweg 32 [29.448]), Laupenstr. 4 [23.960]
 – Alice, Falzerin, Seidenweg 12
 – Alice, Postgehilfin, Optingenstrasse 42
@@ -41682,7 +41620,7 @@ Jura, Murifeldweg 69 [20.7413]
 – Ernst, Bäcker, Tillierstrasse 1
 – Ernst, Bäckermeister u. Spezierer, Tillierstrasse 1 [22.358]
 – Ernst, Bahnarbeiter, Raineggweg 7
-– Ernst, Bauamtarbeiter. Schosshaldenstr. 30
+– Ernst, Bauamtarbeiter, Schosshaldenstr. 30
 – Ernst, Bereiter, Breitfeldstrasse 36
 Schneider, s. auch Schneiter u. Schnyder
 – Ernst Friedr., Chef d. Brandwache, Zeughausgasse 4
@@ -41758,7 +41696,7 @@ Schneider, s. auch Schneiter und Schnyder
 – Gertrud, Ladentochter, Kehrg. 45, Bümpliz
 – - Gottfr., Autotransporte, Postgasse 40
 – Gottfr., Einzieher b. Gaswerk, Scheiben– Gottfr., Küferei, Tscharnerstr. 40 [28.786]
-– Gottfr., Rangiervorarbeiter. Murifeldw. 9
+– Gottfr., Rangiervorarbeiter, Murifeldw. 9
 – Gottfr., Schlosser W.-F., Scheibenstr. 19a
 – Gottfr., Schuhmachermstr., Rodtmattstr. 99
 – Gottfr., Wagnermeister, Murtenstrasse 47 [34.697]
@@ -41780,7 +41718,7 @@ Schneider, s. auch Schneiter und Schnyder
 – Hedwig (Schneider), Damen-Frisiersalon, Genossenweg 19
 – Hedwig (Zingg), Coiffeuse, Muristrasse 71 [34.842]
 – Heinr. (Deutschmann), Hutmacher, Weissenbühlweg 34
-; — Heinr. Rob.. Kaufm., Hallerstr. 62 [23.389]
+; — Heinr. Rob., Kaufm., Hallerstr. 62 [23.389]
 – Heinr., Schlosser, Elisabethenstrasse 29
 – Heinr., Schneidermeister, Steigerweg 13
 – Heinr., Versieh.-Beamter, Effingerstr. 41
@@ -41884,11 +41822,11 @@ Sektion f. Linienbau- u. Kabelanlagen der
 – Rud., Bahnarbeiter, Weissensteinstr. 12
 – Rud., Versicherungsangestellter, Kehrg. 45, Bümpliz
 – Rudolf, pens. Gaseinzieher, Kehrgasse 45, Bümpliz
-– Rud.. Kässalzer, Pappelweg 8
+– Rud., Kässalzer, Pappelweg 8
 – Rud. W., Maler, Flurstrasse 8
 – Rud., Handlanger, Kehrgasse 54, Bümpliz
 – Rud. Rob., Probierer, Stationsweg 38
-– Rud.. Reisender, Bümplizstrasse 62a
+– Rud., Reisender, Bümplizstrasse 62a
 – Rud. (Götschmann), Schlosser, Chutzenstrasse 28
 – Rud. Gottl., Schlosser, Murtenstrasse 153c
 – Rud., Schmied, Mindstrasse 9
@@ -41927,8 +41865,7 @@ Mobiliar-Vers.-Gesellsch., Jubiläumsstr. 31 (ab 1. Mai 1936: Jubiläumsstrasse 
 – Wilh., Hilfsarb., Werkgasse 25, Bümpliz
 – Willy. Schreiner, Murtenstrasse 47
 – Gebr. (W. u. A.), Garage «Jura», Waffenweg 5 [21.034]
-Schneider, Gebr. 24.156
-A.-G., Biglen, Filiale Bern, Schuhgeschäft, Treibriemen, Techn. Artikel, Ryffligässchen 6
+Schneider, Gebr. 📞 24.156 A.-G., Biglen, Filiale Bern, Schuhgeschäft, Treibriemen, Techn. Artikel, Ryffligässchen 6
 – & Cie., Aug., Elektrotechnische Werkstätte, Stockerenweg 6—8 [24.445]
 – & Hegi, Handel mit Kolonialwaren und Nährmitteln, Bollwerk 23
 Schneider & Rindlisbacher
@@ -41967,7 +41904,7 @@ Schneiter, s. auch Schneider und Schnyder
 – Marianna (Flückiger), Wwe., Dählhölzliweg 3
 – Marie Martha, Ladentochter, Dornweg 4
 – Marie, Tapeziererin. Dählhölzliweg 3
-– Oskar. Schreiner, Flurstrasse la
+– Oskar. Schreiner, Flurstrasse 1a
 — Paul A. (Jaillet), Zollbeamter, Wylerstr. 14
 – Pauline EL. Steinauweg 12
 – Rob. F., Kaufmann, Hochfeldstrasse 24
@@ -42007,7 +41944,7 @@ Schneuwly, Alphons, Hilfsarbeiter, Gerechtigkeitsgasse 42
 – Hadorn, G., Gipser- und Malergeschäft, Neufeldstrasse 139 [33.262]
 – Willy B., Versich.-Angest., Morillonstr. 13
 Schnewlin, Meinrad, Lehrer am städt. Progymnasium, Beaulieustrasse 33 [32.349]
-– Rob., eidg. Beamter. Altenbergstrasse 10
+– Rob., eidg. Beamter, Altenbergstrasse 10
 Schnöder, Etienne Ant., Dr., Redaktor, Morillonstrasse 28
 Schnorf, Ernst, Schreiner, Bümplizstr. 153
 – Heinr., Privatier, Murifeldweg 63
@@ -42055,7 +41992,7 @@ Schoch, Adelheid Gertrud, Haushaltungslehrerin, Spitalackerstrasse 11
 – Fred, Architekt, Bovetstrasse 9 [29.346]
 – Frieda Erika. Bureaulistin, Bovetstrasse 9
 – Hans, Bauführer, Landoltstrasse 50
-– Heinr.. Versicherungsagent, Peterweg 9, Bümpliz
+– Heinr., Versicherungsagent, Peterweg 9, Bümpliz
 – Hilde, Bureaulistin, Bovetstr. 9 [29.346]
 – Ida, städt. Beamtin, Neufeldstrasse 11
 – Jules H., Berchtoldstrasse 39
@@ -42122,7 +42059,7 @@ Schönenberg, Friedr. Wilh., Landschaftsgärtnerei, Holzikofenweg 7 [27.011]
 Schönenberger, Dora, Verwaltungsangestellte, Neubrückstrasse 127
 – Georges, Tapezierer, Steigerweg 19
 – Karl Meinrad, Weber, Lorrainestrasse 6
-– Marie (Meyer), Donnerbühlweg la
+– Marie (Meyer), Donnerbühlweg 1a
 – Mathilde (Breuchaud), Wwe. des Oberforstinspektors, Waldhöheweg 11 [29.907]
 – Max Charles, Waldhöheweg 11
 – Rosine, Fabrikarbeiterin, Aarbergerg. 49
@@ -42194,7 +42131,7 @@ Schöpfer, A., Frau, Schwarztorstrasse 76
 – Hulda, Ladentochter, Spitalackerstr. 21 [31.070]
 – Jul. Helene, Angestellte, Schwarztorstr. 76
 – Oskar, kant. Beamter, Greyerzstrasse 23
-– William H., Dr. phil., Prof.. Direktor desbotanischen Gartens, Jubiläumsstrasse 57 [20.135]
+– William H., Dr. phil., Prof., Direktor desbotanischen Gartens, Jubiläumsstrasse 57 [20.135]
 Schopferer, Karl, Wirt zum Restaurant Viktoriahall, Effingerstrasse 51 [21.208]
 Schopmeyer, Joh. Heinr., Schneider, Gerechtigkeitsgasse 8
 Schöppner, Klara, Gotthelfstrasse 20
@@ -42239,7 +42176,7 @@ Schori, Bertha, Bureauangestellte, Glockenstrasse 8, Bümpliz
 – Frieda (Hohl), Wwe., Charcuterie, Schwarzenburgstrasse 25 [34.437]
 – Friedr. Rud., Ausläufer, Wylerfeldstr. 40
 – Friedr , Chauffeur, Alleeweg 11
-– Friedr.. Heizer. Engehaldenstrasse 192
+– Friedr., Heizer. Engehaldenstrasse 192
 – Friedr. Alb., Mechaniker, Engerain 26
 – Friedr. Hermann, Schuhmacher, Neufeldstrasse 27a
 – Friedr., Trambilletteur, Alleeweg 11
@@ -42248,10 +42185,10 @@ Schori, Bertha, Bureauangestellte, Glockenstrasse 8, Bümpliz
 – Fritz, Schriftsetzer, Rodtmattstrasse 62
 – G. H. (Biancone), Dr. jur., Generalagenturder « Neuchäteloise » (Bierhübeliweg 29 [20.807]), Bollwerk 23 [33.582]
 – Gottfr., Magaziner bei den S. B. B., Spitalackerstrasse 49
-– Gottfr,, Schreiner, Kasernenstrasse Ile
+– Gottfr., Schreiner, Kasernenstrasse Ile
 – Hedwig, Ladentochter, Bantigerstrasse 27
 – Ida, Effingerstrasse 41b
-– Joh. Friedr., Angestellter. Weberstr. 25
+– Joh. Friedr., Angestellter, Weberstr. 25
 – Joh. Ernst (Schellenberg), in Fa. Gebr.
 Schori. Metzgerei. Breitenrainplatz 38
 – Joh., Kohlenarbeiter, Bümplizstrasse 38
@@ -42274,7 +42211,7 @@ Schori. Metzgerei. Breitenrainplatz 38
 – Walt., (Grossenbacher), Postbeamter, Maulbeerstrasse 11 [29.097]
 — Walter, Steinschleifer, Burgfeldweg 14
 – Walter, Tramangestellter, Birkenweg 42
-– Gebr.. Metzgerei und Charcuterie. Breitenrainplatz 38 [24.360]
+– Gebr., Metzgerei und Charcuterie. Breitenrainplatz 38 [24.360]
 Schörlin, Emil, Gipser- u. Malermeister, Hallerstrasse 31 [36.608]
 – Hans A., Schriftsetzer, Bernstrasse 4, Bümpliz
 – Math., Ladentochter, Mattenhofstrasse 7
@@ -42289,15 +42226,14 @@ Schorno, Alfr., Dr. jur., Fürsprech, Bureauchef der Pensionssektion der eidg. M
 Schosshaldenfriedhof, Ostermundigenstr. 60 [41.095]
 Schosshaldenschulhaus, Laubeckstrasse 23
 Schott, Arnold, Vertreter, Seftigenstr. 36
-– Hans, Malermeister, Murifeldweg 64
-. [31.375]
+– Hans, Malermeister, Murifeldweg 64 [31.375]
 – Viktor, Tapezier- u. Dekorationswerkstätte, Dammweg 5 [36.184]
 – Walter, Ingenieur, Sulgenheimweg 19
 Schöttli, Jean Edouard (Jauslin), Schriftsetzer, Rohrweg 10
 Schöttlin, Hs. Paul, Fabrikarbeiter, Spitalackerstrasse 57
-Schrade, Fröd. Ch., eidg. Beamter. Gotthardweg 15 [45.559]
+Schrade, Fröd. Ch., eidg. Beamter, Gotthardweg 15 [45.559]
 Schräder, Ludw., Karosserie-Techniker, Dalraazirain 36
-Schrafl, Anton, Dr. jur,, Generaldirektor der
+Schrafl, Anton, Dr. jur., Generaldirektor der
 S. B. B., Gryphenhübeliweg 7 [34.141]
 Schräg, Alfr-, Beamter der S. B. B., Bolligenstrasse 40
 – Alfred, Bahnangestellter, Seidenweg 38
@@ -42307,7 +42243,7 @@ Schräg, Alfr-, Beamter der S. B. B., Bolligenstrasse 40
 – Eug. Paul, Hilfsarbeiter, Rodtmattstr. 52
 – Fritz, Hausknecht, Ladenwandstrasse 51
 – Gottl., Gasarbeiter, Rodtmattstrasse 60
-– Gottl., Schreinermeister. Nordweg 8
+– Gottl., Schreinermeister, Nordweg 8
 – Hans Walter, Cbauffeur-Mechan., Werkgasse 20, Bümpliz
 – Hans Werner, Pferdewärter, Talweg 13
 – Herm. Jul., Bureaulist, Mattenhofstr. 31
@@ -42325,7 +42261,7 @@ Schräg, Alfr-, Beamter der S. B. B., Bolligenstrasse 40
 Schräg, U., pens. Wegmstr., Altenbergstr. 3
 – Walter, Patissier, Wablheimstrasse 49
 Schraner, Julius, pens. Arbeiter der Waffenfabrik, Aarbergergasse 17
-– Wilh.. Mechaniker, Dietlerstrasse 2
+– Wilh., Mechaniker, Dietlerstrasse 2
 Schranz, Friedr., Pferdewärter, Unt. Aareggweg 3
 – Joh. Friedr., Metzger, Kramgasse 4
 – Marg. (Bärtschi), Wwe., Standstrasse 9
@@ -42351,7 +42287,7 @@ Schreyer und Schreier
 – Konrad R., Wagenmaler, Lentulusstr. 37
 – Marie (Aebi), Wwe., Schneiderin, Lentulusstrasse 37
 – Otto, Kaufmann, Melchthalstrasse 29
-– —Paul Ferd . Typograph. Lagerweg 5
+– Paul Ferd., Typograph, Lagerweg 5
 – Th., Frl., Mercerie, Muristrasse 55
 – Walter, Telephonarbeiter, Römerweg 26
 Schriftenkantrolfe der Gemeinde Bern, Polizeidirektion, Predigergasse 5. Geöffnet: Montag bis Freitag von 9—11 % Uhr und von 14—17 Uhr, Samstag von 9— 11 % Uhr [20.421]
@@ -42390,7 +42326,7 @@ Kasernenstrasse 37 [25.027]
 – Alf. W., Hilfsarbeiter, Martiweg 17
 – Bertha, Wwe., Privat., Beundenfeldstr. 43 [29.838]
 – Erwin K., Versicherungsinspektor, Engestrasse 1 [25.991]
-– Friedr. Gottl.. Mechan., Dietlerstrasse 10
+– Friedr. Gottl., Mechan., Dietlerstrasse 10
 – Charles, Postbeamter, Wyttenbachstr. 14
 – Christ., Karrer, Sandrainstrasse 52
 – Edgar, Dr. phil., Major, Infanterieinstruktor, Alpeneckstrasse 17 [28.077]
@@ -42409,7 +42345,7 @@ Schüepp, Alb., Maschinentechniker S. B.B., Länggassstrasse 21a i
 – Walter Jakob, eidgen. Beamter, Gryphenhübeliweg 19
 Schufer, Phil., Schuhmachermeister, Wyttenbachstrasse 26
 Schuh, Frieda, Kunsthändlerin, Monbijoustrasse 6 ji
-Schuhhaus Capitol, Neuengasse 39 [23.1001
+Schuhhaus Capitol, Neuengasse 39 [23.100]
 – Löw, A.-G., Marktgasse 4 [23373
 – Rivoli A.-G., Spitalgasse 9 [21.749]
 # Date: 1935-12-15 Page: 26020756/449
@@ -42426,8 +42362,8 @@ Schulzahnklinik, städt., Bundesgasse 26 [24.924]
 Schüle, Klara E., Bureaulistin, Schwarztorstrasse 23b
 – Pauline B., Güterstrasse 38
 Schüler, Albert, Fabrikdirektor, Kollerweg 5a
-– Arnold. Dr. jur.. Subdirektor der Versicherungs-A.-G., Junkerngasse 41 [23.251]
-– Aug.. Masch.-Zeichner. Elisabethenstr. 15
+– Arnold. Dr. jur., Subdirektor der Versicherungs-A.-G., Junkerngasse 41 [23.251]
+– Aug., Masch.-Zeichner. Elisabethenstr. 15
 – Bernhard, Steindrucker, Reichenbachstr. 41
 – Bernh. Hans, Steindrucker, Wagnerstr. 11
 – Elisabeth (Eggler), Wwe., Privat., Seidenweg 21
@@ -42476,7 +42412,7 @@ Schulthess, Ernst Emil, Kaufmann, Ensingerstrasse 3 [34.017]
 – R., Frl., Breitenrainstrasse 27
 – Rosa, Ladentochter, Beundenfeldstrasse 19
 – Rosa Gertrud, Sekretärin, Jägerweg 4
-– Walter H.. Buchhalter. Parkstrasse 3
+– Walter H., Buchhalter, Parkstrasse 3
 – Walter (Michel), Orthopädist, Schwarzenburgstrasse 6
 – & Co., A., Reisebureau Asco, Wechselstube, Vertretungen, Bollwerk 15 (Genferhaus) [21.480]
 Schultz, Gustav Ad., Mechaniker, Randweg 9
@@ -42500,23 +42436,23 @@ Schumacher, Alfred, Damenschneider, Waisenhausplatz 27
 # Date: 1935-12-15 Page: 26020757/450
 Schumacher, Gertrud Frieda, Verkäuferin, Sandrainstrasse 52
 – Gust., Zimmerpolier, Martiweg 12
-– Hans Ferd.. Elektrotechn., Steinerstr. 25
+– Hans Ferd., Elektrotechn., Steinerstr. 25
 – Hans (Seelkofer), Kolonialwarenhandlung, Kramgasse 12 [21.505]
 – Helene, Lehrerin an der Breitfeldsehule, Greyerzstrasse 24
-– Herm.. Buchbinder, Florastrasse 20
-– Hermann’s Wwe.. Buchbinderei (Thunstrasse 33 [31.769]), Monbijoustrasse 24 [21.504]
+– Herm., Buchbinder, Florastrasse 20
+– Hermann’s Wwe., Buchbinderei (Thunstrasse 33 [31.769]), Monbijoustrasse 24 [21.504]
 – Ida, Bureaulistin, Thunstrasse 33
 – Jakob, Konsumarbeiter, Tscharnerstr. 45
 – Jakob, Maurer, Magazinweg 6
 – Joh., Hilfsarbeiter, Stauwehrrain 8
 – Joh., Fabrikarbeiter, Stauwehrrain 8
 – Joh., Handelsgärtnerei, Jurastr. 47 [32.512]
-– Joh. Fr., kaufm. Angest,, Kursaalstr.il
+– Joh. Fr., kaufm. Angest., Kursaalstr.il
 – Jos., Bauamtarbeiter, Postgasse 56
-– Karl, Friedhofarb.. Veilchenw. 2, Bümpliz
+– Karl, Friedhofarb., Veilchenw. 2, Bümpliz
 – Karoline R. (Brack), Wwe. des Pfarrers, Kramgasse 2 [20.081]
 – Margr., Bureaulistin, Stauwehrrain 8
-– Marie, Geschäftsangest.. Weissenbühlw. 8
+– Marie, Geschäftsangest., Weissenbühlw. 8
 – Martha. Angestellte, Bernastrasse 67
 – Martha Rosa, Ensingerstrasse 39
 – Mathias, Monteur, Bärengasse 12, Bümpliz
@@ -42536,10 +42472,10 @@ Schüpbach, Ad. Gärtner, Elfenauweg 44c
 – Adolf, Handlanger, Stalden 30
 – Albert, Prof., Dr. med., Chefarzt am Inselspital, Seftigenstrasse 2 [22.672]
 – Albert, Maurer, Bahnhöbeweg 44, Bümpliz
-– Alfr.. Schreiner, Federweg 25
+– Alfr., Schreiner, Federweg 25
 – Alfr., Hilfsarbeiter, Stalden 30
 – Anna, Fabrikarbeiterin, Stalden SO
-– Christ.. Angestellter, Wachtelweg 23
+– Christ., Angestellter, Wachtelweg 23
 – Christ., Dachdecker, Freiburgstrasse 62
 – Christ., pens. Gasarbeiter, Bottigenstr. 69, Bümpliz
 – Christ., Hilfsarb., Chaletweg 14, Bümpliz
@@ -42547,7 +42483,7 @@ Schüpbach, Ad. Gärtner, Elfenauweg 44c
 – Christ. Alfr., Monteur, Altenbergstrasse 37
 – Christ-, Wegmeister, Ladenwandstrasse 98
 – Dora A. H., Bureaulistin, Gutenbergstr. 4
-– Elsa, Ladentochter. Rodtmattstrasse 89
+– Elsa, Ladentochter, Rodtmattstrasse 89
 Schüpbach, Emil, Schneider, Herrengasse 24
 – Emma, Heimpflegerin, Bottigenstrasse 69, Bümpliz
 – Erich Fr., Schlosser, Gerechtigkeitsg. 50 [21.663]
@@ -42581,13 +42517,13 @@ Schüpbach, Emil, Schneider, Herrengasse 24
 – Huldreich, Lehrer, Alpeneckstrasse 21
 – Ida, Heimpflegerin, Bottigenstr. 69, Bümpliz
 – Ida, Ladentochter, Rodtmattstrasse 89
-– Jakob, Hilfsarbeiter. Sulgenbachstrasse 28
+– Jakob, Hilfsarbeiter, Sulgenbachstrasse 28
 – Joh., Bäckerei, Kirchbergerstrasse 10
 – Joh., Gasarbeiter, Thunstrasse 111
 – Joh., Lichtwächter E.-W., Pestalozzistr.25
 – Joh. Ernst, Schlosser W.-F., Wiesenstr. 59
 – Joh., Verkäufer, Wabernstrasse 25
-– Karl. Bäckermeister. Keltenstr. 104, Bümpliz [46.210]
+– Karl. Bäckermeister, Keltenstr. 104, Bümpliz [46.210]
 – Karl, Chauffeur, Effingerstrasse 75
 – Klara, Hilfsarbeiterin, Seidenweg 3
 – Lina, Frau, Kolonialwaren, Kirchbergerstrasse 10 [45.815]
@@ -42611,7 +42547,7 @@ Schupbach, Paul W., Dr. med., Arzt, Freiburgstrasse 18
 – Rud., Isoleur, Seidenweg 64
 – Rud., Polizeikorporal, Scheuermattweg 16
 – Walter E., Kaufm., Wylerstr. 71 [29.685]
-– Walter Gottfr.. Buchbinder, Wyttenbachstrasse 33
+– Walter Gottfr., Buchbinder, Wyttenbachstrasse 33
 – Walter, Hilfsarbeiter, Sulgenbachstrasse 28
 – Walter, Hilfsarbeiter, Freiburgstrasse 62
 – Walter, Käser, Oberbottigenweg 29, Oberbottigen
@@ -42620,7 +42556,7 @@ Schupbach, Paul W., Dr. med., Arzt, Freiburgstrasse 18
 – & Kropf, Dachdecker- u. Maurergeschäft, Flurstrasse 5 [33.002]
 Schüpfer, Xaver Jos., Fabrikarbeiter, Muldenstrasse 44
 Schuppisser, Alb., Architekturbureau, Spitalackerstrasse 61 [25.071]
-– Charles W., kaufm. Angestellter. Mattenhofstrasse 13
+– Charles W., kaufm. Angestellter, Mattenhofstrasse 13
 – Heinrich, elektr. Installationen, Breitenrainstrasse 47 [24.958]
 – Heinrich, Dr. med., Arzt, Effingerstr. 41c [21.750]
 – Ida (Frei), Wwe., Coiffeuse, Damensalon, Mattenhofstrasse 13 [27.750]
@@ -42637,7 +42573,7 @@ Heimat, Asylweg 6, Bümpliz
 – Elisab Sophie. Bureaulistin d. O. Z. D., Wyttenbachstrasse 10
 – Elise, Bureaulistin, Cedernstr. 9, Bümpliz
 – Elsa Lydia, Einlegerin. Herzogstrasse 14
-– Emil Ernst,, Kaufmann, Alexandra weg 0 [27.749]
+– Emil Ernst., Kaufmann, Alexandra weg 0 [27.749]
 – Emilie (Renfer), Ladentochter, Thunstr. 111
 – Ernst, Buchhalter, Breitenrainstrasse 69
 – Ernst, stadl. Beamter, Spitalackerstr. 59
@@ -42647,11 +42583,10 @@ Heimat, Asylweg 6, Bümpliz
 – Ernst, Kassier, Ensingerstrasse 7
 – Ernst, Polizeifeldweibel, Spitalackerstr. 59
 – Ernst, Techniker, Optingenstrasse 49
-– Ferd., Fabrikt.. Kl. Muristalden 3 [36.004]
-– Ferd. Ed., Schreiner, Schwarztorstr. 51
-. [20.254]
+– Ferd., Fabrikt., Kl. Muristalden 3 [36.004]
+– Ferd. Ed., Schreiner, Schwarztorstr. 51 [20.254]
 – Drieda O., Damenschneiderin, Wiesenstrasse 71
-– Friedr.. Buchbinder, Metzgergasse 64
+– Friedr., Buchbinder, Metzgergasse 64
 – Friedr. Rud., Ing. agr., Florastrasse 21
 Schürch, Friedr., Kaufmann, Greyerzstr. 24 [31.647]
 – Friedr., Zigarrenhdlg., Metzgergasse 59
@@ -42676,7 +42611,7 @@ Schürch & Sohn, Postgasse 60 [35.459]
 – Joh. Gottfr., Maurer, Herzogstrasse 8
 – Jch. Fr., Handlanger, Herrengasse 30
 – Joh. Ed., Mechaniker, Depotstrasse 52
-– Joh,, Tramangestellter, Wiesenstrasse 71
+– Joh., Tramangestellter, Wiesenstrasse 71
 – Joh., Vertreter, Greyerzstrasse 21
 – Joh. Ulr. Walter, Schreiner, Muesmatt-strasse 34
 – Karl, Parkettleger, Stöckackerstrasse 56, Bümpliz [46.612]
@@ -42801,7 +42736,7 @@ Schütz, Ernst, Schwimmlehrer und Masseur, Gesellschaftsstrasse 79
 – Marg. (Ulrich), Wwe., Gesellschaftsstr. 43
 – Margrit, Papeteriegeschäft, Gerechtigkeitsgasse 72
 – Marg., Verkäuferin, Weissenbühlweg 4
-– Marie Hedwig, Krankenschwester. Niesenweg 3
+– Marie Hedwig, Krankenschwester, Niesenweg 3
 – Martha, Fabrikarbeiterin, Veilchenweg 7, Bümpliz
 – Martha Lina (Wälti), Milchhandlung, Gerbergasse 19a
 – O. Ernst, Handlanger, Brunnhofweg 32
@@ -42867,7 +42802,7 @@ Schwab, Charles Alb., Hilfsarbeiter, Marzilistrasse 28
 – Emma, Bureaulistin, Spitalackerstrasse 21
 – Ernst R., Bäckermstr., Freiestr. 42 [33.148]
 – Ernst Alex., Bautechniker, Laubeckstr. 192 [33.756]
-– Ernst, Beamter S. B. B.. Seidenweg 14
+– Ernst, Beamter S. B. B., Seidenweg 14
 – Ernst, Marktkrämer, Zähringerstrasse 25
 – Ernst, Elektromonteur, Brünnackerweg 29, Bümpliz
 – Ernst, Landwirt, Bümplizstr. 73 [46.137]
@@ -42876,7 +42811,7 @@ Schwab, Charles Alb., Hilfsarbeiter, Marzilistrasse 28
 – Frieda, Ladentochter, Bümplizstrasse 13
 – Fr. Max, Beamter der B. L. S., Kasernenstrasse 45
 – Fr., Handlanger, Riedernstr. 42, Bümpliz
-– Friedr.. Pferdewärter, Allmendstrasse 14
+– Friedr., Pferdewärter, Allmendstrasse 14
 – Friedr Arth., Pferdewärter, Murifeldw. 19
 – Friedr., Weichenwärter, Niesenweg 4
 – Fritz, Cafe-Restaurant Zytglogge, Amthausgasse 2 [22.687]
@@ -42926,9 +42861,9 @@ Schwab, Kurt, Schreiner, Zaunweg 22
 – Robert, Oberfahrer K. R. D., Beundenfeldstrasse 42
 – Rosa Bertha, Fabrikarbeiterin, Kehrg. 15, Bümpiiz
 – Rosa B., Murtenstrasse 30
-– Rosa Gertr.. Verkäuferin, Diesbachstr.il
+– Rosa Gertr., Verkäuferin, Diesbachstr.il
 – Rudolf Alfred, Mechaniker, Bümplizstr. 13
-– Rud.. Schweinemästerei, Bümplizstrasse 13
+– Rud., Schweinemästerei, Bümplizstrasse 13
 – Samuel, Hausierer, Bäckerenveg 1
 – Siegfr., Kaufmann, Effingerstrasse 35
 – Susanna (Corneli). Wwe., Quartierhof 13
@@ -42940,8 +42875,8 @@ Schwabe, F., Gipser- u. Malermeister, in Fa. Gygi & Co., Dekorations- u. Flachma
 – Hermann. Buchhalter, Weingartstrasse 47
 Schwald, Alfr., Hilfsarbeiter, Kesslergasse 27
 Schwaller, Dora Flora, Bureaulistin, Standstrasse 8
-– Josef Emil, mech.-techn. Werkst.. Standstrasse 8 [32.4261
-– Joseph. Pferdewärter. Könizstrasse 21
+– Josef Emil, mech.-techn. Werkst., Standstrasse 8 [32.4261
+– Joseph. Pferdewärter, Könizstrasse 21
 – Otto, Chefmonteur, Wylerstrasse 47
 Schwalm, Christ. Alfr., Sek.-Lehrer, Brünnenstrasse 50, Bümpiiz [46.121]
 – Karl (Ziiilig), Hallerstrasse 5 [31.470]
@@ -42962,7 +42897,7 @@ Schwander, Joli., Militärstrasse 63
 – Martha, Krankenpflegerin, Kramgasse 81 [33.073]
 – Paul, Zahnarzt, Elisabethenstrasse 4
 – Robert, Briefträger, Dammweg 9
-– Willi O., kaufm. Angestellter. Moserstr. 12
+– Willi O., kaufm. Angestellter, Moserstr. 12
 Schwank, Jak. Osk., Architekt, Morillonstr. 9
 – Joh. K., Ingen, in Fa. Leupin & Schwank, Thunstrasse 37 [20.952]
 – Baumgartner, 0 , Schuhhandlung u. Rep,-Werkstatt (Keltenstr. 93), Bümplizstr 148 [46.229]
@@ -42995,7 +42930,7 @@ Schwarz, Alfr., Grossmetzgerei, Sennweg 19 [23.179]
 – J. Jakob, Bankbeamter, Hochfeldstr. 109 [35.400]
 – Jakob Rud., Elektrotechn., Mattenhofstr.9
 – Joh. Rud., Kaufmann, Steinhölzliweg 21
-– Joh. Heinr,, Asphalter. Güterstrasse 40
+– Joh. Heinr., Asphalter, Güterstrasse 40
 – Johanna Verena, Haushaltungslehrerin, Hallwylstrasse 44
 – Karl E., Eisendreher, Gerechtigkeitsg. 57
 – Karl, Buchbinder, Weissenbühlweg 28
@@ -43061,7 +42996,7 @@ Schweighauser, Alfred Em., Buchbindermstr., in Fa. Alfr. Schweighauser & Co., Fr
 – August (Mischler), pens. Vorstand d. Rechnungskontrolle u. Hauptbuchhaltung der
 S. B. B., Gutenbergstrasse 31
 – Karl, Friedeckweg 14 [29.408]
-– & Co., Alfr.. Verlags- u. Sortimentsbuchbinderei. Seilerstrasse 25 [31.662]
+– & Co., Alfr., Verlags- u. Sortimentsbuchbinderei. Seilerstrasse 25 [31.662]
 Schweiker & Co., H., Manufakturwarenhdlg., Kramgasse 16 [34.148]
 Schweinfurth, Anna Elise (Schöni), Wwe., Kramgasse 54 [32.717]
 Schweingruber, Adolf, Reisender, Weissenbühiweg 19
@@ -43075,9 +43010,9 @@ Schweingruber, Adolf, Reisender, Weissenbühiweg 19
 – Ernst (Aebi), Gesanglehrer a. d. Knabensekundarschule I, Schönbergw. 12 [34.404]
 – Friedr., Dr. phil., Rektor des Freien Gymnasiums, Schillingstrasse 24 [32.521]
 – Fritz, Bahnangest. S. B. B., Könizstr. 53
-– Gottfr.. Bahnarbeiter, Löchliweg 30
+– Gottfr., Bahnarbeiter, Löchliweg 30
 – Hugo M., Notar, Beaulieurain 17 [35.767]
-– Joh.. Lehrer. Bitziusstrasse 7 [35.804]
+– Joh., Lehrer. Bitziusstrasse 7 [35.804]
 – Joh., Handlanger, Brünnenstrasse 62, Bümpliz
 – Joh., Pferdewärter, Herzogstrasse 20
 – Karl, städt. Beamter, Schützenweg 37
@@ -43086,8 +43021,8 @@ Schweingruber, Adolf, Reisender, Weissenbühiweg 19
 – Otto (Dellsperger), Buchhalter-Prokurist, Beaulieustrasse 47 [27.095]
 – Paul, kaufm Angestellter, Fröschmattweg 12. Bümpliz
 – Rob. Fr., Chauffeur, Freiburgstrasse 184, Bümpliz
-– Rob.. Hilfsarbeiter. Könizstrasse 53
-– Rob.. Schmied. Bottigenstr. 60, Bümpliz
+– Rob., Hilfsarbeiter, Könizstrasse 53
+– Rob., Schmied. Bottigenstr. 60, Bümpliz
 – Robert Emil, Versicherungsbeamter, Hochfeldstrasse 94 [33.063]
 – Walter, Elektromonteur, Wylerstrasse 53
 – Walter, Pferdewärter, Alleeweg 24
@@ -43098,7 +43033,7 @@ Kannengieser, Bahnhofplatz 1 [29.511]
 «Schweiz», Allg. Versicherungs-A.-G. Zürich, Generalagentur Bern: Lehmann, A., Zeughausgasse 26 [23.355]
 Schweizer, Ad., eidg. Beamter, Schwarzenburgstrasse 6
 – Ad., pens. Postangest., Länggassstrasse 29 [33.712]
-Ad., Dienstchef b. d. Oberpostdirektion, Zinggstrasse 8 [23.986]
+— Ad., Dienstchef b. d. Oberpostdirektion, Zinggstrasse 8 [23.986]
 – Alb. Rob., Bankbeamter, Sandrainstr. 102
 – Albertina (Ganahl), Wwe., Seidenweg 35
 – Albr., Bauamtarbeiter, Schöneggweg 17
@@ -43138,18 +43073,18 @@ Ad., Dienstchef b. d. Oberpostdirektion, Zinggstrasse 8 [23.986]
 – Fritz (Bachmann), Milch-, Butter- und Käsehandlung, Birkenweg 23
 – Fritz, Sek.-Lehrer, Gotthärdw. 3 [45.384]
 — Fritz, Schlosser, Bümplizstrasse 167
-– Gottfr., Tramangestellt.. Fischermätteliw. 5
-– Gottl. Frz., Beamter d. B. L. S.. Veilchenweg 4, Bümpliz
+– Gottfr., Tramangestellt., Fischermätteliw. 5
+– Gottl. Frz., Beamter d. B. L. S., Veilchenweg 4, Bümpliz
 – Gottl., Beamter O. P. D., Frohbergweg 7
 – Hans, Heizungsmonteur, Ladenwandstr. 13
 Schweizer, Hans (Svoboda), Kunstmaler, Weissensteinstrasse 80 [26.272]
 – Hans, Spengler, Weissensteinstrasse 51
 – Hans (Bürgermeister), Tapezierermeister, Rabbentalstrasse 63a [32.746]
-– Hedwig Er.. Bureaulistin, Klaraweg 2
+– Hedwig Er., Bureaulistin, Klaraweg 2
 – Heinr. K., Geometer, Wabernstrasse 14
 – Herm. O., Chefmechan., Freiburgstrasse 69 [28.851]
 – Jakob, Webermeister, Standstrasse 33
-– Joh., Bauamtarbeiter. Landoltstrasse 52
+– Joh., Bauamtarbeiter, Landoltstrasse 52
 – Joh., Handlanger, Bottigenstr. 245, Oberbottigen
 – Joh., Maurer, Bümplizstrasse 62
 – Johanna El., Einlegerin, Neufeldstrasse 21
@@ -43270,7 +43205,7 @@ Winterthur, Suhdirektion Bern: Teuscher, Alfred. Münzgraben 2 [29.333]
 Schweiz. Unfallversicherungsanst. in Luzern, «Suva», Kreisagentur Bern, Laupenstr. 11 [29.361]
 Schweizer. Uniformenfabrik A.-G., Schwanengasse 6 [21.114], Mützenabteilg.: Marzilistrasse 8a [22.437]
 Schweizer. Verband «Frauenhilfe», Sektion Bern (S. V. F. H.), Präsidentin, Schosshaldenstrasse 23
-Schweiz. Verband der Tapezierermeister-Dekorateure u. d. Möbel-Detailhandels, Kramgasse 7 . [28.197]
+Schweiz. Verband der Tapezierermeister-Dekorateure u. d. Möbel-Detailhandels, Kramgasse 7 [28.197]
 Schweiz. Verband zur Förderung d. gemeinnützigen Wohnungsbaues, Kreis Bern, Geschäftsstelle: Advokaturbureau Werner
 Oesch. Bundesgasse 28
 Schweiz. Verband evangel. Arbeiter und Angestellter, Sekretariat, Weissensteinstr 122 [21.338]
@@ -43278,8 +43213,7 @@ Schweiz. Verband der gewerblichen Bürgschaftsgenossenschaften, Neuengasse 20, B
 Schweiz. Verband des Früchte- u. Gemüsehandels, Lorrainestrasse 27/Schmiedweg 3
 Schweiz. Verband von Comestibles-Importeuren, Kramgasse 19
 Schweiz. Volksbank (Generaldirektion und Niederlassung Bern), Christoffelg. 6 [00]
-Schweizerische Wagons- und Aufzügefabrik
-A.-G. Schlieren - Zürich, Zweigniederlassung Bern. Optingenstrasse 27 [24.679]
+Schweizerische Wagons- und Aufzügefabrik A.-G. Schlieren - Zürich, Zweigniederlassung Bern. Optingenstrasse 27 [24.679]
 Schweiz. Wirte-Verein, Zentralsekretariat, Münzgraben 2
 Schweiz. Zentralpolizeibureau, Bundeshaus-Westbau [61]
 Schweizergarten, Restaurant, Papiermühlestrasse 12 [24.0291
@@ -43310,7 +43244,7 @@ Schwestern - Missionshaus «Sonnenheimat», Haspelweg 40 [27.5091
 Schwill, Franz, Vizedirektor b. Internat. Bureau des Weltnachrichtenvereins, Pavillonweg 14 [33.913]
 – Paul A., Dr. jur., Fürsprecher (Pavillonweg 14 [33.913]), Christoffelg. 2 [35.825]
 Schwitter, Kaspar, Sekretär der Schweiz. Alkobolverwaltung, Seilerstrasse 23
-– Otto Fr.. Buchbinder. Waffenweg 8
+– Otto Fr., Buchbinder. Waffenweg 8
 Schwitz, Joh. Fr., Maler u. Heraldiker, Gerechtigkeitsgasse 33
 Schwitzer, Ad., Drechsler, Spitalackerstr. 55
 Schwitzgebel, Franz Jos., Chirurg. Instrumentenmacher, Birkenweg 15
@@ -43346,7 +43280,7 @@ Sechehaie, Rose Henr., Bureaulistin, Habsburgstrasse 6
 Secretan, Andre Aug., Angestellter, Rabbentalstrasse 71
 – Eric Eug., Angestellter, Trachselweg 1
 – Maurice. Ingenieur Länggassstrasse 55
-Secüritas, Schweiz. Bewachungsgesellschaft, A.-G., Generaldirektion und Filiale Bern, . Seilerstrasse 7 [21.116]
+Secüritas, Schweiz. Bewachungsgesellschaft, A.-G., Generaldirektion und Filiale Bern, Seilerstrasse 7 [21.116]
 Sedeco. Hutfabrik. Marktgasse 46 [21.443]
 Sedelmeyer, G. (Sigri), Frau, Florastrasse 28 [36.447]
 Sedes A.-G., An- u. Verkauf u. Verwaltungvon Liegenschaften, Bärenplatz 9
@@ -43370,13 +43304,13 @@ Seger s. auch Seeger
 – Elsa, Schneiderin, Elisabethenstrasse 26
 – K. (Wendel), Magaziner. Cäcilienrain 3
 – Oskar (Egli), Kaufmann, Heckenweg 9 [45.192]
-– Walter. Tramarbeiter. Elisabethenstrasse 26
+– Walter, Tramarbeiter, Elisabethenstrasse 26
 Segessemann, Alb. Heinr., Handlanger, Freiburgstrasse 165
-Alfr.. Mechaniker. Waffenweg 17
+— Alfr., Mechaniker. Waffenweg 17
 – E. A., alt Lehrer, Wyttenbachstrasse 10
 – Jakob, Gerechtigkeitsgasse 74
-– Joh. Rob. (Suter), Notar, Habsburgstr. 10
-. [31.608]oegessenmann, Friedr., Sekretär, Standstr. 9
+– Joh. Rob. (Suter), Notar, Habsburgstr. 10 [31.608]
+Segessenmann, Friedr., Sekretär, Standstr. 9
 Segesser, s. auch Sägesser
 – Ernst, Prokurist, Gesellschaftsstrasse 14 [34.160]
 – Louis Otto (Fehlmann), Kaufmann, Brückfeldstrasse 37
@@ -43386,11 +43320,11 @@ Seidel, Kurt, Ingen., Optingenstr. 5 [36.484]
 – Werner M. J., Ing., eidg. Beamter, Blumenbergstrasse 16 [23.283]
 Seidenhaus Jucker & Cie. (vorm. G. Kellenberg), Seidenstoff-Fabrikation und Handelin Seidenwaren, Detail, Gros, Export, Theaterplatz [23.730]
 Seiferle, Fritz Karl, Gipser, Langmauerweg 1
-Seifert, Max Arth.. Zeichner, Mühlemattstr 66
+Seifert, Max Arth., Zeichner, Mühlemattstr 66
 – Rud., Reklame-Berater, Waldheimstr. 86
 Seiffert, Hilda Ida, Gotthelfstrasse 14
 – Josef, Kaufmann, Brückfeldstr. 43 [26.246]
-Seiler, Ad.. Fabrikarbeiter. Eggimannstr. 22
+Seiler, Ad., Fabrikarbeiter, Eggimannstr. 22
 – Alb., Wirt, Kramgasse 20 [23.677]
 – Alb. (Zumstein), Kellner, Gewerbestr. 33
 – Alfred, Handlanger, Jurastrasse 42
@@ -43409,8 +43343,7 @@ Brandversicherung, Gotthelfstr 16 [28.462]
 – Ernst Friedrich, Steigerungs-Aktuar des
 Betr.-Amtes Bern-Stadt, Bierhübeliweg 33
 – Fanny, Ladentochter, Schärerstrasse 7
-– Fr. (Bruggisser), Prof., Dr. med., prakt.
-Arzt, Thunstrasse 36 [22.376]
+– Fr. (Bruggisser), Prof., Dr. med., prakt. Arzt, Thunstrasse 36 [22.376]
 – Friedr., Hilfsarbeiter, Gerechtigkeitsg. 20
 – Fritz, Hilfsarbeiter, Waffenweg 21
 – Garibaldi. Schlosser. Scheibenstrasse 24
@@ -43439,8 +43372,8 @@ Seiler, Margar. B., Bureaul., Kasernenstr. 47
 – Peter, Kellner, Brückenstrasse 59
 – Renatus, Tiefdrucktechniker, Böcklinstr. 13
 – Rob., Coiffeur, Waffenweg 21
-– Rob.. Führergehilfe S. B. B.. Seidenweg 18
-– Rob. Aug., Maschinenmeister. Speichergasse 39
+– Rob., Führergehilfe S. B. B., Seidenweg 18
+– Rob. Aug., Maschinenmeister, Speichergasse 39
 – Rosa M. (Auber), Wwe. des Notars, Humboldtstrasse 7 [33.843]
 – Rud., Photograph, Böcklinstrasse 13
 – Sandro Friedr. Alb., Dr. med., Assistenzarzt, Thunstrasse 36
@@ -43515,7 +43448,7 @@ Senn, Alfred, Dr. med., Dozent, Arzt u. Zahnarzt (Sulgeneckstr. 38 [33.446]), Ma
 – Andreas, Reklamezeichner, Jubiläumsstr.23
 – Andreas, Bremser d. S. B. B., Schwarztorstrasse 21
 – Arthur, Buchbinderei, Hochfeldstrasse 7
-– Bertha (Wehrli), Wwe,, Mezenerweg 8
+– Bertha (Wehrli), Wwe., Mezenerweg 8
 – Bruno, Feinmechaniker, Bubenbergstr. 4
 – Elise, Mattenhofstrasse 22 [34.522]
 – Emil, Zahntechn., Gebiss-Reparaturatelier
@@ -43524,7 +43457,7 @@ Senn, Alfred, Dr. med., Dozent, Arzt u. Zahnarzt (Sulgeneckstr. 38 [33.446]), Ma
 – Erika, Bureaulistin, Bubenbergstrasse 4
 – Ernst, Elektriker, Viktoriaplatz 2
 – Erwin, Zelluloidwaren, Schwarztorstr. 23 [29.817]
-– Eug., kaufm. Angestellter. Mezenerweg 8
+– Eug., kaufm. Angestellter, Mezenerweg 8
 – Frieda (Kaufmann), Bubenbergstrasse 4 [32.569]
 – Frieda, Modistin, Muldenstrasse 21
 – Fritz, Angestellter, Bubenbergstrasse 4
@@ -43613,7 +43546,7 @@ Siebenmann, Daniel, Ingenieurbureau, Apparatebau und -Handel, Konsumstrasse 4a [
 – Frieda (Dick), Wwe., Jubiläumsstrasse 53 [34.520]
 – Hans O., Metzger, Bernstr. 104, Bümpliz
 – Hans, Gasthof zum Löwen, Bernstr. 104, Bümpliz [46.011]
-– Herm.. Ingenieur, Dittlingerweg 16
+– Herm., Ingenieur, Dittlingerweg 16
 – Max, in Fa. Siebenmann & Co., Seelandweg 7
 – Paul Arth., Versicherungsinspektor, Monbijoustrasse 87 [24.382]
 – Rob. Ad., Bauamtarbeiter, Turnweg 31
@@ -43676,7 +43609,6 @@ Siegenthaler, Alb., Elektriker, Schifflaube 38
 – Emil (Spycher), Weichenwärter, Tulpenw.4
 – Emma, Schneiderin, Hopfenweg 34
 – Emma (Lobsiger), Spezereihdlg., weg 1 [28.640]
-Reproduktionen, techn. Aufnahmen etc. Haliwag Bernliefert die Clich6fabrik der Telephon 28.222i-
 # Date: 1935-12-15 Page: 26020770/463
 Siegenthaler, Ernst (Fulirimann), Schwarztorstrasse 31
 – Ernst, Angestellter der S. B. B., Industrieweg 20
@@ -43692,12 +43624,12 @@ Siegenthaler, Ernst (Fulirimann), Schwarztorstrasse 31
 – Franz, Hilfsarbeiter, Burgfeldweg 12
 – Franz G., Konzertunternehmer, Brunng. 4
 – Friedr., Zimmermann, Marktgasse 4
-– Friedr.. Handlanger Tsoharnerstrasse 15
+– Friedr., Handlanger Tsoharnerstrasse 15
 – Friedr., Pferdewärter, Allmendstrasse 48
 – Friedr., Reisender, Morgenstr. 13, Bümpliz
 – Friedr., Vertreter, Ostring 38
 – Fritz, Bäcker, Schauplatzgasse 28
-– Fritz. Bahnarbeiter. Holligenstrasse 96
+– Fritz. Bahnarbeiter, Holligenstrasse 96
 – Fritz, gewes. Mandatträger, Greyerzstr. 33
 – Gottfr., Ausläufer, Gerechtigkeitsgasse 54
 – Gottfr., Mechaniker, Siedlungsweg 19
@@ -43705,7 +43637,7 @@ Siegenthaler, Ernst (Fulirimann), Schwarztorstrasse 31
 – Gottfr., Stricker. Felshaldenweg 29
 – Gottl., Sägenfeiler, Holligenstrasse 35
 – Hans, städt. Beamter, Emanuel-Friedlistrasse 33 [27.077]
-– Hs.. Handlanger, Weidmattw. 16. Bümpliz
+– Hs., Handlanger, Weidmattw. 16. Bümpliz
 – Hans, Liftmonteur, Attinghausenstr. 21
 – Heidi. Bureaulistin, Wiesenstrasse 67
 – Hermann, Handlanger, Rodtmattstr. 64
@@ -43714,11 +43646,11 @@ Siegenthaler, Ernst (Fulirimann), Schwarztorstrasse 31
 – Ida (Mühlethaler), Wwe., Pension, Belpstrasse 47
 – Jakob, Mechaniker, Birkenweg 21
 – Joh., Coiffeur, Jägerweg 2
-– Joh Friedr.. Steckweg 13
+– Joh Friedr., Steckweg 13
 – Joh., Fabrikarbeiter, Burgfeldweg 22
 – Joh., Hilfsarbeiter, Weidmattweg 5, Bümpliz
 – Joh Ulr., Handlanger, Weidmattweg 5, Bümpliz
-– Joh.. Karrer, Bolligenstrasse 117
+– Joh., Karrer, Bolligenstrasse 117
 – Karl Werner, Maler, Effingerstrasse 6
 – Karl. Postpacker, Badgasse 51
 – Katharina, Bureaulistin, Em.-Friedlistr. 33
@@ -43816,7 +43748,7 @@ Siegrist u. Sigrist, s. auch Siegerist
 – Dora, kaufm. Angestellte, Aegertenstr. 53
 – Ed. (Egloff), eidg. Beamter, Schanzenbergstrasse 33 [32.0611
 – Edgar, Fürsprecher, Effingerstrasse 1
-– Edwin Walter, Schuhmachermeister. Fischermätteliweg 14 [29.480]
+– Edwin Walter, Schuhmachermeister, Fischermätteliweg 14 [29.480]
 – Elisabeth (Gründer), Wwe., Nelkenweg 17
 – Ella Lydia, Bureauangest., Schwaneng. 7
 – Emil, Coiffeur, Herren- und Damensalon, Burgunderstrasse 113, Bümpliz [46.161]
@@ -43825,8 +43757,8 @@ Siegrist u. Sigrist, s. auch Siegerist
 – Friedr., Geschäftsführer, Weissenbühlw. 4
 – Friedr., Gipser- und Malermeister (Mindstrasse 7), Aarbergergasse 47
 – Fritz, Mechaniker, Speichergasse 12
-– Gottfr.. Baumeister, in Fa. Sigrist & Berger, Wylerstrasse 15 [20.303]
-– Gotthold. Buchbindermstr.. Aegertenstr. 53
+– Gottfr., Baumeister, in Fa. Sigrist & Berger, Wylerstrasse 15 [20.303]
+– Gotthold. Buchbindermstr., Aegertenstr. 53
 – Gustav, Schreiner (Kramgasse 17), Brunngasse 24 [26.319]
 – H. (Hofmann), Prokurist d. Schweiz. Kreditanstalt, Thunstrasse 99 [31.748]
 – Hans, Bureaudiener, Hallwylstrasse 4
@@ -43839,7 +43771,7 @@ Siegrist und Sigrist, s. auch Siegerist
 – Jakob, eidg. Beamter, Karl-Staufferstr. 10
 – Jakob, Magazinchef, Waldheimstrasse 31 [28.355]
 – Joh., Fabrikarbeiter, Schwarztorstrasse 80
-– Joh. Friedr.. Hilfsarbeiter, Wylerstr. 16
+– Joh. Friedr., Hilfsarbeiter, Wylerstr. 16
 – Joh. (Baumgartner), Beamter des Gewerbepolizeiwesens, Jubiläumsstrasse 13 [20.457]
 – K. Emil, Chefmechaniker, Lagerweg 1
 – Karl, Beamter, Herzogstrasse 3
@@ -43859,10 +43791,10 @@ Siegrist und Sigrist, s. auch Siegerist
 – Paul, Handlanger, Belpstrasse 26
 – Rosa (Fehlbaum), Wwe., Aebistrasse 2
 – Rud., Schreiner, Pestalozzistrasse 8
-– Walter. Chef d. Betriebsdienstes d. K. T. D., Neubrückstrasse 57 [25.153]
+– Walter, Chef d. Betriebsdienstes d. K. T. D., Neubrückstrasse 57 [25.153]
 – Walter, Hilfsarbeiter, Effingerstrasse 88
 – Werner, Coiffeur, Breitenrainplatz 27 [27.349]
-– Willi Hans, Vers.-Angestellter. Aegertenstj-asse 53
+– Willi Hans, Vers.-Angestellter, Aegertenstj-asse 53
 – Wilhelm, Monteur S. B. B., Seidenweg 48
 – William, Photograph, Holzikofenweg 31
 – & Berger, Baugeschäft, Hoch- u. Tiefbau, Wylerstrasse 15 [20.303]
@@ -43878,7 +43810,7 @@ Sievers, August Karl, Geschäftsführer, Habsburgstrasse 7a
 – Theodor, Angestellter, Gutenbergstrasse 5
 Sigg, A. C., Beamtin O. T. D., Meisenweg
 – Adelheid. Bureaulistin, Hubelmattstr. 52
-– Alfred, Mechaniker,. Stadtbachstrasse 26 .
+– Alfred, Mechaniker,. Stadtbachstrasse 26
 – Emil, Vertreter, Kapellenstrasse 5
 # Date: 1935-12-15 Page: 26020772/465
 Simonettcinn E. Hermann, ckem.-techn. Produkte, Monbijoustrasse 39 [29.681]
@@ -43892,7 +43824,7 @@ Signer, Jak., Postbeamter, Wylerstrasse 71
 – Joh. Jak., Bahnangestellter, Lorrainestr. 9
 – Joh. Bapt., Kommis, Rainmattstrasse 18
 – Jos. Anton, Kaufmann. Heinr.-Wildstr. 2
-– M. Alfr.. Hilfsarbeiter, Ahornweg 7
+– M. Alfr., Hilfsarbeiter, Ahornweg 7
 – Rud. (Meier), Dr. phil., Prof., Hallerstr. 49 [25.844]
 – Traugott, Reisender, Lentulusrain 20
 Signoretti, Amedeo, Früchtehändler, Quartierhof 15
@@ -43904,7 +43836,7 @@ Sigwalt, Christina (Jost), Samenhandlung, Gerechtigkeitsgasse 27
 – J. (Jost), Angestellter, Gerechtigkeitsg. 27
 – Werner. Magaziner, Grüneckweg 10
 Silbert, Moische, Annoncen-Akquisiteur, Effingerstrasse 11
-Silna, Ph., Schneidermeister, Sennweg 1/Länggassstrasse 18 . [33.931]
+Silna, Ph., Schneidermeister, Sennweg 1/Länggassstrasse 18 [33.931]
 Silveira, Paulo, II. Sekr. der brasil. Gesandt. Schaft, Pension Bois-Fleury [23.970]
 Silux A.-G., Verwertung von Patenten, Spitalgasse 30
 Silvahof A.-G., Jubiläumsstr. 401 [31.531]
@@ -43956,9 +43888,9 @@ Steuerverwaltung, Lorrainestrasse 12 [32.844]
 – K. (Bösiger), Bureauchef S. B. B., Brünigweg 9
 – Kath. Elisab., Frl., Mühlemattstrasse 15
 – Marie, Bureaulistin, Hochfeldstrasse 45
-– Marie Lse. (Stoll), Wwe.. Elfenauweg 11a [36.249]
+– Marie Lse. (Stoll), Wwe., Elfenauweg 11a [36.249]
 – Moritz (Beer), Beamter der Schweiz. Landestopographie, Jägerweg 5 [34.015]
-– Oskar Ernst, Bahnarbeiter. Muldenstr. 55
+– Oskar Ernst, Bahnarbeiter, Muldenstr. 55
 – Otto, Chauffeur, Waffenweg 22
 – Paul W., Schreiner, Speichergasse 39
 – Rene, Teppichklopferei, Vertr. chem.-techn.
@@ -43975,13 +43907,11 @@ Simonett, Elsbeth, Laubeckstrasse 58
 – Hedwig, Rhythmiklehrerin, Hallwylstr. 28 [35.444]
 – Margaritha, schwed. Gymnastik-Direktorin, Hallwylstrasse 28 [35.444]
 – Simon, Sektionschef d. Direkt, d. Landestopographie, Hallwylstrasse 28 [35.444]
-Der zuverlässige Fahrplanfür Bern, in die nähere und weitere Umgebung istder Touristen - Fahrplan ( Verlag Hallwag, Bern), der Ihnen auch interessante Aufschlüsse über genussreiche Touren gibt.
-45/46
 # Date: 1935-12-15 Page: 26020773/466
 Simonetti, Angelo, Mineur, Ulmenweg 9
 – Angelo M., Schneider, Ulmenweg 9
 Simonin, Alb. E., Lagerist, Weissenbühlw. 34
-– Marie Lse. (Flury), Wwe. des Reg.-Rats, Monbijoustrasse 36 . [22.861]
+– Marie Lse. (Flury), Wwe. des Reg.-Rats, Monbijoustrasse 36 [22.861]
 – Pierre GL, Fürsprecher, im Advokaturbureau Bürgi & Simonin, Monbijoustr. 36 [22.861]
 Simplon, Hotel (Hotel garni), Aarbergerg. 60 [23.382]
 Singer, Joh. Jak. (Sifrig), Cbefmaschinist b.
@@ -44053,30 +43983,28 @@ Sollberger, Anna El. (Siegenthaler), Belpstrasse 57
 – Ernst, Vorarbeiter B. N. B., Freiburgstr.167
 – Flora. Damenschneiderin. Mattenenge 7
 – Friedr., Schreiner, Junkerngasse 26
-– Friedr.. pens. Tramführer. Bridelstrasse 30
+– Friedr., pens. Tramführer. Bridelstrasse 30
 – Fritz (Franzoni), Registerführer d. Stadt.
 Vormundschaftsbureaus, Holligenstrasse 47 [31.342]
 – Gottfried, Hilfsarb., Freiestr. 28 [29.118]
 – Hans, Malermeister, in Fa. Hostettler & Sollberger, Länggassstrasse 77 [28JB20]
 – Hans Emil, Postbeamter, Berchtoldstr. 37
 – Hans Otto. Techniker, Holligenstrasse^o
-– Hermann Rud., Bureauangestellter. Länggassstrasse 82
+– Hermann Rud., Bureauangestellter, Länggassstrasse 82
 – Ida Marie, Angestellte, Forsthausweg 5
 – Jakob, Mechaniker, Wiesenstrasse 33
 – J., gew. Bahnwärter, Hopfenweg 9
-Waschküchen-Anlagenfür Privat und öffentliche Gebäude in jeder gewünschten modernen Ausführung zu annehmbaren Preisen durchstettbachen
-Gerechtigkeitsg. 59 Telephon 21.040
 # Date: 1935-12-15 Page: 26020774/467
 Sollberger, Joh., Anschläger, Länggassstr. 77
 – Joh. Rud., Buchbinder, Murtenstrasse 28
 – Joh. Friedr., Handlanger, Forsthausweg 5
 – Joh., Postbeamter, Lorystrasse 12
 – K., Schreiner, Länggassstrasse 97
-– Karl, gew. Gasarbeiter. Bernstr. 38, Bümpliz
+– Karl, gew. Gasarbeiter, Bernstr. 38, Bümpliz
 – Karl. Maurer, Bemstrasse 38. Bümpliz
 – Karl Ernst, Postangest., Hopfenweg 54
 – Lina (Köchli), Wwe., Spezereihandlung, Tscharnerstrasse 30 [35.532]
-– Marie Karol.. Strickerin. Marzilistrasse 2
+– Marie Karol., Strickerin. Marzilistrasse 2
 – Martha, Bankangest., Blumensteinstr. 18
 – Otto, Metzger, Mühlemattstrasse 55
 – Paul, Maler und Graphiker, Freiestrasse 28 [29.118]
@@ -44096,10 +44024,10 @@ Soltermann, Alfred, Chauffeur, Lorbeerstr. 3, Bümpliz
 – Anna (Spycher), Wwe., Sulgeneckstr. 62
 – Bertha, Wwe., Gerechtigkeitsgasse 4
 – Ed. Rudolf, Chauffeur, Sulgeneckstr. 62
-– Ed.. Lithograph, Briinnenstr. 60, Bümpliz
+– Ed., Lithograph, Briinnenstr. 60, Bümpliz
 – Ernst, Abwart, Münzgraben 6
 – Ernst. Metallarbeiter Eggimannstrasse 24
-– Franz Otto. Gasarbeiter. Landoltstrasse 83
+– Franz Otto. Gasarbeiter, Landoltstrasse 83
 – Franz Werner, Elektromonteur, Tiefmattstrasse 9
 – Friedr W., Ausläufer, Brunnhof weg 21
 – Friedr., pens. Bahnarbeiter, Turnweg 37
@@ -44112,7 +44040,7 @@ Soltermann, Alfred, Chauffeur, Lorbeerstr. 3, Bümpliz
 – Hans Otto Bahnarbeiter, Seidenweg 34
 – Hans, Metzger, Moserstrasse 35
 – Hans N., Pianist. Sulgeneckstrasse 62
-– Hedwig Anna, Ladentochter. Sulgeneckstrasse 62
+– Hedwig Anna, Ladentochter, Sulgeneckstrasse 62
 – Ida, Zigarrenhdlg., Gesellschaftsstrasse 26
 – Joh., Kaufmann, Freiestrasse 40
 – Joh., Schlosser, Bridelstrasse 2
@@ -44161,12 +44089,12 @@ Sommer, Ad., pens. Kartograph der Landestopographie, Scheuermattweg 19 [25.698]
 – Fritz, Buchdrucker, Monbijoustrasse 17 [24.663]
 – Fritz, Kaufmann, Steinerstr. 35 [23.847]
 – Fritz, Kondukteur der B. L. S., Schwarztorstrasse 101
-– Fritz, Maschinenmeister. Ländteweg 1
+– Fritz, Maschinenmeister, Ländteweg 1
 – Gottfr. (Rickli). Malerweg 7 [34.088]
 – Gottfr., pens. Installateur, Waldheimstr. 45
 – Gottfr., Pferdewärter, Waffenweg 6
 – Gottl., Stationsbeamter, Weissensteinstr. 24
-– Hans Herrn . Chauffeur. Zentralweg 19
+– Hans Herm., Chauffeur. Zentralweg 19
 – Hans, Handlanger, Moritzweg 20
 – Hans, Mechaniker, Allmendstrasse 30
 # Date: 1935-12-15 Page: 26020775/468
@@ -44272,7 +44200,7 @@ Spähni und Späni
 – Emil. Postbeamter, Steinweg 9
 – Frz. O., Bauzeichner, Brunnhofweg 28
 – Friedr. W., Hilfsarbeiter, Brunnhofweg 28
-– Herm. Ed.. Reisender, Brunnhofweg 28
+– Herm. Ed., Reisender, Brunnhofweg 28
 – J. B. (Winzenried), Wwe., Jägerweg 12
 – Moritz, Angestellter, Birkenweg 22
 – Walter, Reparat. S. B. B., Pestalozzistr. 32
@@ -44295,7 +44223,7 @@ Waagen und Gewichte (Neubrückstr. 116 [31.749]), Eichstätte: Käfiggässchen 3
 – Margrith, Bureaulistin, Fabrikstrasse 35
 – Rob., Stadtkassier, Filiale Bümpliz, Brünnenstrasse 119, Bümpliz [46.037]
 – Rosa, Negoziantin, Bümplizstrasse 106
-– Walter, Beamter S. B. B.. Fichtenweg 1
+– Walter, Beamter S. B. B., Fichtenweg 1
 – Willi Alb., eidg. Beamter, Brünnenstr. 64, Bümpliz
 Spalinger, Karl, Postangestellter, Steinauw.27
 Spälti, Rud., Abwart, Marktg. 50 [35.472]
@@ -44372,7 +44300,7 @@ Spertini, Alice Regina, Verkäuferin, Länggassstrasse 70b
 – Pietro, Maurerpolier, Hochfeldstrasso 71
 – Pietro Paul, jun., Maurer, Länggassstr. 70b
 Spichiger, s. Spychiger
-Spichtin, Robert (Schäublin), Bureauchef der S. B. B.. Trachselweg 21 [45.383]
+Spichtin, Robert (Schäublin), Bureauchef der S. B. B., Trachselweg 21 [45.383]
 Spiegel, Fr. Heinr. Dan., Spengler, Moritzweg 28
 – Michael, Schneider, Metzgergasse 74
 Spiegelberg, Alice R. A., Breitenrainplatz 28 [35.591]
@@ -44399,7 +44327,7 @@ Spielmann, s. auch Spillmann
 – Viktor, Mittelstrasse 6
 Spiess, Aloisa, Musik- und Tanzlehrerin, Ulmenweg 9
 – Erwin Jos., Schriftenmaler, Kistlerweg 6
-– Eug. H.. Hutmacher. Weissenbühlweg 31
+– Eug. H., Hutmacher. Weissenbühlweg 31
 – Giov., Schreiner, Elisabethenstrasse 38
 – Gottfr., Bierbrauer, Felshaldenweg 16
 – Jakob, Schneider, Weissenbühlweg 31
@@ -44427,14 +44355,14 @@ Spindler, Alfred H., kaufm. Angest., Engerain 26
 Spinner, Henriette, Bureauangestellte bei der
 Bundeskanzlei, Brunnhofweg 22
 – J. (Kläntschi), Dienstchef d. Alkoholverwaltung, Brunnhofweg 22
-– Johanna, Ladentochter. Brunnhofweg 22
+– Johanna, Ladentochter, Brunnhofweg 22
 Spinnler, Eduard, Buchbinder, Niggelerstr.6
 Spirig, Alfr. L., Patissier, Mattenhofstrasse 13
 Spitalacker-Apotheke (Verwalt.: O. Baumann), Moserstrasse 23 [22.439]
 Spitalapotheke, Inselspital, Freiburgstrasse 4 [65.310]
 Spittler, Alb. R., Kaufmann, Gryphenhübeliweg 14
 – Friedr. Rud., Röster, Federweg 21
-– Rud. Friedr,, Sek.-Lehrer, Niggelerstr. 16 [26.241]
+– Rud. Friedr., Sek.-Lehrer, Niggelerstr. 16 [26.241]
 Spitznagel, Ad., Zeughausarbeiter, Breitfeldstrasse 37a
 Splendid-Palace, Cinema, v. Werdt-Passage [24.348]
 Splitter A.-G., Liegenschaftsvermittlung etc., Schauplatzgasse 11 [28.455]
@@ -44465,7 +44393,7 @@ Spörri, Ad. Herm., Magaziner O.T. D., Burgfeldweg 14
 Spörri, Werner Herm., Magaziner, Burgfeldweg 14
 – Wilhelm Ch., Gipser u. Maler, Gerberg. 9
 Sportinstitut Bern, Kirchenfeldstrasse 70 [23.172]
-Spoth, Hulda (Franke), Wwe,, Reparatur von Herren- u. Knabenkleidern, Gesellschaftsstrasse 35
+Spoth, Hulda (Franke), Wwe., Reparatur von Herren- u. Knabenkleidern, Gesellschaftsstrasse 35
 Spreng, Alfred, Arzt, Schanzenstrasse 23
 – Alfred, Lehrer der Töchterhandelsschule, Malerweg 11 [35.742]
 – Bertha (Strupler), Wwe. des Fürsprechs, Bubenbergstrasse 18a [31.824]
@@ -44518,15 +44446,15 @@ Spring, Fritz, Mechaniker, in Fa. Spring & Co., Belpstrasse 41
 – Gottfr., Beamter B L. S., Liebeggweg 9
 – Gottfr., Handlanger, Büraplizstrasse 188
 – Gottfr., Heizer, Felsenaustrasse 24
-– Gottfr., Hilfsarbeiter. Metzgergasse 16
+– Gottfr., Hilfsarbeiter, Metzgergasse 16
 – Hektor Adr., Gipser, Vereinsweg 9
 – Hermann (Leu), kaufm. Angest., Wylerstrasse 16
-– Joh. Walter. Angestellter, Murtenstr. 48
+– Joh. Walter, Angestellter, Murtenstr. 48
 – Joh., Fabrikarbeiter, Brunngasse 14
 – Joh., Spengler, Lentulusrain 11
 – Johanna. Bureaulistin Cäcilienstrasse 24
 – Johanna, Ladentochter, Rodtmattstr. 66
-– Johanna El.. Ladentochter. Marzilistr. 30
+– Johanna El., Ladentochter, Marzilistr. 30
 – Julia A., Coiffeuse, Marzilistrasse 30
 – K. Friedr., Heizungstochniker, Sulgenheimweg 10
 – K. (Feldscher), Milch-, Butter- u. Käsehandlung, Lorrainestrasse 63 [32.689]
@@ -44553,7 +44481,7 @@ Sproll, Anna Kl., Weissnäherin, Brückenstr. 5
 Sprunger, Jules R., Kondukteur, Hochfeldstrasse 19
 Spühler, Albert, Chefmonteur, Hauensteinweg 16 [45.020]
 – Anna M. E. (Bürki), Wwe., Seidenweg 53
-– Ed., Bankangestellter. Dietlerstrasse 12
+– Ed., Bankangestellter, Dietlerstrasse 12
 – Emil, Elektromonteur, Ladenwandstr. 17
 – Ernst, Fabrikarbeiter, Gewerbestrasse 12
 – Heinr. (Condron), Vertreter, Greyerzstr. 38
@@ -44568,7 +44496,7 @@ Spycher, Albrecht, Automaler, Balmweg 20
 Spycher, Alois, Fabrikarbeiter, Waldheimstrasse 10b
 – Anna (Würthner), Polygonweg 6
 – Anna Th., Fabrikarbeiterin, Ralligweg 16
-– Aug.. Eisengiesser, Muldenstrasse 46
+– Aug., Eisengiesser, Muldenstrasse 46
 – B., Magaziner, Kesslergasse 13
 – Bertha Marg., Haushaltungslehrerin, Monbijoustrasse 35
 – Bertha, Kassiererin, Laubeckstrasse 59
@@ -44583,19 +44511,19 @@ Spycher, Alois, Fabrikarbeiter, Waldheimstrasse 10b
 – Emma, Corsetiere, Schiösslistrasse 23
 – Emma, Schwarztorstrasse 104 [23.682]
 – Emma (Burri), Wwe., Schlösslistrasse 23
-– Ernst Arn.. Maurer. Bümplizstrasse 12
+– Ernst Arn., Maurer. Bümplizstrasse 12
 – Ernst, Bauführer, Effingerstrasse 41c [26.387]
 – Eugen Alb. (Glauser), Fabrikarb., Schützenweg 7
 – Eureka M., Bureaulistin, Bürglenstrasse 33
 – Friedr. (Klay), ’pens. Bahnarbeiter, Lorrainestrasse 68
 – Friedr. Rob., Hauswart, Spitalgasse 4
-– Friedr.. Hilfsarbeiter. Stöckackerstr. 77a, Bümpliz
+– Friedr., Hilfsarbeiter, Stöckackerstr. 77a, Bümpliz
 – Fritz, Monteur, Stöckackerstr. 77a, Bümpliz
-– Gertrud Fr., Bankangestellte. Sulgenbachstrasse 42 .
+– Gertrud Fr., Bankangestellte. Sulgenbachstrasse 42
 – Gottfr., Bureaulist, Muesmattstrasse 30
-– Gottfr.. Hilfsarbeiter. Fischermätteliweg 2
-– Gottfr.. Kommis. Sulgenbachstrasse 42
-– Hans W.. Chauffeur, Freiburgstr. 125a
+– Gottfr., Hilfsarbeiter, Fischermätteliweg 2
+– Gottfr., Kommis. Sulgenbachstrasse 42
+– Hans W., Chauffeur, Freiburgstr. 125a
 – Hans Werner, Bautechniker, Bottigenstrasse 395, Riedbach
 – Hans A., Heliograph, Bümplizstrasse 12
 – Hans, chirur. Instrumentenmacher, Breitr feldstrasse 31a
@@ -44604,7 +44532,7 @@ Spycher, Alois, Fabrikarbeiter, Waldheimstrasse 10b
 – Hans, Schreiner, Kesslergasse 13
 – Hedwig, Buchbinderin, Gerechtigkeitsg. 25
 – Herm., Feinmechan., Sulgenbachstr. 42
-– J. Gottfr.. städt. Beamter, Bottigenstr. 395, Riedbach
+– J. Gottfr., städt. Beamter, Bottigenstr. 395, Riedbach
 – Joh. Gottfr., Maurer, Sulgeneckstrasse 58c
 – Karl, Portier. Bundesgasse 8
 – Lina, Schneiderin, Neuhäuserweg 1
@@ -44628,7 +44556,7 @@ Spycher, Rosa, Damenschneiderin, Schwarztorstrasse 20
 Spychiger u. Spichiger
 – Christ., Bureauangest., Elisabethenstr. 24a
 – Ernst. Bäcker, Effingerstrasse 4
-– Eugen, Techn.. Neufeldstr. 129 [32.162]
+– Eugen, Techn., Neufeldstr. 129 [32.162]
 – Friedr., Bauhandlanger, Marzilistrasse 23
 – Fr., Bureauchef S. B. B., Balderstrasse 40 [29.182]
 – Joh., Bereiter, Militärstrasse 55
@@ -44700,7 +44628,7 @@ Stäger, s. auch Steger
 – Emil Oskar, Spengler und Installateur, Sulgenauweg 39
 – Ernst, Trambilletteur, Thunstrasse 41a
 – Ernst Rud., Bankangest., Schläflirain 1
-Gottfr.. Landwirt, Elfenauweg 46
+Gottfr., Landwirt, Elfenauweg 46
 – Gottfr., Magaziner. Spitalackerstrasse lb
 – Grete, Kunstmalerin, Alpenstrasse 26 [32.009]
 Hans, Landwirt, Elfenauweg 46 [22.927]
@@ -44738,7 +44666,7 @@ Stähli, Alb., pens. Revisor b. d. Oberpostdirektion, Landhausweg 5
 Berchtoldstrasse 37 [22.183]
 – Fritz Walter, Kaufmann, Seminarstr. 24
 – Fritz, Schmied, Federweg 53
-– Gottfr.. Hilfsarbeiter, Scheibenstrasse 35
+– Gottfr., Hilfsarbeiter, Scheibenstrasse 35
 – Gottfr. (Gründer), Zimmermann, Gerechtigkeitsgasse 38
 – Hans Ernst, Radiotelegraphist, Freiburg-Strasse 125
 – Hedwig, Kontrollgehilfin O. T. D., Effingerstrasse 14a
@@ -44785,8 +44713,8 @@ Sialder, Albert, Kaufmann, Kursaalstr. 10
 – Anna, Damenschneiderin, Freiburgstr, 350, Bümpliz
 – Armin Joh. Ulr., Elektriker, Kramgasse 16 [29.982]
 – Arthur. Techniker b. Kantonsoberingenieur, Waldheimstrasse 10b
-– C. (Egger). Wwe.. Privatiere. Hallerstr. 1
-– E. Fr., Beamter S. B. B.. Kirehbühlweg 50
+– C. (Egger). Wwe., Privatiere. Hallerstr. 1
+– E. Fr., Beamter S. B. B., Kirehbühlweg 50
 – Emil, Beamter d. S. B. B., Alter Aargauerstalden 5 [22.074]
 – Erna M., Bureaulistin, Waldheimstr. 10b
 – Ernst, Antiauitäten, Kramgasse 29
@@ -44820,7 +44748,7 @@ Stalder, Fritz (Bigler), Schuhhdlg. u. Massgesehäft (Brückfeldstrasse 36 [34.3
 – Hugo K., Fabrikarbeiter, Kesslergasse 30
 – -Jak. Ernst, Postgehilfe, Greyerzstrasse 26
 – Jakob, Schreiner, Muesmattstrasse 41
-– Joh Friedr.. Ing.. Inspektor b. eidg. Eisenbahndepart., Optingenstr. 10 [27.482]
+– Joh Friedr., Ing., Inspektor b. eidg. Eisenbahndepart., Optingenstr. 10 [27.482]
 – Joh., Magaziner, Mezenerweg 7
 – Joh. Rud. (Bieri), Schreinerei und Möbelwerkstätte (Lorrainestr. 6a), Kirchgasse 16
 – Joh., Telephonmonteur, Jurastrasse 27
@@ -44841,7 +44769,7 @@ Strasse 54
 – Mina, Frau, Länggassstrasse 40a
 – Moritz, Lehrer, Brückfeldstrasse 36
 – Nelly. Bureaulistin, Waldheimstrasse 10b
-– Otto W. Bankangestellter. Cäcilienstr.21
+– Otto W. Bankangestellter, Cäcilienstr.21
 – Otto, Maurer, Ladenwandstrasse 84
 – P. & L., Hut- u. Mützenfabrik, Optingenstrasse 54 [22 080]
 – Paul, pens. Lehrer der Breitenrainschuie, Kasernenstrasse 34 [36.224]
@@ -44850,27 +44778,27 @@ Strasse 54
 – Paul, Spengler, Gerechtigkeitsgasse 51
 – Paul, in Fa. P. & L. Stalder, Optingenstrasse 54
 – Pauline, Weberin, Langmauerweg 15
-– Peter Jos., pens. Eisenbahnbeamter. Thunstrasse 6 [24.675]
+– Peter Jos., pens. Eisenbahnbeamter, Thunstrasse 6 [24.675]
 – Rosa Marg., Verkäuferin b. Konsum, Muesmattstrasse 44
 # Date: 1935-12-15 Page: 26020782/475
 Stalder, Rosa (Reist), Wwe., Bernastrasse 71
-– Rud.. Mechaniker. Militärstrasse 55
+– Rud., Mechaniker. Militärstrasse 55
 – Rud., Uniformfabrik u. Massgeschäft (Alexandraweg 4 [28.195]), Spitalgasse 88 [22.508]
 – Rud. Paul, Fürsprecher, Jubiläumsstr. 401, Silvahof
 – Viktor F. H., Beamter der B. L. S., Länggassstrasse 73
-– Walter. Ausläufer. Langmauerweg 17
+– Walter, Ausläufer. Langmauerweg 17
 – Walter, Karrer, Rodtmattstrasse 106
 – Walter Julius, Optiker, Jurastrasse 17
 – Werner, Biskuitsfabrik (Alexandraweg 4 [28.195]), Länggassstrasse 61 [20.095]
 – Willy, Radiotelegraphist, Alexandraweg 4 [28.195]
 Stamatiadis, Alexander, Hilfsarbeiter, Kapellenstrasse 30
-– G.. Tabakmeister. Dietlerstrasse 4
+– G., Tabakmeister, Dietlerstrasse 4
 – Willy, Radiogeschäft (Dietlerstrasse 4), Aarbergergasse 61 [29.609]
 Stambach, Walter, eidgen. Beamter, Hallerstrasse 55
 Stamm, Alwine, Bubenbergstrasse 19
 – Christian (Grützner), Bibliothekar, Zeughaasgasse 20
 – Elsa Lydia, Verkäuferin, Neufeldstrasse 38
-– Heinr.. pens. Polizist, Neufeldstrasse 38
+– Heinr., pens. Polizist, Neufeldstrasse 38
 – Heinr Werner, Elektromechaniker, Neufeldstrasse 38
 – Jakob. Zugführer, Länggassstrasse 21a
 – Reinhard Th., Elektrotechniker, Brunnhofweg 20
@@ -44896,16 +44824,16 @@ Stampfli, Alice, Bureaulistin, Knüslihubelweg 27
 – Otto, Zeichner, Thunstrasse 116
 – Stephan, Chauffeur, Waldheimstrasse 16
 Stämpfli, Adolf, Hilfsarbeiter, Postgasse 32
-– Alfr., kant. Beamter. Graffenriedweg 8
+– Alfr., kant. Beamter, Graffenriedweg 8
 – Alice, Bankangestellte, Schwarztorstr. 22
 Stämpfli, Alice, Ladentochter, Breitenrainstrasse 19
 – Arthur, Güterarbeiter S. B. B., Freiburgstrasse 125a
-– C.. Buchhalter. Thunstrasse 92
+– C., Buchhalter, Thunstrasse 92
 – Elisabeth, Verkäuferin, Gotthelfstrasse 20
 – Ernst, Chauffeur u. Magaziner, Rosenw. 9a
 – Ernst, Dental-Laboratorium (Lyss), Ghristoffelgasse 7 [20.170]
 – Ernst W., Kaufm., Greyerzstr. 32 [27.447]
-– Ernst. Pferdewärter. Breitfeldstrasse 8
+– Ernst. Pferdewärter, Breitfeldstrasse 8
 – Ernst Emil. Steindrucker, Kramgasse 15
 – Franz. Angestellter S. S. B., Kirchbergerstrasse 1
 – Franz, Fürsprecher, Bundesanwalt, Wittigkofenweg 9 [25.280]
@@ -44922,7 +44850,7 @@ Stämpfli, Alice, Ladentochter, Breitenrainstrasse 19
 – Gottfried, Schreiner, Burgunderstrasse 140, Bümpliz
 – Gottl. J. u El., Kolonialwarenhandlung, Greyerzstrasse 47 [23.400]
 – Hans, Coiffeur, Marktgasse 52
-– Hans Paul, Kaufmann. Sulgeneckstr. la
+– Hans Paul, Kaufmann. Sulgeneckstr. 1a
 – Hedwig Gertr., Hilfsarbeiterin, Schwalbenweg 28
 — Herm., Dachdecker u. Hafnerarbeiten, Gesellschaftsstrasse 41 [28.888]
 – Johanna Kath., Angestellte, Burgunderstrasse 140, Bümpliz
@@ -44954,12 +44882,12 @@ Stämpfli, Rud., Bahnarb., Freiburgstr. 125a
 – Rudolf (Eugster), Buchdrucker, Schiösslistrasse 17 [22.625]
 – Rud. Otto, Schreiner, Schwarztorstr. 102
 – Ruth Grete, Bureaulistin, Zähringerstr. 23
-– S., Metzgermeister. Rodtmattstrasse 97 [32.286]
+– S., Metzgermeister, Rodtmattstrasse 97 [32.286]
 – W., Dr. jur., Brunnadernstr. 50 [23.065]i—Walter Franz, Schreiner, Standstrasse 28
 – Werner Otto, Ausläufer, Rodtmattstr. 57
 – Werner, Koch, Flurstrasse 31
 – Werner, kaufm. Angest., Bantigerstr. 14
-.— & Cie., Buchdruckerei, Verlag u. Buchbinderei, Stereotypie u. Galvanoplastik, Hallerstrasse 7/9 [23.012]
+— & Cie., Buchdruckerei, Verlag u. Buchbinderei, Stereotypie u. Galvanoplastik, Hallerstrasse 7/9 [23.012]
 Ständer, Emil, Lehrer, Wildermettweg 54 [33.600]
 Stanger, Marie E. (Hodel), Wwe., Vergoldungs- u. Versilberungsanstalt, Dalmazirain 22 [31.027]
 Stanka, Franz, Schuhhandlg., Kramgasse 37 [35.9551
@@ -44967,13 +44895,13 @@ Stanka, Franz, Schuhhandlg., Kramgasse 37 [35.9551
 Stark, Ernst, Teppichstopferei, Brunnmattstrasse 65 [36.551]
 – Friedr Wilh., Werkmeister, Beaumontweg 38i— Hans, Sohn. Camionneur, Automietfahrten, Aarbergergasse 20 [26.084]
 – Joh., Reisender, Aarbergergasse 20
-Starkstrominspektorat, eidg.. Schwaneng. 1 [22.893]
+Starkstrominspektorat, eidg., Schwaneng. 1 [22.893]
 Stather, Luise (Kiener), Wwe., in Fa. Stather & Venner, Bantigerstrasse 22 [31.201]
 – & Venner, Gipser- u. Malergeschäft, Bantigerstrasse 22 [31.201]
 Statistisches Amt, eidg., Hallwylstr. 15 [61]
 Statistisches Amt (städt.), Gurtengasse 3 [23.524]
 Statistisches Bureau des Kantons Bern, Falkenplatz 4 [35.546]
-Staub, A., Postangestellter. Rodtmattstr. 75
+Staub, A., Postangestellter, Rodtmattstr. 75
 – Adolf, Maler u. Glaser, Länggassstrasse 23
 – A. Kl., pens. Lehrerin, Wildermettw. 46
 – Alb. E., Tapezierer, Lorrainestr. 1
@@ -45006,7 +44934,7 @@ Landestopographie, Sandrainstrasse 102 [20.011]
 – Jak., Lehrer, Muristrasse 8a
 – Jak. Emil, Privatier, Schosshaldenstr. 1
 – Joh. (Welti), pens. Bahnhofvorarbeiter, Konsumstrasse 14c
-– Joh. Friedr.. Schuhmacher. Bümplizstr. 67
+– Joh. Friedr., Schuhmacher. Bümplizstr. 67
 – Joh. Hrch., Filialleiter, Finkenhubelweg 30 [28.082]
 – Karl Friedr., Buchhalter, Schläflirain 3
 – Lydia, Lingere, Steinhölzliweg 35
@@ -45063,7 +44991,7 @@ Stauffer, A., A.-G., Detailverkauf von Hütenu. Herrenmodeartikeln, Hutmanufaktu
 – Alb. Walter, Mechaniker, Talweg 5
 – Albert, Monteur, Belpstrasse 49
 – Albert, Reisender, Rosshäusernstrasse 35, Bümpliz
-– Alfred, Reg.-Rat, Florastr. 25 . [34.588]
+– Alfred, Reg.-Rat, Florastr. 25 [34.588]
 – Alfr., kaufm. Angest., Sandrainstr. 84
 – Arnold, Hilfsarbeiter, Scheibenstrasse 36
 – Arnold, Polizeigefreiter, Sennweg 19
@@ -45157,11 +45085,11 @@ Stauffer, Paul, Bazar Streiff (Sohillingstr. 3 [35.776]), Bärenplatz 4 [23.016]
 – Wm. E., Beamter der Darlehenskasse der
 Schweiz. Eidgenossenschaft, Kistlerweg 10
 – & Co., Drogerie, Schauplatzg. 7 [23.350], Stauffiger, Hans, Metzger, Dietlerstrasse 12
-Stavag A.-G,, An- u. Verkauf von Automobilen, Amthausgasse 24 [21.700]
+Stavag A.-G., An- u. Verkauf von Automobilen, Amthausgasse 24 [21.700]
 Sfavro, Andre, Dr. jur., Fürsprecher (Monbijoustrasse 92 [28.029]), Hirschengraben 8 [21.942]
 Stebler, Alb., Coiffeur, Rütlistrasse 4
 – Dora, Lehrerin, Gerechtigkeitsgasse 22
-– Ed . Sekretär d. O Z. D., Neufeldstr 32
+– Ed., Sekretär d. O Z. D., Neufeldstr 32
 – Franz Ludw., Hilfsmonteur, Schwarzenburgstrasse 64
 – G., Spenglermeister, Gerechtigkeitsgasse 22 [34.378]
 – Hans, Photograph, Birkenweg 44
@@ -45192,7 +45120,7 @@ Steck, Ida (Bernlochner), Muldenstrasse 1
 – Rudolf W., kaufm. Angest., Belpstr 11 [23.664]
 – Sophie, Frl., Bubenbergplatz 4
 – Th., Dr. phil., gew. Oberbibliothekar der Stadtbibliothek. Tillierstrasse 8 [22.248]
-– Ulr.. pens Beamter d. Landestopographie, Elisabethenstrasse 42 [27.082]
+– Ulr., pens Beamter d. Landestopographie, Elisabethenstrasse 42 [27.082]
 Steckler, Chs. A., Versich.-Beamter, Blumenstein strasse 3
 – K. M., Buchhalter, Blumensteinstrasse 3 [35.245]
 Steenken, Eduard Hrch., Kunsthändler, Stauffacherstrasse 41
@@ -45226,10 +45154,10 @@ Steffen, Adolf (Glur), Schlosser, Hopfenweg 40
 – Friedr., Holzer, Murtenstr. 217, Bümpliz
 – Friedr., Magaziner, Freiburgstrasse 163
 — Friedr. (Tüscher), Sattlermeister b. kant. Kriegskommissariat. Beundenfeldstr. 54
-– Fritz, Dr.. Jubiläumsstrasse 21 [32.68BJ
-– Gottfr.. Hilfsarbeiter, Mattenhofstr. 36
-– Gottfr.. Handlanger, Bümplizstrasse 19
-— Gottfr.. Hilfsarbeiter, Militärstrasse 49
+– Fritz, Dr., Jubiläumsstrasse 21 [32.68BJ
+– Gottfr., Hilfsarbeiter, Mattenhofstr. 36
+– Gottfr., Handlanger, Bümplizstrasse 19
+— Gottfr., Hilfsarbeiter, Militärstrasse 49
 — Gottfr Anton, Generalagent der Alpina-Versicherung, Fischerweg 22 [20.24UJ
 – Hans Alfr., Gärtner, Alleeweg 22
 # Date: 1935-12-15 Page: 26020786/479
@@ -45238,7 +45166,7 @@ Steffen, Hedwig, Aarbergergasse 6
 – Ida Emma, Bureaulistin, Altenbergstr. 26
 – Jakob, Magaziner, Altenbergstrasse 26
 – Jakob, Postangest., Spitalackerstrasse 69
-– Joh., Hilfsarbeiter. Kirchbergerstrasse 10
+– Joh., Hilfsarbeiter, Kirchbergerstrasse 10
 – Joh., Postangestellter, Drosselweg 25
 – Joh. Jak. (Krebs), Zimmermann, Scheibenstrasse 30
 – Karl, Blockwärter, Jurastrasse 32
@@ -45253,16 +45181,16 @@ Steffen, Max Albr. 📞 34.841 (Kirchhoff), dipl. Archit., S.-I.-A., Brunnaderns
 – Otto, pens. Bankangestellter, Altenbergstrasse 120 [35.938]
 – Otto G., Schriftsetzer, Falkenplatz 7
 – Paul, Schreiner. Rodtmattstrasse 61
-– Roh., städt. Beamter. Bantigerstrasse 43
+– Roh., städt. Beamter, Bantigerstrasse 43
 – Rob. (Schellenberg), Fürspr., Langmauerweg 110 [26.375]
 – Robert Walter, Schuhmachermeister (Cäcilienstrasse 27), Junkerngasse 3
 – Rosa B., Frau, Glätterin, Herzogstrasse 8
 – Rosa, Sekretärin, Tscharnerstrasse 47
-– Rosa (Nüesch), Wwe.. Seilerstr. 6 [33.526]
+– Rosa (Nüesch), Wwe., Seilerstr. 6 [33.526]
 – Rud., Privatier, Eichmattweg 5
 – Walter (Junker), Glaser, Buchenweg 10
 – Walter, Kartograph, Cäcilienstrasse 26
-– Walter. Maler, Waffenweg 20
+– Walter, Maler, Waffenweg 20
 – Walter, Schlosser, Neufeldstrasse 118
 – Werner, Handlanger, Wachtelweg 15
 – Werner, Hilfsarbeiter, Heckenweg 19
@@ -45282,7 +45210,7 @@ Stegmann, Adolf, Wirt z. Beaulieu, Erlachstrasse 3 [22.459]
 Schlosser, Ferd.-Hodlerstr. 16
 — Frieda, Schneiderin, Länggassstrasse 10
 ""nr’ S pen §l er > Fischermätteliweg 17
-– U Ed.. Gasarbeiter, Badgasse 41
+– U Ed., Gasarbeiter, Badgasse 41
 Otto Ed., Tapezierer, Badgasse 41
 Stehelin, Andree Charlotte, Seilerstrasse 24
 – Augusta (Wittmer), Privat., Seilerstr. 24 [29.973]
@@ -45356,8 +45284,7 @@ Steiger, s. auch v. Steiger und Gsteiger
 — Rob., Seelandweg 7 [32.610]
 – R., Frau, in Fa. Steiger, vorm. Fritz Steiger, Gummiwaren u. Kellereiartikel, Monbijoustrasse 27 [32.375]
 – Rudolf Ernst, Telephonarbeiter, Junkerngasse 36 [35.146]
-– Viktor Jakob, Dr. jur., Sekretär der eidg.
-Alkoholverwaltg., Kramburgstr. 20 [21.859]
+– Viktor Jakob, Dr. jur., Sekretär der eidg. Alkoholverwaltg., Kramburgstr. 20 [21.859]
 — W. (Dubach), in Fa. Buchdruckerei Steiger, Spitalackerstrasse 28 [33.789]
 — Walter, Buchbinder, Mühlemattstrasse 58
 — Walter, Coiffeurgeschäft (Marzilistrasse 6), Marzilistrasse 15 [35.769]
@@ -45404,7 +45331,7 @@ Steimle, Ludwig, in Fa. Steimle & Cie. Balmweg 25 [22.487]
 – Hedwig (Moser), Wwe., Steinhölzliweg 67 [4.5-349]
 – Oskar. A.-G., Sperrholzlager, Neuhäuserweg 10 [20.646]
 – & Co., Akt.-Ges., Schreinerei. Fensterfabriku. Holzhandlung, Neuhäuserweg 7 [20.648
-Stein, M. W.. Dr. phil.. Kramgasse 43 [27.335]
+Stein, M. W., Dr. phil., Kramgasse 43 [27.335]
 – Theodor (Falk), Ingen., Blumenbergstr. 39
 # Date: 1935-12-15 Page: 26020788/481
 Steinacher, Alois (Lang). Dalmaziweg 103 [21.446]
@@ -45471,8 +45398,7 @@ Steiner, E. Helene, Schneiderei-Atelier, Seilerstrasse 22 [27.995]
 – Ernst, Chauffeur, Militärstrasse 14
 – Ernst, Sohn, Garage-Portier, Bernstrasse 5
 – Ernst Charles, Hafner, Neubrückstrasse 73
-– Ernst Theodor, Vertr. d. Fa. Andre & Cie.
-A.-G., Lausanne, Getreidehandel (Monbijoustrasse 21), Bollwerk 15 [24.892]
+– Ernst Theodor, Vertr. d. Fa. Andre & Cie. A.-G., Lausanne, Getreidehandel (Monbijoustrasse 21), Bollwerk 15 [24.892]
 – Ernst, Handlanger, Lorrainestrasse 43
 – Ernst, Handlanger, Werkg. 21, Bümpliz
 – Ernst, Hilfsarbeiter, Optingenstrasse 45
@@ -45485,7 +45411,7 @@ A.-G., Lausanne, Getreidehandel (Monbijoustrasse 21), Bollwerk 15 [24.892]
 – Eugen Rud., Sänger, Neufeldstrasse 111
 – Fanny (Aemmer), Lentulusstrasse 44
 – Fanny Dora, Bureaulistin, Lentulusstr. 44
-– Felix Friedr.. Metzger, Freiburgstrasse 55
+– Felix Friedr., Metzger, Freiburgstrasse 55
 – Ferdinand. Buchhalter, Schulweg 11
 – Ferd., Geschäftsführer des Metallarbeiterverbandes, Schulweg 11
 – Fr. (Reinhard), Beamter d. Hauptkasse d.
@@ -45503,7 +45429,7 @@ S. B. B., Steinauweg 30
 – Friedr. Ernst, Restaurant Postgasse, Postgasse 48 [36.044]
 – Friedr., städt. Beamter, Karl-Staufferstr. 26
 – Friedr., Techniker, Heinrich-Wildstrasse 5 [20.728]
-– Fritz, kaufm. Angest.. Pestalozzistrasse 38
+– Fritz, kaufm. Angest., Pestalozzistrasse 38
 – Fritz. Kassier, Lorystrasse 6
 – Fritz (Flockiger), Beamter B. L. S., Schönbergweg 22 [32.227]
 # Date: 1935-12-15 Page: 26020789/482
@@ -45534,7 +45460,7 @@ Steiner, Fritz 📞 24.195 gew. Stadtingenieur, Ingenieurbureau (Unt. Dufourstra
 – Hedwig, Bureaulistin, Thunstrasse 38
 – Hedwig, Fabrikarbeiterin, Haspelweg 40
 – Hedwig, Schwimmlehrerin, Jurastrasse 23
-– Heinr. A.. Inspektor der Schweiz. Mobiliar-Versicherungsgesellschaft, Riedweg 1 [35.260]
+– Heinr. A., Inspektor der Schweiz. Mobiliar-Versicherungsgesellschaft, Riedweg 1 [35.260]
 – Helene, Gehilfin K. T. D., Viktoriastr 59
 – Helene, Bureaulistin. Weissensteinstr 114
 – Helene Gertrud, Einlegerin, Brückenstr. 11
@@ -45585,15 +45511,15 @@ Steiner, Joh. Ulr., Chauffeur, Hopfenrain 16
 – Rob., Angestellter, Hopfenrain 16
 – Rob., Ausläufer, Brunngasse 54
 – Rob., Mechaniker, Weissensteinstrasse 34
-– Rob. (v. Arx), Postangestellter. Weissensteinstrasse 34 [29.686]
+– Rob. (v. Arx), Postangestellter, Weissensteinstrasse 34 [29.686]
 – Robert. Seminarlehrer und Organist, Obstbergweg 3
 – Rosa (Kipfer), Wwe., Gerechtigkeitsg. 35
 – Rosalie, Bureaugehilfin O. P. D., Breitenrainstrasse 81
 – Rosalie Joh., Knabenschneiderin, Jungfraustrasse 22
 – Rosina, Höheweg 34
 – Rosina (Waltert), Wwe., Forsthausweg 1
-– Rud.. Abwart, Gerbergasse 10 [27.754]
-– Rud.. Schriftsetzer, Mattenhofstrasse 13
+– Rud., Abwart, Gerbergasse 10 [27.754]
+– Rud., Schriftsetzer, Mattenhofstrasse 13
 – S. (Ramser). gew. Gärtner, Holligenstr. 34
 – S. A., Polizeikorporal, Thunstrasse 38
 – Severin Jos., Polizeikorporal, Murtenstr. o
@@ -45610,7 +45536,7 @@ Steiner, Theophil Max, Journalist, EffingersträssG /9
 – Werner Jak., Kaufmann, Zieglerstrasse 33
 – Werner Rud., Möbelschreiner, Mühlemattstrasse 35
 – Werner, Schneider, Rodtmattstrasse 112
-– Wilh.. Tramangestellter. Mindstrasse 4
+– Wilh., Tramangestellter, Mindstrasse 4
 – Willy, Hilfsarbeiter, Läuferplatz 6
 – Willy, Schlosser, Weissensteinstrasse 34 [29.636]
 – Xaver, Angestellter, Eigerplatz 12
@@ -45633,13 +45559,13 @@ Steinmann, s. auch Steinemann
 – Anna B. (Gerber), Wwe. des Schulsekret., Wylerstrasse 36
 – Anna B. (Tüscher), Wwe., Viktoriastr. 43
 – Anna Maria (Häberli), Wwe., Berchtoldstrasse 31
-– Aug., Polizeiwachtmeister. Mühlemattstr.43
+– Aug., Polizeiwachtmeister, Mühlemattstr.43
 – Bernhard, Br. med., Vereinsweg 4 [29.803]
 – Dora Hedwig, Bureaulistin, Viktoriastr. 43
 Ernst, Dr. jur., Generalsekretär (Effingerstrasse 31 [27.592]), Bundesplatz 2 [24.832]
 – Ernst, Dreher S S B., Schwarzenburgstr.64
 – Ernst, Mechaniker, Weissenbühlweg 31
-– Friedr.. Hilfsmechan., Kehrg. 54, Bümpliz
+– Friedr., Hilfsmechan., Kehrg. 54, Bümpliz
 – Friedr., Kommis, Zähringerstrasse 62
 – Friedr. A., Vers.-Beamter, Zähringerstr. 62
 – Gottl. Ed., Maurer, Stalden 9
@@ -45691,7 +45617,7 @@ Sterchi, Ad., Fabrikarbeiter, Lentulusstr. 34
 – Ernst, Büchsenmacher, Wiesenstrasse 30
 – Ernst Robert, Feinmechan., Länggassstr. 31
 – Ernst, Pferdewärter, Standstrasse 19
-– Ferd., Spengler, Postgasse 60 .
+– Ferd., Spengler, Postgasse 60
 # Date: 1935-12-15 Page: 26020791/484
 Sterchi, Frieda, Sekretärin, Florastrasse 26 [34.076]
 – Fritz, Beamter O. T. D., Meisenweg 16 [35.244]
@@ -45785,9 +45711,6 @@ Stettier, Alfr., pens. Installateur, Tscharnerstrasse 39a
 – Fritz (Schweizer), Milchhändler, Zähringerstrasse 23 [27.700]
 – Fritz (Liechti), Reitlehrer, Herzogstr. 3
 – Fritz, Steinhauer, Scheibenstrasse 21
-Badeanlagenin mod., gediegener Ausführung.
-Schlafzimmer-Toiletten, Waschküchenanlagen usw. fachgemässstettbacher
-Gerechligkeitsg. 59 Telephon 21.040
 # Date: 1935-12-15 Page: 26020792/485
 Stettier, Gertrud, Damenschneiderin, Moserstrasse 52
 – Gertrud E., Fürsorgerin, Riedweg 19
@@ -45823,11 +45746,11 @@ Stettier, Gertrud, Damenschneiderin, Moserstrasse 52
 – Jean, kant. Beamter, Schosshaldenstr. 9
 – Joh. Emil (Roth), pens. eidgen. Beamter, Steinerstrasse 31
 – Joh. Adolf, Fabrikarbeiter, Nydeckhof 41
-– Joh., Gasarbeiter. Muristrasse 89
+– Joh., Gasarbeiter, Muristrasse 89
 – Joh., Hilfsarbeiter, Schreinerweg 6
 – Joh. Fr., Hilfsarbeiter, Schönburgstr. 48
 – Joh., Hilfsarbeiter, Bümplizstrasse 169
-– Joh.. pens. Landjägerfeldweibel, Bemastrasse 59
+– Joh., pens. Landjägerfeldweibel, Bemastrasse 59
 – Joh., Maler, Murifeldweg 28
 – Julius, Beamter S. B. B., Beaulieustr. 29
 – K. R. Eduard, pens. Bahnarbeiter, Wylerringstrasse 78
@@ -45857,10 +45780,10 @@ Stettier, Max, optisch.-phys. Werkst. (Willadingweg 43 [32.348]), Marktg. 46 [34
 – Rud. Gottl., Hilfsarbeiter, Neuengasse 11a
 – Rud., Magaziner, Junkerngasse 26
 – Rud., Packer u Magaziner, Landhausw. 6a
-– Rud.. Maler, Murifeldweg 28
+– Rud., Maler, Murifeldweg 28
 – Sophie Amelie (Henzi), Wwe. des Notars, Hirschengraben 6 [31.638]
 – Viktor (Graf), Oberpostangestellter, Könizstrasse 55 [29.566]
-– v. Fischer & Cie.. Vermögensverwaltungen, Advokatur u. Notariat, Bubenbergplatz 8 [23.857]
+– v. Fischer & Cie., Vermögensverwaltungen, Advokatur u. Notariat, Bubenbergplatz 8 [23.857]
 – Walter E., Bureaulist, Freiestrasse 35
 – Walter, Postangest., Gesellschaftsstr. 33
 – Walter, Metzger, Aarbergergasse 3
@@ -45894,14 +45817,14 @@ Stiefel, Heinr., Spinner, Ob. Aareggweg 6
 Stiefenhofer, Karl Alfr., Bäcker, Sulgeneckstrasse 58
 – Karl Martin, Spielwaren u. Puppenklinik (Wylerstr. 4), Kornhausplatz 11 [36.265]
 – Werner R., Herren- u. Damen-Coiffeurgeschäft (Wylerstrasse 4), Waaghausgasse 3 [22.898]
-Stiefvater, Jos.. Bauamtarbeiter. Wiesenstr. 19
+Stiefvater, Jos., Bauamtarbeiter, Wiesenstr. 19
 Stieger, Felix A., Radiotechniker, Mittelstr. 11
 Stierli, Alphonse (Graf), Vorst, d. Krankenpflegestelle, Holligenstrasse 17 [25.095]
 – Franz Jos. Siegfr., Stauffacherstrasse 33
-– Frieda, Schneiderin.. Flurstrasse la
-– Pauline, Längere, Flurstrasse la
+– Frieda, Schneiderin., Flurstrasse 1a
+– Pauline, Längere, Flurstrasse 1a
 – Rosa, Damenschneiderin, Karl-Schenkstr.11 [28.682]
-– Rudolf, Büchsenmacher. Flurstrasse la
+– Rudolf, Büchsenmacher. Flurstrasse 1a
 Stierlin, Arn., Dr. phil., Adjunkt b. eidg. Amtf. geist. Eigentum, Keltenstr. 97. Bümpliz
 – Hedwig Rosa M., Lehrerin, Brunnadernrain 8
 – Johanna El. Lse., Helvetiastrasse 31
@@ -45916,8 +45839,8 @@ Stiner, O., Dr. med., Adj. d. Dir. d. Schweiz.
 Gesundheitsamt. Bierhübeliweg 29 [31.821]
 – Siegfried K., Fürspr., Bierhübeliweg 29
 Stirnemann, Bernh. Th., Maler, Kosenweg 9
-– Bertha. Bureaulistin. Elisabethenstrasse 6
-– Emma, Frau, Kanzlistin. Waldhöheweg 7
+– Bertha, Bureaulistin, Elisabethenstrasse 6
+– Emma, Frau, Kanzlistin, Waldhöheweg 7
 – Emma (Hügli), Wwe., Waldheimstrasse 16
 – Ernst, pens. Angest. im eidg. Sanitätsdepartement, Elisabethenstrasse 6
 – Ernst, Schriftsetzer, Theaterplatz 4
@@ -45935,11 +45858,12 @@ Stirner, Marie S., Frau, Fabrikarbeiterin, Neubrückstrasse 19
 Stirnimann, Otto, Bankbeamter, Sulgenrain 6
 – Otto (Birrer), Küfer, Reitschulweg 1
 – Ph. (Berger), Südbahnhofstrasse 15
-Stöber, Joh. Max, Maschinenmeister, Hallerstrasse 34v. Stockaiper, Andreas, Chemiker, Junkerggasse 53
+Stöber, Joh. Max, Maschinenmeister, Hallerstrasse 34
+v. Stockaiper, Andreas, Chemiker, Junkerggasse 53
 Stöcker und Stoker
 – Charles, Zollbeamter, Monbijoustrasse 94
 – Emil Jak. Alb., Assistent, Thunstrasse 99
-— Georg. Vertreter. Läuggassstrasse 21a
+— Georg. Vertreter, Läuggassstrasse 21a
 – Hans, Ingenieur b. eidg. Amt für geistiges Eigentum, Ensingerstrasse 23 [35.239]
 – Hans E., Reinigungsarbeiter, Postgasse 46
 – Jakob (Ruprecht), Ingenieur b. eidg. Patentamt, Thunstrasse 99 [28.473]
@@ -45968,9 +45892,9 @@ Stöckli, Ad., Beamter, Hrch.-Wildstrasse 14
 – Friedr., Bahnarbeiter, Muldenstrasse 44
 – Friedr., Bahnarbeiter, Haldenweg 16
 – Friedr., Camionneur, Freiburgstrasse 155
-– Friedr., Depotchef S. S. B.. Muristras.se 55 [27.418]
+– Friedr., Depotchef S. S. B., Muristras.se 55 [27.418]
 – Friedr., Handlanger, Freiburgstrasse 72a
-– Friedr., Zugführer S. B. B.. Dietlerstr. 44
+– Friedr., Zugführer S. B. B., Dietlerstr. 44
 – Fritz, Hilfsarbeiter, Schöneggweg 14
 – Fritz, Hilfsarbeiter, Friedeckweg 30
 – Fritz Joh., Handlanger, Bottigenstrasse 47, Bümpliz
@@ -45979,7 +45903,7 @@ Stöckli, Ad., Beamter, Hrch.-Wildstrasse 14
 – Gottfried (Kuhn). Beamter der O. P D., Bernastrasse 48
 – Gottl., Handlanger, Falkenweg 5
 – Gust., gew. Revisor der Oberpostkontrolle, Hubelmattstrasse 29
-– Gust.. Schlosser, Wagnerstrasse 11
+– Gust., Schlosser, Wagnerstrasse 11
 – Hanna Lydia, Fabrikarbeiterin. Freiburgstrasse 155
 – Hans, Schreiner. Stöckackerstr. 74. Bümpliz
 – Herm., Fabrikarbeiter, Sonneggring 14
@@ -45989,7 +45913,7 @@ Stöckli, Jean, Vulkanisieranstalt, Mühlemattstrasse 53 [21.318]
 – Joh., Pflasterer, Bahnhöheweg 44, Bümpliz
 – Joh., Verkäufer, Zeigerweg 1
 – Joh., Zimmermann, Burgunderstrasse 113, Bümpliz
-– Joh Ed.. Beamter S. B. B., Effingerstr. 90
+– Joh Ed., Beamter S. B. B., Effingerstr. 90
 – Joh., Maurer, Ladenwandstrasse 98
 – Joh., Pferdewärter, Rodtmattstrasse 108
 – Joh. A., Wegaufseher, Oberbottigenweg 66, Oberbottigen
@@ -46013,7 +45937,7 @@ Stöckli, Jean, Vulkanisieranstalt, Mühlemattstrasse 53 [21.318]
 – Rud., Mechaniker, Peterweg 6, Bümpliz
 – Samuel. Kaufmann, Althofgässchen 5 [33.749]
 – Walter, Ausläufer, Muesmattstrasse 40
-– Walter. Metzger, Gartenstrasse 4
+– Walter, Metzger, Gartenstrasse 4
 – Werner, Postangestellter, Holligenstr. 39
 – Werner, Ausläufer, Bümplizstrasse 152
 Stöcklin, K. Otto (Simon), Coiffeur, Herrenund Damensalon (Viktoriastr. 37), Moserstrasse 15 [36.348]
@@ -46025,7 +45949,7 @@ Stoeffler, Arlette Marg., Bureaulistin, Jubiläumsstrasse 47
 Staffhalle A.-G., Stoffe, Bonneteriewaren, Nouveautös, Marktgasse 11 u. Amthausg. 6 [28.247]
 Stoker, s. Stöcker
 Stoll, Alfred Karl, Magaziner, Standstr. 24
-– Arnold, jun., in Fa. Jb. Merz & Co.. Friedeckweg 2 [33.818]
+– Arnold, jun., in Fa. Jb. Merz & Co., Friedeckweg 2 [33.818]
 – Arnold K., Magaziner, Zähringerstr. 14
 — Elisabeth (Voser), Wwe., Effingerstr. 29 [35.634]
 — Elisabeth (Rufer), Wwe., Liebeggweg 5
@@ -46049,7 +45973,7 @@ Brückfeldstrasse 24
 – Rosa Emma, Empfangsfräulein, Bubenbergstrasse 12
 – Rud., Dachdeckermeister, Steigerweg 19
 Stoller, Adolf, Telephonmcnteur, Dammweg 9
-– Alexander. Hilfsarbeiter. Jurastrasse 55
+– Alexander. Hilfsarbeiter, Jurastrasse 55
 – Alex., Polisseur T. W., Jurastrasse 55
 – Arnold, Gärtner, Forstweg 55
 – Elsa. Bureaulistin, Lentulusstrasse 30
@@ -46076,12 +46000,12 @@ Stoller, Adolf, Telephonmcnteur, Dammweg 9
 – Oskar, städt. Beamter, Greyerzstrasse 27
 – Otto, Bereiter, Kasernenstrasse 45
 – Rud., Karrer, Wankdorfstrasse 11
-– Werner Pr,, Schriftsetzer, Lentulusstr. 30
+– Werner Pr., Schriftsetzer, Lentulusstr. 30
 – Werner W., Tapezierer, Lentulusstr. 30
 – Wilh., Bauarbeiter, Turnweg 24
 Stolz, Hedwig Frieda, Kanzlistin, Sennweg 5
 – Jak., Telephonmonteur. Hauensteinweg 16
-– K. Herm., .Buchdruckerei (Weissenbühlweg 27. Wasserwerkgasse 19 [21.380]
+– K. Herm., Buchdruckerei (Weissenbühlweg 27. Wasserwerkgasse 19 [21.380]
 – Lina (Zbinden), Sennweg 5
 – Sophie, Bureaulistin, Weissenbühlweg 27
 – Walter Oswald, Reisender, Gruberstr. 6
@@ -46152,7 +46076,7 @@ Strahm, Christ., Magaziner, Badgasse 29
 – Gertrud, Hilfsarbeiterin, Gerechtigkeitsg. 76
 – Gottfr., Weichenwärter, Ulmenweg 9
 – Gottl., Schneidermeister, Blumenweg 7
-– Hs. Friedr., Bankbeamter. Tscharnerstr. 7
+– Hs. Friedr., Bankbeamter, Tscharnerstr. 7
 – Hs., Schreiner, Elisabethenstrasse 37a
 – Hedwig H., Ladentochter, Zähringerstr. 49
 – Heinr., Angest., Lagerhausweg 4, Bümpliz [46.206]
@@ -46160,7 +46084,7 @@ Strahm, Christ., Magaziner, Badgasse 29
 – Hermann, Schreiner, Blumenweg 1
 – Hilda A., Ladentochter, Murifeldweg 8
 – Joh. Friedr., Fabrikarb., Felsenaustr. 80
-– Johanna, Ladentochter. Viktoriastrasse 47
+– Johanna, Ladentochter, Viktoriastrasse 47
 – Klara, Ladentochter, Meisenweg 18
 – Klara, Hilfsarbeiterin, Felsenaustrasse 80
 – Luise, Ladentochter, Spitalgasse 31
@@ -46197,7 +46121,7 @@ Strassenbahnen, städtische
 – Station Neubrückstrasse [23.136]
 – Station Papiermühlestrasse [32.296]
 – Station Stadion Wankdorf [23.139]
-– Zeitglocken. Marktgasse 1 . [23.132]
+– Zeitglocken. Marktgasse 1 [23.132]
 Strassen- u. Marktinspektorat, Polizeigebäude [20.421]
 Strassenverkehrsamt, Speichergasse 8—10 [27.111]
 Strasser, Ad. A., Magaziner, Länggassstr. 70b
@@ -46233,7 +46157,7 @@ Straub, s. auch Strub
 – Jeanne E., Dittlingerweg 10
 – Joh. Alfr, Hilfsarbeiter, Landoltstrasse 71
 – Joh. Christ., Zimmermann, Weissensteinstrasse 1
-– K. Herm., Schreinermeister. Scheuerrain 8
+– K. Herm., Schreinermeister, Scheuerrain 8
 – Karl Herm., Zementer, Speichergasse 33
 – Leonore K. R., Coiffeuse, Schwarztorstrasse 53a
 – Margrit, Schwarztorstrasse 53a
@@ -46280,7 +46204,7 @@ Streich, Emil, Fabrikarbeiter, Felsenaustr. 22
 – Marie Emma, Fabrikarbeiterin, Breitenrainstrasse 49
 – Marie, Ladentochter, Heckenweg 27
 – Paul, Hilfsarbeiter, Fischermätteliweg 12
-– Rudolf, Billetteur S. S. B.. Morillonstr. 6
+– Rudolf, Billetteur S. S. B., Morillonstr. 6
 – Werner Rud., Kaufmann, Morillonstr. 6
 Streift, Anna Marie (Zimmermann), Wwe., Bärenplatz 4 [27.841]
 – Arthur (Laubscher), Bankbeamter, Südbahnhofstrasse 8 [27.972]
@@ -46298,20 +46222,20 @@ Streift, Rosalie, Sekretärin, Berchtoldstr. 38 [21.042]
 Streit, Ad., Bahnarbeiter, Polygonweg 25
 – Adolf, Hilfsarbeiter, Grüner Weg 7
 – Alb., Hilfsarbeiter, Klösterlistutz 20
-– Alb,, Hilfsarbeiter, Gerbergasse 38
+– Alb., Hilfsarbeiter, Gerbergasse 38
 – Alex., Handlanger, Bahnstrasse 6h
 – Alfr. (Finger), Blumengeschäft (Cäeilienstrasse b [36.076]), Mattenhofstrasse 13 [21.963]
 – Alfr., Hilfsarbeiter, Stauwehrrain 4
 – Alfr., Hilfsarbeiter, Platanenweg 12
-– Alfr.. Magaziner, Neufeldstrasse 34
+– Alfr., Magaziner, Neufeldstrasse 34
 – Alfr., Mechaniker, Muristrasse 77
-– Alfr., Pferdewärter. Gerbergasse 48
+– Alfr., Pferdewärter, Gerbergasse 48
 – Anna Maria, Damenschneiderin, Weissenbühlweg 28
 – Anna, Falzerin, Freibürgstrasse 56
 – Arnold, Maurer, Waldheimstrasse 31
 – Arthur, Werkstätte für künstlerische Metallarbeiten. Scheuermattweg 17 [27.359]
 – Aug., Handlanger, Gewerbestrasse 34
-– B., Postangestellter. Berchtoldstrasse 46
+– B., Postangestellter, Berchtoldstrasse 46
 – Bendicht, Händler, Lorrainestrasse 8
 – Bertha, Damenschneiderin, Polygonweg 25
 – Bertha, Fabrikarbeiterin, Schanzenbergstrasse 11
@@ -46331,7 +46255,7 @@ Streit, Ad., Bahnarbeiter, Polygonweg 25
 – Ernst, Hilfsarbeiter, Blumenweg 5
 – Ernst Rud., Hilfsarbeiter, Langmauerw. 17
 – Ernst, Hilfsarbeiter, Sulgeneckstrasse 54
-– Ernst. Ingenieur, in Fa. Streit & Co.. Bauunternehmung, Engeriedweg 1 [22.485]
+– Ernst. Ingenieur, in Fa. Streit & Co., Bauunternehmung, Engeriedweg 1 [22.485]
 – Felix. Installateur. Waldheimstrasse 27
 – Fr. Ernst, Schlosser, Rodtmattstrasse 64
 – Franz Joh., Handlanger, Murtenstr. 133a
@@ -46344,12 +46268,12 @@ Streit, Ad., Bahnarbeiter, Polygonweg 25
 – Fritz, Handlanger, Bottigenstrasse 74, Bümpliz
 Streit, Fritz, Hilfsarbeiter, Platanenweg 12
 – Fritz, Mineur, Brunngasse 10
-– Fritz, Pierdewärter. Schützenweg 3
+– Fritz, Pferdewärter, Schützenweg 3
 – Fritz, Schneider, Waldheimstrasse 27
 – Gertrud, Ladentochter, Polygonweg 6
 – Gottfr., Handlanger, Lorrainestrasse 38
 – Gottfr., Chauffeur, Wangenstr. 86, Bümpliz
-– Gottfr.. Maurer, Bottigenstr. 74, Bümpliz
+– Gottfr., Maurer, Bottigenstr. 74, Bümpliz
 – Gottl., Bahnarbeiter, Weberstrasse 1
 – Gottl., Wasserleitungsinstallationen, Stalden 11 [35.992]
 – Hans, Archit. S.I.A. (Alpenstr. 4 [23.224]), Kramgasse 66 [23.223]
@@ -46360,7 +46284,7 @@ Streit, Fritz, Hilfsarbeiter, Platanenweg 12
 – Herm. Ad., Hilfsarbeiter, Polygonweg 25
 – Herm., Hilfsarbeiter, Gäcilienstrasse 9
 – Herrn Gust., Kunstschlosser. Jurastr 40
-– Joh. Rud-, Magazinarbeiter. Jurastrasse 55
+– Joh. Rud-, Magazinarbeiter, Jurastrasse 55
 – Johanna, Hilfsarbeiterin, Blumenweg 5
 – Jul. Hch., Hilfsarbeiter, Werkgasse 21, Bümpliz
 – Karl Josef, Heizer, Quartiergasse 19
@@ -46375,21 +46299,21 @@ Streit, Fritz, Hilfsarbeiter, Platanenweg 12
 – Margarita. Hilfsarbeiterin. Turnweg 6
 – Maria Lydia. Fabrikarbeiterin, Wachtelweg 23
 – Marie Rosa, Angestellte. Weissenbühlw. 28
-– Marie Magdal. (Neuenscbwander), Wwe,, Belpstrasse 49
-– Marie (Moser). Wwe.. Turnweg 6
+– Marie Magdal. (Neuenscbwander), Wwe., Belpstrasse 49
+– Marie (Moser). Wwe., Turnweg 6
 – Martha, Damenschneiderin, Wyttenbachstrasse 16
 – Mathilde M., Fabrikarb., Polygonweg 25
 – Mina, Fabrikarbeiterin, Bahnstrasse 61
 – O. H. E., Hilfsarbeiter, Bühlstrasse 27
-– Oskar Aug., Hilfsarbeiter. Gewerbestr. 34
+– Oskar Aug., Hilfsarbeiter, Gewerbestr. 34
 – Paul Othmar. Beamter, Beaumontweg 38
 – Rob., Sattlerraeister, Rucksack- und Reiseartikelfabrik, Belpstrasse 49 [27.599]
 – Rosa, Bnreaulistin, Turnweg 6
 – Rosa, Länggassstrasse 21
 – Rosalie (Schenkel), Damensalon (Lorrainestrasse 38), Spitalgasse 14 [30.657]
-– Rudolf F.. Beamter der S. B. B., Neufeldstrasse 122 [26.047]
+– Rudolf F., Beamter der S. B. B., Neufeldstrasse 122 [26.047]
 – Rud. (Schnyder), eidg. Beamter, Viktoriastrasse 84
-– Rud.. Hilfsarbeiter, Platanenweg 12
+– Rud., Hilfsarbeiter, Platanenweg 12
 – Rud. (Moser), Kommis, Balmweg 37
 – Rud., Hotzmeister, Neufeldstrasse 111
 – Susann» Bertha (Ryf), Wwe., Viktoriastr. 89
@@ -46411,12 +46335,12 @@ Strelececk, J. Anton, Schlosser, Metzgerg. 40
 Strelin, Alex., Dr. med., prakt. Arzt, Thunstrasse 36 [31.761]
 Streuli, Alfr. (Wyttenbach), Feldeckweg 7r 35.717]
 – Ed. Werner, Sek.-Lehrer, Finkenhubelw. 26 [29.046]
-– Gebr.. A.-G.. Bettwaren- u. Teppichhdlg..
+– Gebr., A.-G., Bettwaren- u. Teppichhdlg..
 Marktgasse 59 [21.599]
 – Jules, Kaufmann, Brunnadernstrasse 47 [34.142]
 – Julius Alfred, Kaufmann. Feldeckweg 7
 – Walter, Hutmacher, Wallgasse 4
-Streun, Alfred Walter. Limonadier, Zeigerw. 1 [32.960]
+Streun, Alfred Walter, Limonadier, Zeigerw. 1 [32.960]
 – Anna (Müller), Wwe., Blumenbergstr. 53
 – Armin (Luginbühl). Sek.-Lehrer, Blumenbergstrasse 48 [32.133]
 – Elisa, Bureaulistin, Monbijoustrasse 18
@@ -46426,7 +46350,7 @@ Streun, Alfred Walter. Limonadier, Zeigerw. 1 [32.960]
 – Joh. (Rufener), Gärtner, Seftigenstrasse 32
 – K., gew. Limonadier. Zeigerweg 1 [32.960]
 – Karl R., städt. Beamter, Greyerzstrasse 47
-– Karl, Pferdewärter. Brunngasse 34
+– Karl, Pferdewärter, Brunngasse 34
 – M Rosa. Damenschneiderei-Atelier Bühlstrasse 49 [32.864]
 – Willy. Kaufmann, Mühlemattstrasse 37
 Strich, Fritz, Dr. phil., Prof., Bühlplatz 3 [21.004]
@@ -46436,8 +46360,8 @@ Stricker, Ernst, Abwart, Hallwag, Breitenrainstrasse 97
 – Olga M., Bureaulistin. Flurstrasse 15
 – Rob., Gipser, Murifeldweg 38
 – Werner Eduard, Drogist, Breitenrainstr. 97
-Strickler, Albert. Dr.. Direktor der Schweiz.
-Kraftübertragungs-A.-G.. Brunnadernstr. 11 [21 969]
+Strickler, Albert. Dr., Direktor der Schweiz.
+Kraftübertragungs-A.-G., Brunnadernstr. 11 [21 969]
 – Andree Alice, Verkäuferin, Neufeldstr. 143
 – Eug. Ed., Bankbeamter, Neufeldstrasse 143
 Jakob, Molkereichef, Gesellschaftsstr. 33
@@ -46475,17 +46399,17 @@ Strub, s. auch Straub
 Strübin, Anna Elisabeth (Haldimann), Privatiere, Blumensteinstrasse 8
 – E. (Schenk), Frau, Dampfbügel-Anstalt (Mezenerweg 4), Beundenfeldstrasse 31
 – Elsa Erna, Bureaulistin, Frikartweg 25
-– Fr.. Reisender. Frikartweg 25 [31.338]
+– Fr., Reisender. Frikartweg 25 [31.338]
 – Max, Mechaniker, Mezenerweg 4
 – Oskar, Karosseriewagner, Trechselstr. 5
-Strüby, Fr. Ant. Alfr., Kultur-Ing.. Tillierstrasse 5 [35.332]
-– Luise (Bühlmann), Wwe.. Neubrückstr. 94
+Strüby, Fr. Ant. Alfr., Kultur-Ing., Tillierstrasse 5 [35.332]
+– Luise (Bühlmann), Wwe., Neubrückstr. 94
 – (Baidinger), Käse- u. Butterhandlg. (Neubrückstrasse 94), Hirschengraben 10
 Struchen, Joh., Bereiter, Elisabethenstr. 42
 Struffenegger, Ad., Telegraphenbeamter, Allmendstrasse 36
 Struss, Fritz (Bay), Schneidermeister (Untere
 Villettenmattstrasse 9), Belpstr.29 [22.616]
-Stüber. Alb.. Bau- u. Möbelschreinerei, Gesollschaftsstrasse 32 [34.941]
+Stüber. Alb., Bau- u. Möbelschreinerei, Gesollschaftsstrasse 32 [34.941]
 – Alfr., Güterarb., Murtenstr. 247, Bümpliz
 # Date: 1935-12-15 Page: 26020799/492
 Stüber, Emil, Handlanger, Bundesrain 16
@@ -46508,7 +46432,7 @@ Stüber, Emil, Handlanger, Bundesrain 16
 – Marie, Schneiderin, Engehaldenstr. 199
 – Robert. Bauführer. Dietlerstrasse 12
 – Rob., Ingenieur, Thunstrasse 97a [36.898]
-– Walter. Buchbinder, Weissenbühlweg 2
+– Walter, Buchbinder, Weissenbühlweg 2
 – Walter O., Mechaniker, Karl-Schenkstr. 1
 – Werner, Angestellter, Länggassstrasse 51
 – Willy. Schreiner. Murtenstrasse 155
@@ -46522,7 +46446,7 @@ Stückelberger, E., Wwe., Kramgasse 56
 – Elisab , Frl, Kramgasse 56
 – Joh., Mercerie-, Schneiderartikel- u. Manufakturwarenhdlg. (Jubiläumsstrasse 19 [33.797]), Kramgasse 56 [23.759]
 Stucker, Anna Martha (Witschi), Wwe., Engestrasse 49
-– Cecile Johanna, Frl.. Weissensteinstr. 62
+– Cecile Johanna, Frl., Weissensteinstr. 62
 – Emil Alb., Maschinenmeister, Federw. 29e
 – Ernst, Sattlermstr., Kasernenstrasse 21 [31.865]
 – Friedr. (Christen), Lehrer. Hochfeldstr. 98
@@ -46550,7 +46474,7 @@ Stucki, Stucky und Stuki
 – Alfred, Hilfsarbeiter, Mittelstrasse 66
 – Alfred, Postangestellter, Rossfeldstr. 15
 – Alice, Kanzlistin, Breitenrainstrasse 87
-– Anna (Schärer), Wwe.. Armandweg 7
+– Anna (Schärer), Wwe., Armandweg 7
 – Armin Hans, kaufm. Angest., Muristr. 69
 – Charles Henri, Hausierer, Nydeckhof 31
 – Charles R. (Schären), eidg. Beamter, Ob.
@@ -46558,7 +46482,7 @@ Villettenmattstrasse 8 [36.052]
 – Chr. Alb., Maurer, Wiesenstrasse 63
 – Christ., Ob. Dufourstrasse 21
 – Chr. G., Revisor b. eidg. Oberkriegskommissariat, Viktoriarain 7 [28.891]
-– Christ. (Leuenberger), eidg. Beamter. Bonstettenstrasse 14 [36.550]
+– Christ. (Leuenberger), eidg. Beamter, Bonstettenstrasse 14 [36.550]
 – Christ., Sanitäts-Adjutant, Militärstr. 32
 – Christ., Pfarrer, Bernstrasse 85. Bümpliz [46.1801
 – Christ., Hilfsarbeiter, Kirchackerweg 13, Bümpliz
@@ -46584,7 +46508,7 @@ Stucki, Emil 📞 24.480 Baumeister, Laubeckstrasse (58 [24.480]) 60
 – Ernst, Hilfsarbeiter, Stalden 16
 – Ernst (Grünig), Maurer, Federweg 37
 – Ernst, Metzger, Spitalgasse 31
-– Ernst, Postbeamter. Humboldtstrasse 47
+– Ernst, Postbeamter, Humboldtstrasse 47
 # Date: 1935-12-15 Page: 26020800/493
 Stucki, Stucky und Stuki
 – Ernst, Tramführer, Lenzweg 9
@@ -46621,7 +46545,7 @@ Stucki, Stucky und Stuki
 – Gertrud, Verkäuferin, Lagerweg 11
 – Gottfr., Bäckermeister, Murtenstrasse 48 [35.243]
 – Gottfr. (Koch), Bau- u. Möbelschreinerei, Wandtafelnfabrik, Magazinweg 12 [22.533]
-– Gottfr Alb., Beamter S. B. B.. Gesellschaftsstrasse 86
+– Gottfr Alb., Beamter S. B. B., Gesellschaftsstrasse 86
 – Gottfr., Handlanger, Marzilistrasse 2h
 – Gottfr. Rud., Milchhandlung, Oh. Dufourstrasse 21 [20.670]
 – Gottfr. (Clemenz), Käse-, Butter- u. Kolonialwarenhandlung, Elisabethenstrasse 34 [24.372]
@@ -46699,22 +46623,21 @@ Stucki, Stucky und Stuki
 – Wilh. Alfr., Hilfsarbeiter, Mittelstrasse 66
 – Wilh. Jak., Lithograph O. P. D., Terrassenweg 14
 Studach, Robert Herm., Prokurist, Neubrückstrasse 51
-Studer, Alb.. Waldhöheweg 9 [22.068]
+Studer, Alb., Waldhöheweg 9 [22.068]
 – Alb., Hilfsarbeiter, Stauffacherstrasse 5
 – Alb. (Grob), Kaufmann, Viktoriastrasse 37 [27.277]
 – Alb., Vertreter, Gerechtigkeitsgasse 44
 – Alfr., Bureaulist, Brunngasse 58
 – Anna Marie, Angestellte, Belpstrasse 73
-– Anna (Zürcher), Wwe.. Kirchenfeldstr. 57 [35.822]
+– Anna (Zürcher), Wwe., Kirchenfeldstr. 57 [35.822]
 – Anny Sophie. Angestellte, Falkenweg 11
 – Anton, Architekt, Bonstettenstrasse 3
 – Armin (Eigenheer), Ingenieur, Kistlerweg 4 [26.388]
 – Arth. (Frei), Dr. jur., Hallwylstrasse 46 [33.805]
 – B., Dr., Studersche Apotheke (Steinhölzliweg 5, Köniz [45.669]), Spitalgasse 32 [21.582]
 – Bertha (Scherzer), Frau, Scheibenstr. 17
-– Ed., Vertreter der Parketterie Müller in
-Alnnach, Scheibenstrasse 17
-– Ed.. Milchhändler, Mindstrasse^j
+– Ed., Vertreter der Parketterie Müller in Alnnach, Scheibenstrasse 17
+– Ed., Milchhändler, Mindstrasse^j
 – Eduard, kant. Beamter, Obere Villettenmattstrasse 4 [20.030]
 – Elise (Schneider), Wwe., Läuferplatz 7
 – Elise (Stämpfli), Wwe. d. Seminarlehrers, Breitenrainplatz 38 [20.799]
@@ -46735,11 +46658,11 @@ Studer, Friedr., Architekt, vormals Davinet & Studer (Kesslergasse 2), Bahnhof p
 – G., Postangestellter, Bonstettenstrasse 5
 – Gebrüder, Kolonialhaus zum Diesbachgut, Neubrückstrasse 76 [24.8121
 – Gertrud, Fabrikarbeiterin, Landhausweg 11
-– Geroldine (Iten), Wwe.. Gutenbergstr 26
+– Geroldine (Iten), Wwe., Gutenbergstr 26
 – Gertrud, Ladentochter, Bottigenstrasse 58, Bümpliz
-– Gottfr.. Abwart, Muldenstrasse 10
+– Gottfr., Abwart, Muldenstrasse 10
 – Gottfr., Gepäckarbeiter, Holligenstrasse 94
-– Gottfr., Gartenarbeiter. Freiburgstrasse 82
+– Gottfr., Gartenarbeiter, Freiburgstrasse 82
 – Gottfr., Polizist, Predigergasse 5
 – Gottfr. El., Schriftsetzer, Mühlemattstr. 37
 – Gottl., Elektriker, Brunnhofweg 24
@@ -46751,7 +46674,7 @@ Studer, Friedr., Architekt, vormals Davinet & Studer (Kesslergasse 2), Bahnhof p
 – Hans, Architekt, in Fa. Steffen & Studer, Falkenhöheweg 1 [23.820]
 – Hans (Cerutti), Portier. Vereinsweg 8
 – Hans Max, kaufm. Angest., Balmweg 37
-– Hans Willy, kaufm Angest.. Amthausg. 12
+– Hans Willy, kaufm Angest., Amthausg. 12
 – Hans, Vertreter, Jennerweg 3
 – Hans Rob., Sennweg 3
 – Hugo, Chauffeur, Pestalozzistrasse 32
@@ -46793,7 +46716,7 @@ Studer, Karl, Lok.-Heizer, Könizstrasse 51
 – Marie, Schneiderin, Länggassstrasse 38
 — Martha, Damenschneiderin, Schreinerweg 3
 — Mina, Ladentochter, Beaumontweg 20
-– Oskar Eugen, städt. Beamter. Denzlerstr. 8 [34.503]
+– Oskar Eugen, städt. Beamter, Denzlerstr. 8 [34.503]
 — Oskar, in Fa. Gebrüder Studer. Neubrückstrasse 76
 — Oskar, Masch.-Techniker, Rodtmattstr. 88
 — Otto, Coiffeur, in Fa. Hadwiger & Studer, Breitenrainstrasse 59
@@ -46809,8 +46732,8 @@ Studer, Karl, Lok.-Heizer, Könizstrasse 51
 – Paul (Marques), Falkenweg 11
 – Paul Peter, Sek.-Lehrer, Jennerweg 3i, [20.662]
 – Pius. Maurer, Freiburgstrasse 472, Bümpliz
-— R. K., Fabrikarbeiter. Morgenstrasse 13, 7 Bümpliz
-– Rob., Angestellter. Weissensteinstr. 86
+— R. K., Fabrikarbeiter, Morgenstrasse 13, 7 Bümpliz
+– Rob., Angestellter, Weissensteinstr. 86
 – Rob. (Blatter), Chemiker, Betriebsleiter, Bernstrasse 93, Bümpliz
 – Rob. (Schmid), Kriminalkommissar, Chef der Fahndungspolizei, Beaumontweg 20 [20.408]
 – Rob., Magazinbeamter der S. B. B., Lilienweg 17
@@ -46831,9 +46754,9 @@ Studer, Walter, Bauzeichner, Muldenstr. 10
 – Walter, Hotelkondukteur, Neufeldstr. 127
 – Walter, Kaufmann, Wattenw T ylweg 17
 – Walter, Bäckermeister, Gerechtigkeitsg, 3 [29.637]
-– Walter. Schlosser. Postgasse 58
+– Walter, Schlosser. Postgasse 58
 – Werner, Käser, Kirchenfeldstrasse 31
-– Werner. Malermeister. Gerechtigkeitsg. 80
+– Werner. Malermeister, Gerechtigkeitsg. 80
 – Werner. Maurer, Kanonenweg 14
 – Willy, Automechaniker, Badgasse 39
 – Willy, Schriftenmaler, Bonstettenstrasse 5 [23.563]
@@ -46865,7 +46788,7 @@ Stumpf, Albert (Brand), gew. Sekretär der O. T. D., Habsburgstrasse 13 [21.204]
 – Lisa (Balsiger), Wwe., Marzilistrasse 16a [31.244]
 – Werner Arthur, Lehrer, Sulgenauweg 39 [35.504]
 Stürchler, Walter, Tierarzt, Seilerstrasse 22
-v. Stürler, J. (v. Erlach), Wwe.. Elfenstr 9 [22.722]
+v. Stürler, J. (v. Erlach), Wwe., Elfenstr 9 [22.722]
 – Margaretha (v. Müller), Wwe., Egelg 55 [29.385]
 – M. Cecile, Florastrasse 18 [31.095]
 – Rob., Dr. jur., Fürsprecher (Elfenstrasse 9 [22.722]). Bundesgasse 6 [21.546]
@@ -46922,7 +46845,7 @@ Sudan, Cal., Beamter S. B. B., Viktoriastr. 39 [32.522]
 – Marie Th., Bureaulistin. Viktoriastrasse 39
 Sudry, P. A., Masch.-Schlosser, Krippenstr. 20
 Süess, s. auch Süss
-– A.. Handlung. Freieckweg 7, Bümpliz
+– A., Handlung. Freieckweg 7, Bümpliz
 – Jakob, Chauffeur, Postgasse 38
 – Rob., Coiffeurgeschäft (Effingerstrasse 55), Zwiebelngässchen 10
 Sulgenau A.-G. Bern, Sonnenbergstrasse 15
@@ -46959,12 +46882,12 @@ Suppiger, Ferd., Angestellter der Publicity A.-G., Spitalackerstrasse 63
 # Date: 1935-12-15 Page: 26020804/497
 Surbeck, s. auch Surbek
 — Arn., Schneider, Breitenrainstrasse 27
-– Georg, Dr,, eidg. Fischereiinspektor, Wabernstrasse 14 [35.687]
-– Lina (Dennstedt), Wwe.. Bubenbergstr. 38
-– Marie (Verrier), Wwe.. Freiestrasse 23
+– Georg, Dr., eidg. Fischereiinspektor, Wabernstrasse 14 [35.687]
+– Lina (Dennstedt), Wwe., Bubenbergstr. 38
+– Marie (Verrier), Wwe., Freiestrasse 23
 – Mathilde, Hilfsarbeiterin, Rütlistrasse 15
-– Peter. Maler. Rütlistrasse 15
-– Traugott. Schlosser. Rütlistrasse 15
+– Peter, Maler, Rütlistrasse 15
+– Traugott, Schlosser, Rütlistrasse 15
 Surbek, Marg. (Frey), Kunstmalerin, Malschule, Junkerngasse 51 [35.877]
 – Viktor (Frey). Kunstmaler, Junkerng. 51 [35.8771
 Surber, Ed., Chefmonteur, Keltenstrasse 93, Bümpliz [46.147]
@@ -46974,12 +46897,12 @@ Surber, Ed., Chefmonteur, Keltenstrasse 93, Bümpliz [46.147]
 – Paula, Bureaulistin, Keltenstr. 93, Bümpliz
 Suremann. Ad. Hch., Chauffeur, Krippenstra.sse 26
 – Martha, Modistin, Krippenstrasse 26
-Surer, Hans. jun.. Uhrmacher. Lorrainestr. 13
+Surer, Hans. jun., Uhrmacher. Lorrainestr. 13
 – -Zumsteg. Hans. Uhren- und Bijouteriehandlung. Lorrainestrasse 13 [22.052]
 Suri, Anna B., pens. Lehrerin, Melchenbühlweg 56
 – Emma (Tschirren), Wäscherin, Belpstr. 30a
-Sury, Albert (Moser), städt. Beamter, Herzogstrasse 8v. Sury, Wilh., pens. Forstingenieur der eidg.
-.Oberforstinspektion, Spitalackerstrasse 74
+Sury, Albert (Moser), städt. Beamter, Herzogstrasse 8
+v. Sury, Wilh., pens. Forstingenieur der eidg. Oberforstinspektion, Spitalackerstrasse 74
 Süss, s. auch Süess
 – Bertha (Gygax), Wwe., Postgasse 28
 Suter, s. auch Sutter und Zutter
@@ -46999,7 +46922,7 @@ Suter, s. auch Sutter und Zutter
 Edgar, Kaufm., Friedheimweg 49 [26.163]
 – E. G., Notar, Adjunkt der kant. Handelsu. Gewerbekammer, Ostermundigenstr. 12a (Schönberg) [32.713]
 – Emil (Petersen), Masch.-Ingenieur, Junkerngasse 51
-— Emil, Versicherungsbeamter. Murifeldw. 30
+— Emil, Versicherungsbeamter, Murifeldw. 30
 – Emilie, Frl., Rabbentalstrasse 77
 – Emma (Buchhofer), Altenbergstrasse 96
 — Ernst, Elektrotechniker, Myrthenweg 11, Bümpliz
@@ -47007,7 +46930,7 @@ Edgar, Kaufm., Friedheimweg 49 [26.163]
 Suter, s. auch Sutter u. Zutter
 – Ernst, Schneider, Lentulusstrasse 41
 – Franz, Schriftsetzer, Zähringerstrasse 51
-– Frieda M.. Ladentochter, Lorrainestrasse 27
+– Frieda M., Ladentochter, Lorrainestrasse 27
 – Fr. (Kummly), städt. Beamter, Schönburgstrasse 43
 – Fritz. Bäckermeister, Quartiergasse 7
 – Fritz, Postkommis, Schanzenbergstrasse 32
@@ -47030,8 +46953,8 @@ Suter, s. auch Sutter u. Zutter
 – Jos., Schreiner, Cäcilienstrasse 9 [20.214]
 – Jos., Elektromonteur, Tscharnerstrasse 43
 – Julius Alwin, Abwart. Gerbergasse 27
-– Louis. Billetteur S. S. B.. Vennerweg 5
-– Martha FL, Angestellte. Lorrainestr. la
+– Louis. Billetteur S. S. B., Vennerweg 5
+– Martha FL, Angestellte. Lorrainestr. 1a
 – Martha, Fabrikarbeiterin, Giessereiweg 9
 – Max, Schlosser, Murtenstrasse 153d
 – Max (Aeschbach), Vertr., Berchtoldstr. 39
@@ -47040,7 +46963,7 @@ Suter, s. auch Sutter u. Zutter
 – Otto, Handelslehrer, Greyerzstrasse 49 [27.894]
 – Paul (Labhardt). Dr. phil., Gymnasiallehrer, Wittigkofenweg 15 [33.728]
 – Rolf, Heiz.-Techniker, Wiesenstrasse 4
-– R.. & Cie., Buchdruckerei und Verlag, Schwanengasse 9 [22.385]
+– R., & Cie., Buchdruckerei und Verlag, Schwanengasse 9 [22.385]
 – Roland, Erw., Heliograph, Viktoriastr. 39 [31.434]
 – Rosa, Näherin, Länggassstrasse 26
 – Rosa (Zysset), Wwe , Stockerenweg 32
@@ -47058,7 +46981,7 @@ Sutermeister, Maria (Hunziker), Wwe., Karl-Hiltystrasse 26 [20.693]
 – Werner, Dr. phil., Gymnasiallehrer, Karl-Hiltystrasse 26
 # Date: 1935-12-15 Page: 26020805/498
 Sutter, s. auch Suter und Zutter
-– Ad., Schneidermeister. Elisabethenstr. 32
+– Ad., Schneidermeister, Elisabethenstr. 32
 – Ad. Aug., jun., Schneid., Elisabethenstr. 32
 – Alfr., Angestellter d. Fa. Kehrli & Oeler, Steinerstrasse 27
 – Alfr. (Bolz), Beamter d. S. B. B., Neufeldstrasse 99
@@ -47091,7 +47014,7 @@ Sutter, s. auch Suter und Zutter
 – Joh. Jak., gew. Beamter S. B. B., Schänzlistrasse 65
 – Joh. E., Hilfsarbeiter, Bethlehemstr. 21, Bümpliz
 – Joh., Lehrmeister in den Lehrwerkstätten, Greyerzstrasse 36
-– Joh. Alb.. Maler, Kesslergasse 4
+– Joh. Alb., Maler, Kesslergasse 4
 – Joh., Mandatträger, Primelweg 5
 – Joh. Karl, Monteur, Lagerweg 4
 – Johanna, Ladentochter, Greyerzstrasse 36
@@ -47105,8 +47028,8 @@ Sutter, s. auch Suter und Zutter
 – Rud., Revolverdreher T. W., Genossenweg 8
 – Viktor Alfr., Postangest., Rodtmattstr. 46
 – Walter Arthur, Buchbinder, Bridelstr. 8
-– Walter E., Postbeamter. Mattenhofstr. 22
-– Walter K.. Wickler, Mörgenstr. 9, Bümpliz
+– Walter E., Postbeamter, Mattenhofstr. 22
+– Walter K., Wickler, Mörgenstr. 9, Bümpliz
 – Werner, Buchhalter, Balderstrasse 30
 Sütterlin, Bernhard (Marner), Muristrasse 51 [22.067]
 Svelc, Josef, Schneider, Kramgasse 57
@@ -47118,7 +47041,7 @@ Szeemann, Etienne, Coiffeur, Monbijoustr. 20
 Szeifert, Martin, Coiffeur, La.ndoltstrasse 75
 Szmulowski, Mowsza, Kaufmann, Monbijoustrasse 43
 Tabakwaren A.-G., Zigarren-Detail- u. -Versandgeschäft Zündhölzerfabr (Geschäftsführer: Ernst Otto), Flurstr 35 [28.260]
-Tacheiiez, Marie B.. Lehrerin, Reichenbachstrasse 87
+Tacheiiez, Marie B., Lehrerin, Reichenbachstrasse 87
 Taddei. Angelo. Früchtehändler, Monbijoustrasse 21
 – Germano, Postbeamter, Wylerstrasse 57
 – Valterino Fortunato, Bauzeichner, Monbijoustrasse 21
@@ -47182,7 +47105,7 @@ Tanner, s. auch Danner
 – Ida Anna, Coiffeuse, Schwarzenburgstr. 18
 – J., Blumengeschäft (Gartenstadt Liebefeld), Bahnhofplatz 11 [32 541]
 – Jakob. Bannwart. Friedhofweg 7
-— Joh.. Hilfsarbeiter, Quartierhof 9
+— Joh., Hilfsarbeiter, Quartierhof 9
 – Joh., Pferdewärter, Elisabethenstrasse 46
 – Johanna R., Kassierin, Spitalackerstr. 5
 – Johanna Frieda, Kunststopferin, Güterstrasse 36
@@ -47199,7 +47122,7 @@ Tanner, s. auch Danner
 Tanner, s. auch Danner
 – Paul, Kaufmann, Zähringerstrasse 28
 – Rosine, Schanzeneckstrasse 25
-– Rud. Ad.. Dreher, Stationsweg 42
+– Rud. Ad., Dreher, Stationsweg 42
 – Rud., Postangest., Depotstr. 28 [23.195]
 – Walter (Schinitter). Dienstchef der eidgen.
 Justizabteilung. Kirchbühlweg 42 [27.002]
@@ -47236,12 +47159,8 @@ Tautenhahn, Willy A., Musiker, Stauffacherstrasse 11av. Tavel, Adele (Stettier),
 – Marguerite, Kindergärtnerin, Schosshaldenstrasse 22
 – Peter Rud., Schosshaldenstrasse 22
 Tavelli & Bruno, A.-G., Nyon, Bureau Bern, sanit. Apparate, Breitenrainpl. 42 [29.303]
-Tavernier, Eugen, gew. Kontrolleur der eidg.
-Waffenfabrik, Sickingerstrasse 3
+Tavernier, Eugen, gew. Kontrolleur der eidg. Waffenfabrik, Sickingerstrasse 3
 – E. F., Kontrolleur, Spitalackerstrasse 6 4
-Für Touren und Reisenist der Touristen- Fahrplan ( Verlag
-Hallwag, Bern) ein zuverlässiger Begleiter, der Ihnen auch interessante Vorschläge für
-Ausflüge vermittelt.
 # Date: 1935-12-15 Page: 26020809/500
 Tavernini, Jakob, Kaufm., Brunnmattstr. 49
 Techert, Irma, Schneiderin, Sulgeneckstr. 37
@@ -47293,7 +47212,7 @@ Tellenbach, s. auch Dällenbach u. Dellenbach
 – Mina, Bureaulistin, Thunstrasse 2
 – Otto, Coiffeur, Meisenweg 23
 – Werner, Pferdewärter, Ulmenweg 13
-– Willi Ad.. Schlosser, Ostermundigenstr. 57
+– Willi Ad., Schlosser, Ostermundigenstr. 57
 Temes, Maison, Robes, Effingerstrasse 8 [33.840]
 Tempelmann, Umberto Gottfr., Mechaniker, Weingartstrasse 49
 Temperli, Heinrich, Glaspolierer, Rodtmattstrasse 77
@@ -47332,9 +47251,6 @@ Teuscher, s. auch Tüscher
 – Frieda (Stettier), Wwe., Diesbachstr. 15 [36.586]
 – Friedr., Kontrolleur b. d. Gen.-Dir. P-T.T., Falkenhöheweg 4 [35.586]
 – Hans, Postaspirant, Effingerstrasse 69
-Das moderne Badzimmermacht Ihnen sicher
-Freude. Lassen Sie sichberaten durchsteftbachen
-Gerechtigkeitsg. 59 Telephon 21.040
 # Date: 1935-12-15 Page: 26020810/501
 Teuscher s. auch Tüscher
 – Hektor, Installateur, Weingartstrasse 45
@@ -47371,7 +47287,7 @@ Thalmann, Alb., Pierre, eidg. Beamter, Karl-Schenkstrasse 7
 – Marie (Fuchs), Wwe., Bühlstrasse 39
 – Martha (Pulver), Wwe., Chutzenstr. 49
 – Olga Helene, Bauzeichnerin. Hopfenw. 27
-– O. L. F. (Fischborn), Wwe.. Hopfenweg 27
+– O. L. F. (Fischborn), Wwe., Hopfenweg 27
 – Paul, Dr., Gymn.-Lehrer, Chutzenstr. 47 [31.9471
 Theater, Kornhausplatz 20, Direktor [22.232], Verwaltungs-Direktion [21.783], Kassier [20.777]
 Theatergenossenschaft Bern, Predigergasse 3du Theätre, Cafe u. Confiserie, Theaterplatz 7 [22.026]
@@ -47387,8 +47303,7 @@ Maria, Empfangsdame, Steigerweg 19
 Theilkäs, Luise (Kröpfli), Brückfeldstr. 12 [21.524]
 Thekla-Film A.-G., Filmfabrikation und -verleih, Bundesplatz 2 [36.115]
 Thelin, Anna, eidg. Beamtin, Schänzlistr. 19
-Therma A.-G., Schwanden, Fabrikation elektr.
-Apparate, Verkaufsbureau Bern, Monbijoustrasse 47 [22.681]
+Therma A.-G., Schwanden, Fabrikation elektr. Apparate, Verkaufsbureau Bern, Monbijoustrasse 47 [22.681]
 Theyssen, Mathilde, Dr. med., Aerztin, Gryphenhübeliweg 53
 Th ie, Richard, Glaser. Rodtmattstrasse 62
 Thiebaud, Adrien Fr., Uhrenmacher, Waaghausgasse 7
@@ -47404,12 +47319,12 @@ Thierstein, Alfred, Architekt, in Fa. Thierstein & Ghielmini, Mayweg 14 [33.429]
 – Erwin Walter, Hausierer, Wylerstrasse 57
 – Fanny, Ladentochter, Junkerngasse 27
 – Fr., Bäckerei-Konditorei, Gerbergasse 36 [24.071]
-– Friedr. E.. Bäckermeister, Landoltstr. 53 [29.060]
+– Friedr. E., Bäckermeister, Landoltstr. 53 [29.060]
 – Friedr., Bibliothekgehilfe, Thunstrasse 16
 – Hans. Kaufmann Marzilistrasse 36
 – Herm., Kaufmann, Dietlerstrasse 52
-– J. G. (Meyer), Kaufm.. Breitenrainstr. 31
-– L. (Buchmüller), Wwe., Antiquitäten und Kunsthandlg.. Bildhauerei (Marzilistr. 36 [31.062]), Kramgasse 66 [31.984]
+– J. G. (Meyer), Kaufm., Breitenrainstr. 31
+– L. (Buchmüller), Wwe., Antiquitäten und Kunsthandlg., Bildhauerei (Marzilistr. 36 [31.062]), Kramgasse 66 [31.984]
 – Maria L. B., Frau, Seidenweg 53
 – Marie, Privatiere. Neufeldstrasse 97
 – Marie Elise, Bürglenstrasse 41
@@ -47433,16 +47348,16 @@ Thoma, Albert, Telegraphist, Wylerstrasse 73
 Thoma, Osk. Edw., Rechen- u. Bureaumaschinen, Schwarzenburgstrasse 14b [27.623]
 Thomale, Jakob Anton, eidg. Beamter, Maulheerstrasse 9
 Thomann. s auch Thommen
-– Ad., Hilfsarbeiter. Mattenhofstrasse 15
+– Ad., Hilfsarbeiter, Mattenhofstrasse 15
 – Adolf, Kantonspolizist, Ferd.-Hodlerstr. 7
 – Anna, Angestellte, Karl-Hiltystrasse 27
 – Franz Fel., eidg. Beamter, Berchtoldstr. 41
 – Gottfried. Ziegeleiarbeiter, Niederbottigenweg 105, Bümpliz
-– Henri Rob.. Angestellter. Berchtoldstr. 41
+– Henri Rob., Angestellter, Berchtoldstr. 41
 – Henriette Sophie (Nadler), Wwe., Beaulieustrasse 84 [20.668]
 – J., gew. Bezirkspolizist, Laubeckstrasse 1
 – Jakob. Hilfsangestellter, Aarbergerg. 37
-– Joh.. Handlanger. Aarbergergasse 46
+– Joh., Handlanger. Aarbergergasse 46
 – Joh., Schlosser, Gerechtigkeitsgasse 30
 – Jul., Oberst, Instrukt.-Offizier der Sanität, Kollerweg 9 [33.851]
 – Karl (Amacher), Bankbeamter, Blumensteinstrasse 14
@@ -47457,7 +47372,7 @@ Thomet, Adolf, Pächter, Bottigenstrasse 383, Riedbach
 – Alfred, Bauhandlanger, Weidmattweg 7, Bümpliz
 – Alfred, Fürsprecher u. Notar (Bernstr. 90, Bümpliz [46.555]), Amthausg. 14 [22.383]
 – Alfred Gottfr., Landwirt, Bottigenstr. 410, Riedbach
-– Alfr., Landw . Riedhachstr. 350. Riedbach
+– Alfr., Landw., Riedhachstr. 350. Riedbach
 – Alice Lina, Weissnäherin, Wernerstr. 14
 – Chr., gew. Landwirt. Mannenriedstrasse 21, Riedbach
 – Ernst. Landwirt. Bottigenstr. 410. Riedbach
@@ -47479,7 +47394,7 @@ Thomet, Joh., Taxameterbetrieb, Lentulusrain 7 [24 099]
 – Paul, Maurer, Breitfeldstrasse 38
 – Rud., Hilfsarbeiter, Wernerstrasse 14
 – Rud., Gipser- und Malergeschäft, Gesellschaftsstrasse (42) 48 [34.339]
-– Sam.. Landwirt. Riedbachstr. 310. Riedbach
+– Sam., Landwirt. Riedbachstr. 310. Riedbach
 – Werner, Möbelschreiner, Laupenstrasse 4
 Thomi, Ad., Pächter, Papiermühlestrasse 120
 – Albert, Maurer, Bahnhöheweg 38, Bümpliz
@@ -47491,12 +47406,12 @@ Thomi, Ad., Pächter, Papiermühlestrasse 120
 – Emil Alex., Metzger, Schifflaube 28
 – Ernst, Sohn, Leiternfabrikant, Brünnenstrasse 104, Wohlen
 – Ernst, Landarbeiter, Matzenriedstr. 112, Oberbottigen
-– Ernst Rangierarbeiter S. B. B.. Freibnrgstrasse 62
+– Ernst Rangierarbeiter S. B. B., Freibnrgstrasse 62
 – Ernst, Schreiner, Werkgasse 34, Bümpliz
-– Ernst. Waldarbeiter. Matzenriedstrasse 94, Oberbottigen
+– Ernst. Waldarbeiter, Matzenriedstrasse 94, Oberbottigen
 – Ernst, Tramangestellter, Werkgasse 34, Bümpliz
 – Ernst, Wankdorfweg 11
-– Friedr.. Rahnangest., Kehrg. 35. Bümpliz
+– Friedr., Rahnangest., Kehrg. 35. Bümpliz
 – Fritz, Hilfsarbeiter, Bethlehemstrasse 116, Bümpliz
 – Fritz, Mechaniker, Badgasse 35
 – Gottl., Holzer, Niederriedweg 120, Oberbottigen
@@ -47515,9 +47430,9 @@ Thommen, s. auch Thomann
 – Ernst Emil. Adjunkt d. Amtsschreiberei, Brückfeldstrasse 15 [29.778]
 – Ernst. Maschinensetzer. Sulgenauweg 38
 – Hans, Hilfsarbeiter, Freiburgstrasse 70
-– Heinr., Beamter. Tillierstrasse 1
+– Heinr., Beamter, Tillierstrasse 1
 – Helmut Walter, kant. Angest., Junkerng.1
-– Herm.. Direktor der Securitas A.-G.. Filiale Bern, Bersethweg 8 [28.034]
+– Herm., Direktor der Securitas A.-G., Filiale Bern, Bersethweg 8 [28.034]
 Thommen & Co. 📞 29.434 Heizöl, Benzin, Petrol, Oele. Fette, ehern, techn. Produkte. Bubenbergplatz 8
 # Date: 1935-12-15 Page: 26020812/503
 Thomsen, K. M., Schreiner, Bäckereiweg 7
@@ -47536,7 +47451,7 @@ P. T. T., Grüneckweg 3
 – Paul, Schlosser. Freiestrasse 55
 – R. (Thönen), Hauswart. Heinr.-Wildstr. 3
 – Rud., Chauffeur, Lorystrasse 12 [26.014]
-– Rud. Alfr.. Rest. z. Hallergarten, Gesellschaftsstrasse 24 [21.777]
+– Rud. Alfr., Rest. z. Hallergarten, Gesellschaftsstrasse 24 [21.777]
 – Werner Joh., Hilfsarbeiter, Metzgergasse 17
 – Willi, Kontrolleur S. O. B., Chutzenstr. 39
 Thöni, Ed. Albin, Pension, Wallg. 4 [35.755]
@@ -47549,9 +47464,9 @@ Thöni, Ed. Albin, Pension, Wallg. 4 [35.755]
 Thormann, Annemarie Charlotte. Haspelg. 15
 – Antoinette Marie, Haspelgasse 15
 – Charles, Bankdirektor, Haspelgasse 15 [35 358]
-– Elisab . Frl., Muristrasse 28 [31.4161
+– Elisab., Frl., Muristrasse 28 [31.4161
 – Esther Isabella, Lehrerin, Brunnadernstrasse 31 [33.960]
-– Fr.. Dr phil., I. Bibliothekar der Stadtbibliothek. Privatdozent. Brügglerweg 19
+– Fr., Dr phil., I. Bibliothekar der Stadtbibliothek. Privatdozent. Brügglerweg 19
 – Georg Ulr Ph., Architekt, Alter Aargauerstalden 30
 — Helene Jolande, Frl., Sprachlehrerin, Brunnadernstrasse 31 [33.960]
 – H. (v. Herrenschwand), Wwe., Höhew. 36 [24.857]
@@ -47567,11 +47482,11 @@ Thüler, A., Werkinstr., Aehrenw. 27, Btimpliz [46.619]
 – Friedr., Ausläufer, Gerbergasse 6
 – Friedr., Bahnarbeiter, Freiburgstrasse 492, Bümpliz
 Thüler, G. Arthur, eidg. Beamter, Lerchenweg 27
-– Gottfr.. Schreiner, Kirchbergerstrasse 10
+– Gottfr., Schreiner, Kirchbergerstrasse 10
 – Hans. Automechaniker, Gerbergasse 4
 – Hedwig, Länggassstrasse 76
 – Herm., elektr. Anlagen, Neubrückstr. 78 [31.065]
-– Julius Rob.. Bautechniker, Länggassstr. 51
+– Julius Rob., Bautechniker, Länggassstr. 51
 – Karl, Hilfsmonteur, Gerbergasse 4
 – Karl Joh., Spengler, Mattenenge 7
 – Lydia, Telephonistin. Länggassstrasse 76
@@ -47586,7 +47501,7 @@ Thurian, Andre, Angest., Mühlemattstrasse 18
 Thürig, Emil, Mechaniker. Weberstrasse 10
 Thüring, Emil, Schneidermeister, Hallerstr. 14
 – Franz Paul, Mechaniker, Hallerstrasse 14
-Thurnheer, Jak.. Postbeamter, Kapellenstr. 6 [28.193]
+Thurnheer, Jak., Postbeamter, Kapellenstr. 6 [28.193]
 Thurni, M. Elisabeth, Aarbergergasse 61
 – Martha (Hess), Wwe., Herren-Modegesch., Scheibenstrasse 19a [36.667]
 – Otto Rob., Handlanger, Gruberstrasse 12
@@ -47597,7 +47512,7 @@ Thut, Ernst. Bureauchef der Stadtkanzlei, Grüneckweg 6
 – Margaretha Dora, Telephonistin, Altenbergstrasse 29
 – Paul, Direktor d. Bern. Kraftwerke, Willadingweg 36 [25.302]
 Tieche, Alice Elvire. Frau, Ensingerstr. 30
-– Ed.. Dr. phil., Prof., Muristrasse 5 [33.108]
+– Ed., Dr. phil., Prof., Muristrasse 5 [33.108]
 – Henri Dr. phil., Schulsekretär, Weissenbühlweg 10 [28.879]
 – K. Ad., Kunstmaler, Zieglerstr. 25 [22.214]
 – E. (Gammeter) Wwe., Epicerie fine, Ensingerstrasse 30 [35.754]
@@ -47733,14 +47648,14 @@ Trachsel, Alfred [32.560] chem. Produkte, Fahr, der «Therma»-Bodenwichse. Uebe
 – Gertrud Desiree, Bureaulistin, Spitalackerstrasse 9
 – Gottfr., Bahnarb. S. B. B., Hochfeldstr. 69
 – Gottfr, Dr. jur., Fürspr., Advokatur- u. Inkassobureau (Ob. Dufourstrasse 39), Spitalgasse 30 [27.060]
-– Hanna, Ladentochter. Melchenbühlweg 23
+– Hanna, Ladentochter, Melchenbühlweg 23
 – Hans, Einzüger, Murifeldweg 79
 – Hedwig, Bureauangestellte, Dahliaweg 18
 – Herm. Jos., Bankangestellter, Mittelstr. 61
 – Herm., Schmied, Wiesenstrasse 26
 – Joh., Fabrikarbeiter, Gerbergasse 3
 – Joh., Handlanger, Brunngasse 56
-– Joh.. Handlanger, Bümplizstrasse 83
+– Joh., Handlanger, Bümplizstrasse 83
 – Joh. Christ., Melker, Melchenbühlweg 23
 – Joh. Alb., Reisender, Blumenweg 5
 Joh., Schmied, Stöckackerstr. 89, Bümpliz
@@ -47756,7 +47671,7 @@ Trachsel, Klara, Modistin, Gesellschaftsstr. 18
 – Rosalie, Bureaulistin, Frohbergweg 9
 – Rudolf, Hilfsarbeiter, Freiburgstrasse 161
 – Samuel Gottfr., Schmied. Pappelweg 7
-– Walter. Bankangestellter. Berchtoldstr. 49
+– Walter, Bankangestellter, Berchtoldstr. 49
 – Walter O., Hilfsarbeiter, Gerbergasse 48
 – Walter, Spezialh. für Bienenhonig, Ferd.-Hodlerstrasse 16
 – Walter, Versich.-Angest., Bubenbergstr. 49
@@ -47794,14 +47709,12 @@ Traversa, Alice, Vertrieb d. «Ara» Haarfärbemittels, Zähringerstrasse 46
 – Enrico, Maler, Zähringerstrasse 45
 – Giuseppe Dom., Coiffeurmeister, Herren- u. Damensalon, Zähringerstrasse 46 [29.692]
 – Roger E., Bauzeichner, Zähringerstrasse 46
-Parquet- & Chaletfabrik AG., Bern
-Telephon 22.116 - Sulgenbachstrasse 12
 # Date: 1935-12-15 Page: 26020815/506
 Trebis, L. (Leuenberger). Damenschneiderin, Schwarztorstrasse 21
 Trebour, Fritz, Sägenfeilerei und Schleiferei, Stalden 17/19
 Trechsel, Anna Kath., Damenschneiderin, Seminarstrasse 19
 – Ernst, Dr phil., Seminarstr. 19 [25.223]
-– Ernst (Bühler), Ingen., Beamter d. Obertelegr.-Direkt.. Seminarstr. 19 [25.223]
+– Ernst (Bühler), Ingen., Beamter d. Obertelegr.-Direkt., Seminarstr. 19 [25.223]
 – Heinr. Jak., Bureaulist, Breiteweg 6
 – Henriette M. Alice, Bureaulistin, Breitew. 6
 – Lydia Magdalena, Sonnenbergstrasse 12 [34.859]
@@ -47901,20 +47814,20 @@ Trösch, s. auch Troesch
 – Fridolin, Schlosserlehrmeister d. Lehrwerkstätten, Wylerstrasse 67
 – Fritz Jakob, Hilfsarbeiter, Lorrainestr. 66
 – Jonas, Spengler, Museumstrasse 15
-– G. Fritz (Gfeller), gew Friedhofbuchhalter. Rehhagstrasse 18. Bümpliz
+– G. Fritz (Gfeller), gew Friedhofbuchhalter, Rehhagstrasse 18. Bümpliz
 – Marie, Lehrerin, Vennerweg 9
 – Martha (Rohrer), Pension, Neubrückstr. 67 [34.364]
 – Max, Fürsprecher, Neubrückstrasse 67
 – Sophie. Fabrikarbeiterin. Postgasse 48
 – Walter, Reparaturwerkstätte, Uferweg 6
-– Walter. Schmied, Dalmazirain 24
+– Walter, Schmied, Dalmazirain 24
 Trostei, Karl E , Vertr., Forstweg 65 [25.084]
 Trottet, Paul, Bankangest., Vereinsweg 8
 Troxler, Anna Maria (Brunner), Wwe.). Luternauweg 5 [36.107]
 – Fernanda E A., Kanzlistin S. E. V., Luternauweg 5
 – Josef, Beamter S. B. B., Effingerstr. 67
 – Mathilde (Bühlmann), Wwe. des Zahnarzts. Laupenstrasse 8 [34.6221
-Max Jos.. Retoucheur, Effingerstrasse 67
+Max Jos., Retoucheur, Effingerstrasse 67
 – Walter Th Photograph, Mindstrasse 4
 Trüeb u Trüb
 – Bertha (Grimm), Wwe., Privatiere, Fellenbergstrasse 8 [27 4151
@@ -47933,7 +47846,7 @@ Militärdepart., Heinrich-Wildstrasse 12 [32.004]
 – J. H., gew. Schriftsetzer, Mittelstrasse 23
 – Klara Thekla, Lingere, Zeigerweg 6
 – Konr. O., mech. Bau- und Möbelschreinerei (Balmweg 30 [34.117]), Brunnmattstr. 30 [22.871]
-– Marie (Gerber), Wwe.. Zielweg 23
+– Marie (Gerber), Wwe., Zielweg 23
 Trudel, Hrch. Joh., Chauff., Kasernenstr. 9
 Trümmer, Adele Klara, Verkäuf., Metzgerg. 20
 – Alb. Helm, Hilfsarbeiter, Metzgergasse 20
@@ -47965,7 +47878,7 @@ Pulververwaltung, Ensingerstr. 40 [27.659]
 – Hans, kaufm. Angest., Ensingerstrasse 40
 Tschaggelar, Christian, Hilfsarbeiter, Ladenwandstrasse 17
 – Eduard, Angestellter, Bollwerk 23
-– Emil, Fabrikarbeiter. Muesmattstrasse 42
+– Emil, Fabrikarbeiter, Muesmattstrasse 42
 – Erwin Samuel, Chauffeur, Fabrikstrasse 9
 – Eugen. Chauffeur, Bollwerk 23
 – Ida, Hilfsarbeiterin, Oberweg 1
@@ -47977,9 +47890,9 @@ Tschaggelar, Christian, Hilfsarbeiter, Ladenwandstrasse 17
 – Otto, Packer, Freiburgstrasse 49
 # Date: 1935-12-15 Page: 26020817/508
 Tschaggelar, Paul, Magaziner, Könizstr. 22
-– Samuel, Fabrikarbeiter. Bollwerk 23
+– Samuel, Fabrikarbeiter, Bollwerk 23
 – Wilhelm, Hilfsarbeiter, Seidenweg 5
-Tschamper, Fr., pens. städt. Baugerüstkontrolleur, Wiesenstrasse 74 .
+Tschamper, Fr., pens. städt. Baugerüstkontrolleur, Wiesenstrasse 74
 – Fritz, Kaufmann, Wiesenstrasse 74
 – Maria E., Wiesenstrasse 74
 ;— Otto, Chauffeur E. W. B., Länggassstr. 106 [20.353]
@@ -47993,7 +47906,7 @@ Tschan, Anna M., Näherin, Schwanengasse 5
 – Friedr., Hilfsarbeiter, Ladenwandstr. 49
 – Fritz, Grubenarbeiter, Burkhartweg 11, Bümpliz
 — Gottl., Handlanger, Stöckackerstrasse 77, Bümpliz
-— Joh., Handlanger, Weidmattweg 12, Bümpliz .
+— Joh., Handlanger, Weidmattweg 12, Bümpliz
 — Rud., Ausläufer, Burkhartweg 11, Bümpliz
 – Werner, Magaziner, Weissensteinstr. 61
 – Wilhelmina Hermina, Bureaulistin, Seidenweg 24
@@ -48058,7 +47971,7 @@ Tschannen, Friedrich Hermann, Mechaniker, Wachtelweg 15
 – Robert, in Firma Buchdruckerei Tschannen & Züttel, Kapellenstrasse 26 [24.176]
 – Rosa (Linder), Wwe., Mattenhofstrasse 17
 – Theodor, Brünnackerweg 27, Bümpliz
-– W., Telegr.-Angestellter. Scheibenstr. 19a
+– W., Telegr.-Angestellter, Scheibenstr. 19a
 – Walter, Adjunkt und Kassier der Amtsschaffnerei. Daxeihoferstrasse 3 [34.0511
 – Walter, Hilfsarbeiter, Jurastrasse 77
 – Walter Ernst. Kaufmann, Monbijoustr. 25
@@ -48149,7 +48062,7 @@ Tschanz, Lina, Mattenhofstrasse 33
 – Rosalie, Tavelweg 33
 – Rud., Käser, Murtenstr. 222, Bümpliz
 – Rud., Maurer, Altenbergstrasse 20
-– Rudolf, Nachtwächter. Murtenstr gisse 222, Bümpliz
+– Rudolf, Nachtwächter, Murtenstr gisse 222, Bümpliz
 – Rud., Hilfsarbeiter, Bümplizstrasse 60
 – Samuel, Chauffeur S. O. B., Balmweg 21
 – Walter, Kaufmann, Kramgasse 29 [28.767]
@@ -48162,7 +48075,8 @@ Zentralbilioth., Brunnmattstr. 17 [29.053]
 – Ernst, Gasarbeiter, Sandrainstrasse 95
 – Hans. Postkommis, Zwyssigstrasse 26
 – J., Maschinist, Belpstrasse 16 [22.566]
-– Lotti Hedwig, Modistin, Belpstrasse 16v. Tscharner, Fritz, Marktgasse 21 [31.643]
+– Lotti Hedwig, Modistin, Belpstrasse 16
+v. Tscharner, Fritz, Marktgasse 21 [31.643]
 – Max (Lombard), in Fa. H. v. Wattenwyl & Cie., Kalcheggweg 14 [28.115]
 – Ther. (de Lesseft), Elfenstr. 19 [32.979]
 Tschechoslowakische Gesandtschaft, Kanzlei, Muristrasse 53 [24.914 u. 24.915]
@@ -48177,7 +48091,7 @@ Tschiffeli, Klara Joh. Adele, Privatiere, Bubenbergplatz 4
 Tschirch, Alexander, Dr., pens. Professor, Kollerweg 32 [31.296]
 – Margarethe, Privatiere, Kollerweg 32
 # Date: 1935-12-15 Page: 26020819/510
-Tschirren, Alfr.. Schreiner, Murtenstr. 155o
+Tschirren, Alfr., Schreiner, Murtenstr. 155o
 – Friedr., Primarlehrer, Hubelmattstr. 50 [20.199]
 – Fritz Ernst, Angestellter, Morillonstr. 14
 – Fritz, Maurer. Murtenstrasse 155o
@@ -48185,7 +48099,7 @@ Tschirren, Alfr.. Schreiner, Murtenstr. 155o
 – Gottl. Alb., Schreiner, Gewerbestrasse 12
 – Jean, Konfiserie, Kramgasse 73 [31.864]
 – Joh. Rud., Maler, Morillonstrasse 14
-– Joh.. Hafner, Morillonstrasse 14
+– Joh., Hafner, Morillonstrasse 14
 – Kurt, Postbeamter, Fischerweg 18
 – Otto, Hilfsarbeiter G. W. B., Rütlistrasse 11
 – Rudolf, Angest., Pestalozzistr. 1 [27.267]
@@ -48194,7 +48108,7 @@ Tschopp, Charles (Feuz), Typograph, Moserstrasse 15
 Georgine Martha, Viktoriarain 6
 – Lina Ida, Frau, Verkäuferin, Waghausg. 8
 – Othmar, Schlosser. Schärerstrasse 9
-– Walter. Beamter der S. B. B., Stöckackerstrasse 99a, Bümpliz [46.584]
+– Walter, Beamter der S. B. B., Stöckackerstrasse 99a, Bümpliz [46.584]
 – Wilhelm, Postchauffeur, Rossfeldstr. 23
 Tschudi und Tschudy
 – Arthur Theodor, Versieh.-Beamter, Klaraweg 11 [31.488]
@@ -48221,7 +48135,7 @@ Tschui, Joh., städt. Beamter, Bierhübeliweg 31
 – Rud., Mareh.-Tailleur, Gerechtigkeitsg. 4
 – Rud., Coiffeur, Kesslergasse 38
 – Walter, Hilfsarbeiter, Gerechtigkeitsg. 4
-Tschumi, Adeln.. Landjäger. Muesmattstr. 24
+Tschumi, Adeln., Landjäger. Muesmattstr. 24
 – Anna (Burkhalter), Wwe., Weberstrasse 3
 – E., Lehrerin der Lorraineschule. Kirchbühlweg 44
 – Elise, Feilenbergstrasse 10
@@ -48239,7 +48153,7 @@ Tschumi, Ernst Walter, Autosattler, Dalmaziweg 87
 – Hans, Fürspr., Advokaturbureau (Werdtweg 5a [27.651]), Neuengasse 20 [24.235]
 – Hans, Pensionshalter, Kramgasse 14 [29.966]
 – Jakob, Kommis, Gryphenhübeliweg 14
-– Julius, Angestellter der S. B. B.. Stadtbachstrasse 6
+– Julius, Angestellter der S. B. B., Stadtbachstrasse 6
 – Ludwig Eugen, Vertreter, Gerechtigkeitsgasse 8
 – Marie Elise, Kirchbühlweg 44
 – Martha Maria (Schmid), Wwe., Sennweg 9 [20.697]
@@ -48251,12 +48165,12 @@ Tschumper. August. Direktor der Parkett- u. Chaletfabrik, Sulgenbachstr. 12 [22.
 – Oskar Gottfr., Angestellter, Berchtoldstr. 58 [28.644]
 Tschümperlin, Wilhelm, Kondit., Metzgerg. 56
 Tschupp, A. Otto, Ingenieur, Nünenenweg 23
-Tschuppert, Anton J.. Packer. Aebistr 17
+Tschuppert, Anton J., Packer. Aebistr 17
 Tseou, Kia Yong, Sekretär der chinesischen Gesandtschaft, Willadingweg 23
 Tuason, Vinzenz Jos. Alb., Fürspr., Haspelgasse 16
 Tuberkulose-Fürsorgeverein der Stadt Bern, Gerechtigkeitsgasse 72 [23.779]
 Tuberkulosefürsorge, Verein Bern-Land, Schwanengasse 5 [21.250]
-Tuchfabrik Adrian Schild A.-G.. Wasserwerkgasse 17 [22.6121
+Tuchfabrik Adrian Schild A.-G., Wasserwerkgasse 17 [22.6121
 Tüller, Erwin, Apotheker, Verwalter d. Bahnhof-Drogerie und Apotheke Schmid & Cie., Neufeldstrasse 118 [34.338]
 Tumarkin, Anna, Dr., Prof., Hallwylstr. 44
 Tung, Enrico, Redaktor, Wabernstrasse 24 [20.166]
@@ -48286,35 +48200,35 @@ Depot der B. N. B., Schwarzenburgstr. 6
 Turnhalle, Altenbergstrasse 39 [22.280]
 – Schwellen mätteli, Schwellenmattstrasse 1 [34.065]
 Turri. Siro. eidgen. Beamter, Heinrich-Wildstrasse 16
-Turrian, Alfr., Dr.. amerik Zahnarzt, Konsulvon Portugal (Marienstrasse 18 [21.839]), Amthausgasse 6 [23.032]
+Turrian, Alfr., Dr., amerik Zahnarzt, Konsulvon Portugal (Marienstrasse 18 [21.839]), Amthausgasse 6 [23.032]
 Turlschi, Ernst J., Zementer, Stockerenweg 4
 – Fritz, eidg Beamter Wyttenbachstr. 32
 Tüscher, s auch Teuscher
 – A M., pens. Lehrerin. Bubenbergstrasse 5
-– Alfr.. Polizeigefreiter. Murifeldweg 1
-– Alfr.. Rohrnetzaufseher. Brunnmattstr. 10
+– Alfr., Polizeigefreiter, Murifeldweg 1
+– Alfr., Rohrnetzaufseher. Brunnmattstr. 10
 – Alfred, Schlosser, Brunnmattstrasse 10
 – Charles Alfr., Kommis, Gutenbergstr. 19
-– Eduard 0 . Mechaniker. Bümplizstr. 171
+– Eduard O., Mechaniker. Bümplizstr. 171
 – Ernst. Küfer, Effingerstrasse 15
 – Erwin, Ausläufer, Effingerstrasse 15b
-– Friedr.. Elektrotechniker, Dalmaziweg 75
+– Friedr., Elektrotechniker, Dalmaziweg 75
 – Friedr., Schlachthofangest. Standstr 30
 – Hans Alfr., kant. Angestellter, Murifeldweg 1
 – Hans Heinrich, Spengler. Bümplizstr. 58
 – Joh., Bahnarbeiter, Bümplizstrasse 58
 – K., Zimmermann. Standstrasse 26
-– Karl. Chauff.. Winterholzstr 43. Bümpliz
+– Karl. Chauff., Winterholzstr 43. Bümpliz
 – Lisette (Zumbrunnen). Kaffeewirtschaft, Kramgasse 77 [35.338]
 – Martha Olga, Ladentochter, Effingerstr. 15b
-– P., Lic. jur.. Ob. Dufourstrasse 7 [35.635]
+– P., Lic. jur., Ob. Dufourstrasse 7 [35.635]
 – Roger Max, Dr. med., Freiburgstrasse 18
 – Sophie Berta. Weissnäherin, Bümplizstr.58
 Twerenbold, Adolf (Stauffer), Handel in Möbeln, Teppichen, Vorhängen, Monbijoustrasse 36 [29.348]
 – Alois S., Hausbursche, Kornhausplatz 7
 – Ernst Werner. Bankangest., Rosenweg 9a
 – Louise M. (Bachmann), Modes « Mado», Kornhausplatz 7 [26.184]
-– Melanie F., Bankangest.. Ereiestrasse 23
+– Melanie F., Bankangest., Ereiestrasse 23
 Typon A.-G., Photogr. Filme, Muristrasse 51
 Ubbens, Charl. Gust. Ernst, Sonnenbergstr. 7 [25.665]
 Ubert, Klara, Lebensmittelhandlung, Zieglerstrasse 31 [23.653]
@@ -48329,7 +48243,7 @@ Uebersax, Alice, Abwartin, Wallgasse 4
 – Hans, Zahntechniker, Gutenbergstrasse 8
 – Heidy, Verkäuferin, Länggassstrasse 57
 – Heinr. Hugo, Maurer, Breitfeldstrasse 56
-– Ida Bertha. Abwartin, Wallgasse 4
+– Ida Bertha, Abwartin, Wallgasse 4
 – Martha, Bureaulistin. Beaumontweg 15 [36.432]
 – Otto E., Schreiner, Talweg 5
 – Paul M., Autosattler, Murtenstrasse 29
@@ -48350,14 +48264,14 @@ Uhlmann, s auch Ulmann u Ullmann
 – Erika Hedwig, Verkäuferin, Rodtmattstr.58
 – Ernst, Bücherrevisor, Brückfeldstrasse 39 [28.463], Bureau Hans Santschi, Daxelhoferstrasse 18 [23.898]
 – Ernst, Magaziner, Landoltstrasse 69
-– Ernst, Pferdewärter. Breiteweg 4
+– Ernst, Pferdewärter, Breiteweg 4
 – Ernst. Postangestellter, Schärerstrasse 21
 – Ernst, Marktfahrer, Pappelweg 6
 – Eugen, Ausläufer, Eggimanstrasse 31
 – F H., Kaufmann, Länggassstrasse 96
 – Frieda, Damenschneiderin, Breitfeldstr. 35a
-– Friedr.. Handlanger. Murtenstrasse 153e
-– Friedr.. Schlosser. Hochfeldstrasse 51
+– Friedr., Handlanger. Murtenstrasse 153e
+– Friedr., Schlosser. Hochfeldstrasse 51
 – Friedr., Stricker, Sodweg 7
 – Fritz. Heizer, Schänzlistrasse 39
 – Fritz, Hilfsarbeiter, Kesslergasse 27
@@ -48385,7 +48299,7 @@ Uhlmann, s. auch Ulmann u. Ullmann
 – Rud., Fabrikarbeiter, Tunnelweg 14
 – Sophie Elise, Fabrikarbeiterin, Ob. Aareggweg 4
 – Walter Louis, Obergärtner, Altenbergstr. 29
-– Walter. Schreiner, Tunnelweg 12
+– Walter, Schreiner, Tunnelweg 12
 – Werner, Meohan., Aehrenweg 37, Bümpliz
 – Wilhelm, Spengler, Ladenwandstrasse 94
 Ulldry, Jos. A. A., pens. Beamter, Moserstr. 30
@@ -48401,7 +48315,7 @@ Ulli, Albert, Mechaniker, Wiesenstrasse 66
 — —Hob., Ingenieur, Amthausgasse 2 [33.264]
 Ullmann, s. auch Uhlmann und Ulmann
 – Alwine (Maier), Wwe., Greyerzstrasse 34
-— Helena, Ladentochter. Eggimannstr 31
+— Helena, Ladentochter, Eggimannstr 31
 – Jak. A., Fabrikarbeiter, Ob. Aareggweg 4
 – Karl Max, Kaufmann, Greyerzstrasse 34 [33.2971
 Ulmann, Alfr. G., Ausläuf., Brunnadernstr. 21
@@ -48424,7 +48338,7 @@ Ulrich, Ad., Hilfsarbeiter, Elisabethenstr. 57
 – Ed., Polizeiwachtmeister, Hochfeldstr. 97 [20.511]
 – Ernst, Ausläufer, Länggassstrasse 41
 – Friedr., Karrer, Stalden 24
-– Friedr.. Schlosser, Beundenfeldstrasse 44
+– Friedr., Schlosser, Beundenfeldstrasse 44
 – Friedr. Eduard, jun., Schlosser, Beundenfeldstrasse 44
 – Friedr., Wegaufseher, Bethlehemstr. 121, Bümpliz
 – Friedr., Maler, Stöckackerstr. 71, Bümpliz
@@ -48440,7 +48354,7 @@ Ulrich, Ad., Hilfsarbeiter, Elisabethenstr. 57
 – Hermann, Gipser- u. Malermeister, Länggassstrasse 41
 – Hermann, Polizeikorporal, Nägeligasse 4
 – J., Architekt, eidg. Bauinspektor, Schillingstrasse 15 [33.679]
-.— Joh., Hilfsarbeiter, Brünnenstr. 76, Bümpliz
+— Joh., Hilfsarbeiter, Brünnenstr. 76, Bümpliz
 – Joh., Maurer, Weidmattweg 14, Bümpliz
 – Jos., Karrer, Lerchenweg 30
 – Magdalena El. (Hostettler), Wwe., Egelgasse 20b
@@ -48457,7 +48371,7 @@ Ulrich, Ad., Hilfsarbeiter, Elisabethenstr. 57
 – Rosa (Lier), Wwe., Mühlenplatz 4
 – Rudolf, Fabrikarbeiter, Stöckackerstr. 71, Bümpliz
 – Rudolf, Mechaniker, Mühlenplatz 4
-– Walter, Postangestellter. Bridelstrasse 8
+– Walter, Postangestellter, Bridelstrasse 8
 – Walter Ernst, mech. Schreinerei (Beundenfeldstrasse 44), Allmendstrasse 9 [28.04oJ
 – Werner Rud., Telephonmonteur, Beundenfeldstrasse 44
 # Date: 1935-12-15 Page: 26020822/513
@@ -48531,7 +48445,7 @@ Urben, Alfred, Mech., Gesellschaftsstrasse 12
 – Rosette. Schneiderin, Metzgergasse 32
 Urech, Alb. Aug., Postbeamter, Diesbachstr. 31
 – Aug. Karl, Dr., Sektionschef b. eidg. Versicherungsamt, Neubrückstr. 120 [25.964]
-– Erngt Erwin. Hilfsarbeiter. Wasserwerkg. 8
+– Erngt Erwin. Hilfsarbeiter, Wasserwerkg. 8
 – Hans, Patissier, Beundenfeldstrasse 39
 – J. H., gew. Vorstandstellvertreter der Zentralwagenkontrolk der S. B. B., Thunstr. 24 [35.584]
 – Jacques, Seftigenstrasse 34
@@ -48603,7 +48517,7 @@ Utz, Ad., Handlanger, Seidenweg 33
 – Kl. (Geiser), Wwe., gew. Arbeitslehrerin, Haldenweg 4 [20.682]
 – Roland, kaufm. Angest., Jägerweg 14
 – Rosa, Geschäftsangestellte. Gerechtigkeitsgasse 71
-– Walter. Kassier, Jägerweg 14
+– Walter, Kassier, Jägerweg 14
 Utzinger, Heinr., Mechaniker, Freiburgstr. 444, Bümpliz
 – Heidy Lydia, Telephonistin, Greyerzstr. 22
 – Joh. Jak. (Merz), Kassier des Gaswerksu. d. Wasserversorgung, Greyerzstrasse 22 [25.918]
@@ -48656,8 +48570,7 @@ Vassaux, Eugenie S., Ladentochter, Sodweg 9
 – Fr., Angestellter, Wallgasse 2
 – Friederika Rosa (Fries), Wwe., Weisseristeinstrasse 10
 – Jean Paul, Billetteur S. S. B., Alleeweg 7
-Vatter, Adolf F. (Mauderli), Apotheker, in Fa.
-A. Vatter & Co., Apotheke u. Drogerie zu
+Vatter, Adolf F. (Mauderli), Apotheker, in Fa. A. Vatter & Co., Apotheke u. Drogerie zu
 Rebleuten, Seminarstrasse 24 [35.677]
 – Erich Rob., kaafm. Angest., Kalcheggw. 22
 – G. R., A.-G., Samenhandlung, Spezialgeschäft für Vogelfutter, Bärenplatz 2 [27.431]
@@ -48773,7 +48686,7 @@ Vereinshaus, evangelisches, Zeughausg. 35/39
 – Lorraine, Lorrainestrasse 84
 Verkäuferinnenschule der Stadt Bern, Sekretariat: Zeughausgasse 31 [21.241J
 Verkaufsstelle der Genossenschaft zentralschweizerischer Ziegeleibesitzer, Neueng. 20, Bürgerhaus [21.027]
-Verkehrsbureau, offiz.. Bundesg. 18 [23.951]
+Verkehrsbureau, offiz., Bundesg. 18 [23.951]
 Verlag der Internat. Vereinigung der Beamtendes Zivilstandsdienstes (« Izet »), Neuengasse 24
 Verlagsgenossenschaft C. A. Loosli’s Werke, Brünnenstrasse 105, Bümpliz
 Vermeide, L. (Mangeat), Kanzleisekr. b. int. Bureau der Telegraphenunion, Bovetstr. 9
@@ -48799,7 +48712,7 @@ Vertriebs-Aktiengesellschaft « Entlüftungsanlagen Zimmermann », Schwanengasse
 Verwa A.-G. Bern, Liegenschaftsverwaltungusw., Murtenstrasse 29 [21.012]
 Verwaltungsgericht, Kanzlei. Schanzenstr. 17 [23.803]
 Vesco, Angelo, Maurer, Brückfeldstrasse 20
-Vescovi, Nicola, Fabrikarbeiter. Fährstr. 34
+Vescovi, Nicola, Fabrikarbeiter, Fährstr. 34
 – Rosa, Fabrikarbeiterin, Felsenaustr. 82
 Vest, Seraphine (Egger), Wwe., Herzogstr. 26
 Veterinäramt, Schweiz., Kanzlei, Bundeshauß-Nordbau [61]
@@ -48822,19 +48735,17 @@ Konrad. Schlosser, Wyttenbachstrasse 33
 – Otto, Schriftsetzer, Bümplizstrasse 60a
 Wilhelmine E. (Egger), Wwe., Finkenr. 3
 Vianelli, Angelo, Maurer, Standstrasse 32
-Angelo Paul, Biscuitier, Standstrasse 32
+— Angelo Paul, Biscuitier, Standstrasse 32
 Vicini, Giuseppe, Maurer, Ralligweg 14
 Vick, Karl Wilhelm (Grünblatt), Chemigraph, Könizstrasse 20
 « Victoria », Krankenanstalt, Schänzlistr. 65 [22.915]
 Sanatorium, Sonnenbergstr. 14 [22.911]
-Victoriahall, Cafe-Restaurant, Effingerstrasse
-51/53 [21.208]
+Victoriahall, Cafe-Restaurant, Effingerstrasse 51/53 [21.208]
 Vidoudez, Marcel Henri, Zeichner, Güterstrasse 34
 Viehweg, Max Hermann, Angestellter, Mittelstrasse 9
 Vieli, Francesco D., Dr., Steinauweg 6
 – Parfümerie, Dr. Georg Vieli (Steinerstr. 39 [23.883]), Helvetiastrasse 5 [33.536]
-– Peter (de Pury), Dr. jur., I. Adjunkt der
-Handelsabteilung, Schillingstr. 3 [22.892]
+– Peter (de Pury), Dr. jur., I. Adjunkt der Handelsabteilung, Schillingstr. 3 [22.892]
 Vierte Baugesellsch. Stauffacherstrasse A.-G., Chutzenstrasse 21
 Vifian, s. auch Fivian
 – Alfr., Metzgermstr., Hallerstr. 23 [31.479]
@@ -48872,10 +48783,6 @@ Villiger, Friedr., Schreiner, Elisabethenstr. 44.
 – Josef, Schneider, Scheibenstrasse 23
 – Klara, Damenschneiderin, Scheibenstr. 23
 – Nelly, Bureaulistin, Scheibenstrasse 23
-Auswindmaschinenfür Privat- und Geschäftsbetriebe leistungsfähig und insolider Konstruktion liefert
-W. SCHLAFLI
-Spenglerei u. Installationsgeschäft
-Mühlemattstr. 14a, Tel. 27.520
 # Date: 1935-12-15 Page: 26020827/518
 Villiger, Otto, Typograph, Steinauweg 23
 – Rudolf, in Fa. Blaser & Villiger, Bonstettenstrasse 3
@@ -48944,13 +48851,13 @@ Vogel, Dora Klara, Damenschneiderin, Bärengasse 12. Büinpliz
 – Max, Fürsprecher, Gurtengasse 3
 – Rosa Albertine, Fabrikarbeiterin. Effingerstrasse 55
 – Sam., Postbeamter, Freiestrasse 37
-– Walter. Dekorateur, Holzikofenweg 31
+– Walter, Dekorateur, Holzikofenweg 31
 – X., Schriftsetzer, Brünnenstr. 60, Bümpliz
 Vogelbacher, Leo, Buchdrucker, Rodtmattstrasse 89
 Vögele, Rosa (Büttikcfer), Pension, Fischerweg 20 [34.3431
 Vögeli, Ad., Beamter, Engehaldenstrasse 97
 – Ad., Möbelschrein. (Genfergasse 8), Beundenfeldstrasse 31a
-– Ad. Nikl.. Post-Garagechef, Engehaldenstrasse 97 [21-673
+– Ad. Nikl., Post-Garagechef, Engehaldenstrasse 97 [21-673
 – Alfred. Bäckerei, Bühlstrasse 27 [31.8501
 – Alfred, Hilfsarbeiter, Metzgergasse 54
 – Alfred. Schlosser. Badgasse 41
@@ -48964,7 +48871,7 @@ Vögeli, Ad., Beamter, Engehaldenstrasse 97
 – Christ., Hufschmied G. R D., Zeigerweg 10
 – Elisabeth (Lieber), Wwe., Scheibenstr.
 – Ernst, Baugeschäft. Thormannmätteliw. 3o [27.420J
-– Ernst (Köhli), Hilfsarbeiter, Keltenstr. 97, Bümpliz ..
+– Ernst (Köhli), Hilfsarbeiter, Keltenstr. 97, Bümpliz
 – Ernst (Harnisch), Sek.-Lehrer, Schriftexperte, Wylerstrasse 28 [S2.o4ö]
 – Eva Hel., Bureaulistin. Tavelweg 37
 # Date: 1935-12-15 Page: 26020828/519
@@ -48979,7 +48886,7 @@ Vögeli, Fanny (Nobs), Fabrik, u. Verkauf v. Corsets, Breitenrainplatz 36 [26.13
 – Fritz, Mechaniker, Breitenrainplatz 36
 – Fritz, Metzger, Spitalackerstrasse 72
 – G., Hauswart, Effingerstrasse 11
-– Gottfr,, pens. Bahnarbeiter. Elisabethenstrasse 44
+– Gottfr., pens. Bahnarbeiter, Elisabethenstrasse 44
 – Gottl., Mechan., Burgunderstr. 57, Bümpliz
 – Hans, Kässalzer, Kehrgasse 31, Bümpliz
 – Hans, Tramarbeiter, Moritzweg 16
@@ -48987,7 +48894,7 @@ Vögeli, Fanny (Nobs), Fabrik, u. Verkauf v. Corsets, Breitenrainplatz 36 [26.13
 – Herrn Rud., Tramangest., Wiesenstr. 40
 – J. M., pens. Schneider, Breitfeldstrasse 47
 – Joh., gew. Munitionsarbeiter, Mattenenge 9
-– Joh.. Strassenreiniger, Seidenweg 20
+– Joh., Strassenreiniger, Seidenweg 20
 – Karl, Bankangestellter, Engehaldenstr. 97
 – Lea, Ladentochter, Zwiebelngässchen 14
 – Lea, Lehrerin, Gottlieb-Kuhnweg 14
@@ -49029,7 +48936,7 @@ Vogler, Ernst, Maschinenmeister, Flurstr. 6
 – E. Spenglermstr. (Standstrasse 28), Scheibenstrasse 38 [32.607]
 Vogt, Ad., Vertreter, Kursaalstrasse 6 [24.755]
 – Ad., Abwart, Nouengasse 28
-– Adolf, Postangestellter. Güterstrasse 38
+– Adolf, Postangestellter, Güterstrasse 38
 – Ad., Schreiner, Länggassstrasse 20
 – Alice, Bureaulistin, Länggassstrasse 71
 – Alice. Heilsarmeeoffizierin. Murifeldweg 1
@@ -49055,8 +48962,7 @@ Vogt, Ad., Vertreter, Kursaalstrasse 6 [24.755]
 – Ida, Krankenpflegerin, Brunngasse 10
 – Ida Martha, Klavierlehrerin, Hallerstr. 60
 – Jaqueline (van den Brink), Falkenhöhew. 1 [23.820]
-– J. J., Betriebsleiter der «Hallwag», Abtlg.
-Buchdruck, Tavelweg 34 [26.258]
+– J. J., Betriebsleiter der «Hallwag», Abtlg. Buchdruck, Tavelweg 34 [26.258]
 – Johanna (Kistler), Wwe., Scheuermattw.10 [35.669]
 – Joh., Handlanger, Bottigenstr. 76, Bümpliz
 – Karl, Beamter der Baudirektion I, Zähringerstrasse 32 [29.253]
@@ -49065,18 +48971,16 @@ Buchdruck, Tavelweg 34 [26.258]
 – Kurt, Schaufensterdekorateur, Tavelw. 34 [26.258]
 – Lena (Schmidt), Wwe., Schwarztorstr. 41 [34.120]
 – Maria Josefina (Vogt), Abwartin, Marzilistra.ssö 6
-– Max Alb., Techniker S. B. B.. Hochfeldstrasse 107
+– Max Alb., Techniker S. B. B., Hochfeldstrasse 107
 – Otto, Buchbinder, Länggassstrasse 71
 – Otto (Kern), Kalkulator, Landoltstrasse 50
-Asphaltarbeitenbei Strassenbau, Vorplätzen, Gärten usw. n RjZZOZERßz wec k m ä ss i g, f ac h gern äss durch die bern - bümpliz
-Strassenbauunternehmung: Telephon Nr. 46.12a
 # Date: 1935-12-15 Page: 26020829/520
 Vogt, Paul Otto (Brechbühl), kaufm. Angest., Sennweg 15
 – Peter (Frei), Bankbeamt., Jubiläumsstr. 13
 – Rob. (Hildebrand), Dr. med., Arzt, Gutenbergstrasse 6 [21.466]
 – Rosa, Sekretärin, Belpstrasse 42
-; —W., gew. Handelsgärtner, Belpstrasse 42
-– Werner, Dr. jur., Generalagent der «Helvetia», Schweiz. Unfall- u. Haftpflicht-Versieh.-Anstalt, Müslinweg 32 [29.754]
+— W., gew. Handelsgärtner, Belpstrasse 42
+– Werner, Dr. jur., Generalagent der «Helvetia», Schweiz. Unfall- u. Haftpflicht-Versich.-Anstalt, Müslinweg 32 [29.754]
 Vögtli, Meinrad, Gärtner, Gesellschaftsstr. 84
 – Gertrud E., Damenschneid., Gesellschaftsstrasse 84
 Vögtlin, Elisab. M. (Rathgeb), Wwe., Schneiderin, Rodtmattstrasse 110
@@ -49123,7 +49027,7 @@ Vollenweider, A., Frau, Pension, Gutenbergstrasse 15 [35.676]
 – Hans Ad., Packer, Attinghausenstrasse 31
 – Hans, Angestellter, Gerbergasse 7
 – Jak., Beamter, Länggassstr. 68a [35.782]
-– Joh.. Bildhauer. Mühlemattstrasse 68
+– Joh., Bildhauer. Mühlemattstrasse 68
 – Johanna B., Bureaulistin, Mauibeerstr. 5
 – Martha (Buchmüller), Wwe., Ostermundigenstrasse 12 [35.887]
 – Martha (Galliker), Wwe., Bureaulistin, Rossfeldstrasse 25
@@ -49139,7 +49043,7 @@ Volmerhausen, Franz, Buchbinder, Dalmaziweg 67 [32.861]
 Volz, Friedr., med., Drogist, in Fa. W. Volz & Cie., Brunnadernstrasse 11 [32.545]
 – Gerard, Länggassdrogerie (Brückfeldstr. 25 [34.624]), Länggassstrasse 53 [34.624]
 – Luise, Privatiere, Schanzeneckstrasse 25
-– O. (Fiaux), gew. Versich.-Beamter. Dählhölzliweg 8 [29.709]
+– O. (Fiaux), gew. Versich.-Beamter, Dählhölzliweg 8 [29.709]
 – W., Apotheker, in Firma W. Volz & Cie., Humboldtstrasse 31 [22.136]
 – W., & Co., Centralapotheke, Zeitglocken 2 [21.094]
 Vonarburg, Jakob, Monteur, Tscharnerstr. 45
@@ -49250,7 +49154,7 @@ Wabersacker - Immobilien A.-G., Freiburgstr.
 Nr. 125
 Wächli, G., Schreiner, Bubenbergstrasse 10a
 – Klara, Lehrerin. Landoltstrasse 54
-– Paul. Prokurist der Allgem. Vers. A.-G.. in Bern, Brückfeldstrasse 43 [27.702]
+– Paul. Prokurist der Allgem. Vers. A.-G., in Bern, Brückfeldstrasse 43 [27.702]
 – Willy, Elektromonteur, Stockerenweg 18
 – Jenni, Albert, Sattler- u. Tapezierermstr., Militärstrasse 62 [34.544]
 Wachs, Ernst Walter, Ing. S. B. B., Schwarztorstrasse 9 [26.024]
@@ -49293,7 +49197,7 @@ Wäffler, Anna (Wymann), Wwe., Lorrainestrasse 64
 – Samuel, amtl. Holzmesser, Stadtbachstr. 26 [32.735]
 Waga A.-G., Haushaltungsartikel etc., Marktgasse 32
 Wäger, Franz Anton, Dr., Journalist, Diesbachstrasse 16 [35.712]
-Wägli, Alex. Walter. Mech., Brunnhofweg 3
+Wägli, Alex. Walter, Mech., Brunnhofweg 3
 – Anna (Häusler), Wwe., Stockernweg 3
 – David. Hilfsarbeiter, Lorrainestrasse 23
 – Emil Rud., kaufm. Angest., Stockernweg 3
@@ -49350,10 +49254,10 @@ Wahl, Jakub, Viehhändler. Mühlemattstr. 57 [21.139]
 – Jules, Privatier, Kapellenstr. 24 [36.037]
 – Marcel, Verkäufer, Kapellenstrasse 24
 – Paul, Tscharnerstrasse 1 [28.310]
-Wahlen, Alb., in Fa. A. Wahlen & Cie.. Baumater.-Hdlg., Greyerzstrasse 83 [32.379]
+Wahlen, Alb., in Fa. A. Wahlen & Cie., Baumater.-Hdlg., Greyerzstrasse 83 [32.379]
 – Anna. Frl., Brunnmattstrasse 50
 – Arthur, Tapezierer, Herzogstrasse 13
-– Ernst Rud.. Maschinenzeichner, Alter Aargauerstalden 32
+– Ernst Rud., Maschinenzeichner, Alter Aargauerstalden 32
 – Friedr. Alb., Kaufmann, Herzogstrasse 13
 – Hans, Bankangestellter, Alter Aargauerstalden 32
 – Hans, Sattler- u. Tapezierermeister, Herzogstrasse 13 [32.163]
@@ -49366,20 +49270,19 @@ Wahlen, Alb., in Fa. A. Wahlen & Cie.. Baumater.-Hdlg., Greyerzstrasse 83 [32.37
 – & Cie. A., Bau- und Brennmaterial- und Eisenhdlg., Ryffligässchen 8 [23.038]
 Wahli, Alb., Bauaufseher, Unt. Gerechtigkeitsgässchen 4
 – A., Schriftsetzer, Schönburgstrasse 26
-– Anna Elise, Frl.. Zwiebelngässli 10
-– Bertha, pens. Bankangest.. Berchtoldstr. 15
-– E., Gipser- u. Malermeister, Birkenweg 27
-., [31.270]
+– Anna Elise, Frl., Zwiebelngässli 10
+– Bertha, pens. Bankangest., Berchtoldstr. 15
+– E., Gipser- u. Malermeister, Birkenweg 27 [31.270]
 – Ernst Alfr., Maler, Birkenweg 27
-– Fr.. Schriftsetzer. Fichtenweg 9
-Friedr, Handlanger, Weissensteinstr 22
-Fritz. Telegraphist, Fichtenweg 25 [26.072]
+– Fr., Schriftsetzer. Fichtenweg 9
+— Friedr, Handlanger, Weissensteinstr 22
+— Fritz, Telegraphist, Fichtenweg 25 [26.072]
 – Hans, Heizungsmonteur. Buchenweg 10
-Johanna Math., Telephonistin. Fichtenw. 9
+— Johanna Math., Telephonistin. Fichtenw. 9
 – Karl, eidg. Beamter, Beundenfeldstr 9
 – Maria (Zbinden), Wwe., Freiburgstr. 341, Bümpliz
 – Marie, Lingere, Freiburgstr. 341, Bümpliz
-– Rob., kaufm. Angestellter. Freiburgstr. 341, Bümpliz
+– Rob., kaufm. Angestellter, Freiburgstr. 341, Bümpliz
 — Rob., Handlanger, Buchenweg 10
 – Rob., mech Schreinerei. Scheibenstr. 22c [36.907]
 – Rud., Handlanger, Wylerringstrasse 68
@@ -49402,21 +49305,21 @@ Wälchli, Alfred, Postangest., Cäcilienstr 26
 – Bertha, Wwe., Greyerzstrasse 72 [24.769]
 – Charles, Rest. Kirchenfeld, Thunstrasse 5 [28.177]
 – Emil, Bureaulist, Lentulusstrasse 32
-– Ernst, Bahnarbeiter. Weissensteinstr. 70
+– Ernst, Bahnarbeiter, Weissensteinstr. 70
 – Ernst, Hilfsarbeiter, Chaletweg 16, Bümpliz
 – Ernst, Uhrenmacher, Weissensteinstr. 70
 – Fritz, Installateur. Murtenstrasse 36
 – Fritz, Wärter, Schermenweg 34
 – Gottfr., pens. Sektionschef d. eidg. Versich.-Amtes, Murtenstrasse 36
-– Gottfr., Postangestellter. Nordweg 10
+– Gottfr., Postangestellter, Nordweg 10
 – Hans. Herren- und Damensalon, Landoltstrasse 32 [26.244]
-– Joh.. Postangestellter, Seidenweg 16
+– Joh., Postangestellter, Seidenweg 16
 – Joh., Schneider, Schwarztorstrasse 97
 – Martha, Fabrikarbeiterin, Gerbergasse 38
 – Marie. Damenschneiderin. Murtenstrasse 36
 – Otto, Chauffeur, Heckenweg 19
 – R., Zimmermann, Lentulusstrasse 32
-– Rob., Vertreter. Kesslergasse 33
+– Rob., Vertreter, Kesslergasse 33
 – Walter, Coiffeur, Effingerstrasse 41b
 – Werner Jak., Buchbinder, Kirchenfeldstrasse 35
 – Willi, Vater, Büchdruckerei und Verlag, Lerchenweg 26 [24.680]
@@ -49471,11 +49374,11 @@ Wallach, L., Kaufmann, Thunstr. 68 [23.056]
 Wall, Danile N., Sekretär, Em.-Friedlistr. 12
 Wälle, Ernst, Typograph, Schifflaube 40
 – Maria, Schneiderin, Neuengasse 6
-Waller, Gottfr.. Vertreter. Greyerzstrasse 35
+Waller, Gottfr., Vertreter, Greyerzstrasse 35
 – Ida (Meyer), Wwe., Filialleit., Jägerweg 17
 – Rud. Fr. P., Bankangest., Spitalackerstr. 9
 – Maison de couture, Spitalgasse 30 [27.009]
-Wallimann, Hans, Beamter d. S. B. B.. Bernastrasse 59 [24.393]
+Wallimann, Hans, Beamter d. S. B. B., Bernastrasse 59 [24.393]
 Walliser, Helene L. Elisabeth, Bureaulistin, Mühlemattstrasse 18
 – Helene, Frau, Schneiderin, Mühlemattstr. 18
 – Hermann, Architekturbureau, Monbijou- jstrasse 101 [34.283]
@@ -49488,7 +49391,7 @@ Wabern [22.078]), Schauplatzgasse 39 [22.851]
 – Friedr., Magaziner, Bethlehemstrasse 117, Bümpliz
 – Hedwig A., Frau, Fischerweg 19 [21.022]
 – Hedwig, Bastelschule, Nägeligasse 6 1
-– J. H.. Prokurist, Stadtbachstr. 38 [32.392]
+– J. H., Prokurist, Stadtbachstr. 38 [32.392]
 – Mathis, Postbeamter, Hopfenweg 54
 – Max, Zahnarzt, Dr. med. dent., Junkerng. 15
 – Olga, Bureaugehilfin der O. T. D., Fellenbergstrasse 19
@@ -49580,9 +49483,9 @@ Walther u. Walter, s. auch Wälder
 – Gertrud, Ladentochter, Brünigweg 17
 – Gertrud W., Wwe., Verkäuferin, Rodtmattstrasse 60
 – Gottfr., pens. Lehrer, Florastr. 15 [28.376]
-– Gottfr., Maurermeister. Lorrainestrasse 67
+– Gottfr., Maurermeister, Lorrainestrasse 67
 – Gottfr., Vorarbeiter, Metzgergasse 56
-– Gottl., Postangestellter. Aegertenstrasse 54
+– Gottl., Postangestellter, Aegertenstrasse 54
 – Hanny Mina, Grabenpromenade 9
 – Hans V., kant. Bücherexperte, Hallwylstrasse 24
 – Hans, Brass. Lorraine, Quartiergasse 17 [22.266]
@@ -49625,7 +49528,7 @@ Walther u. Walter, s. auch Wälder
 – Luise (Althaus), Wwe., Wildhainweg 19a
 – M. M. Th., Heizungstechniker, Sulgenbachstrasse 14
 – Marg. Anna, Bankangest., Bubenbergstr. 3
-– Marg.. kant. Beamtin, Wiesenstrasse 71
+– Marg., kant. Beamtin, Wiesenstrasse 71
 – Margr. Rosalie, Ladentochter, Aegertenstrasse 54
 – Margr., Wirtin, Seftigenstrasse 99
 – Maria Anna, Zähringerstrasse 69
@@ -49642,9 +49545,9 @@ Walther u. Walter, s. auch Wälder
 – Nelly, Hilfsarbeiterin, Bühlstrasse 27
 – Oskar, Bautechniker, Lorrainestrasse 13
 – Oskar Alb., Dr., Verwaltungs- und Treuhandbureau, Tillierstrasse 15 [31.817]
-– Otto, Arcü.. Chef d. techn. Dienstes d. eidg.
+– Otto, Arcü., Chef d. techn. Dienstes d. eidg.
 Baudirektion. Bantigerstrasse 4 [27.778]
-– Otto, Gasarbeiter. Schöneggweg 25
+– Otto, Gasarbeiter, Schöneggweg 25
 – Otto, Schleifer, Seheibenstrasse 33
 – Otto, Schuhmacher, Neubrückstrasse 82
 – Paul, Angestellter, Tscharnerstrasse 48
@@ -49654,7 +49557,7 @@ Baudirektion. Bantigerstrasse 4 [27.778]
 – Rene Henri, Mechaniker Militärstrasse 59
 – Robert, Velohändler, Bümplizstrasse 115, Filiale Effingerstr. 41 [26.242] [46.136]
 – Roger, Postangest., Bottigenstr. 57, Bümpliz
-– Rosa, Beamtin 0 P. D.. Wildhainweg 19a
+– Rosa, Beamtin 0 P. D., Wildhainweg 19a
 – Rosa Klara (Wenger). Lingerie. Aegertenstrasse 54 [22.039]
 – Rosa (Bücher), Wwe., Dählhölzliweg 12 [29.042]
 – Rud., Buchhalter, Spitalackerstr. 9 [20.197]
@@ -49696,11 +49599,11 @@ Wälti, s. auch Walti u. Welti
 – Eduard G. (Henriod), pens. intern Beamter, , Alpenstrasse 19a [20.575]
 – Elisab. M. K., Bureaul., Schillingstr. 28
 – Elisabeth, Lehrerin, Länggassstrasse 70c
-– Emil Arthur, Bahnarbeiter. Aehrenweg 41, Bümpliz
+– Emil Arthur, Bahnarbeiter, Aehrenweg 41, Bümpliz
 – Emil, Handlanger, Läuferplatz 6
 – Emil, Notar, im Notariatsbureau Paul Hofer (Engeriedweg 7 [27.776]), Zeughausgasse 27 [27.811]
 – Emil Georg, Dachdeckermeister, Gütenbergstrasse 13
-– Emil, Schlosser, Flurstrasse la
+– Emil, Schlosser, Flurstrasse 1a
 – Emma (Rüfenacht), Fellenbergstrasse 18
 – Emma, Verkäuferin, Schwalbenweg 8
 – Ernst (Gratz), eidg. Beamter, Greyerzstrasse 42
@@ -49726,7 +49629,7 @@ Wälti, s. auch Walti u. Welti
 – Franz. Handlanger, Reitschulweg 3
 – Friedr. Alb., Ausläufer, Schwalbenweg 8
 – Friedr., Bahnarbeiter, Schlossstrasse 121
-– Friedr . Handlanger Aarüergergaose 2U
+– Friedr., Handlanger Aarüergergaose 2U
 – Friedr., Magaziner, Schlossstrasse 121
 – Friedr., Mechaniker, Mihtärstrasse 45
 – Friedr., Metzger Tillierstrasse 18
@@ -49737,17 +49640,17 @@ Wälti, s. auch Walti u. Welti
 – Fritz Franz, kaufm. Angest., Stalden 8
 – Fritz, Versicherungsvertreter, Werkgasse 9, Bümpliz
 – Fritz, Papet., Breitenrainplatz 35 [32.237]
-– Gottfr.. Chauffeur, Weissensteinstrasse 1
+– Gottfr., Chauffeur, Weissensteinstrasse 1
 – Gottfr., Handlanger, Freiburgstrasse 70
 – Hanna Marie, Arbeitslehrerin, Brünnenstrasse 106, Bümpliz
 – Hs. Ernst, Bahnarbeiter, Raineggweg 3
 – Hans Werner, Drogist, Spitaiackerstr. 25
-– Hans. Gerichtssekr.. Bernstr. 98, Bümpliz
+– Hans. Gerichtssekr., Bernstr. 98, Bümpliz
 – Hans, Elektromefchaniker, Sulgeneckstr. 60
 – Hans, Hilfsarbeiter, Wiesenstrasse 75
 – Hans, Hilfsarbeiter, Muristrasse 73
 – Hans. Hilfsarbeiter, Werkg. 9. Bümpliz
-– Hans. Hilfsarbeiter. Wylerringstrasse 58
+– Hans. Hilfsarbeiter, Wylerringstrasse 58
 – Hans, Installateur. Meisenweg 15
 – Hans, Führergehilfe S. B. B., Gruberstr. 8
 – Hans Fritz, Maschinenmeister, Meisenweg 15
@@ -49763,9 +49666,9 @@ Wälti, s. auch Walti u. Welti
 – Joh., Bedienter, Gruberstrasse 8
 – Joh. Alft elektr. Anlagen, Bümplizstr. 153 [46.216]
 – Joh. Friedr., Kaufmann, Holligenstr. 15 [27.618]
-– Johanna, Bureaulistin, Blumenweg la
+– Johanna, Bureaulistin, Blumenweg 1a
 – Johanna Magdalena, Bureaulistin, Lentulusstrasse 57
-– Klara Margr., Damenschneiderin, Blumenweg la
+– Klara Margr., Damenschneiderin, Blumenweg 1a
 – Lina (v Gunten), Wwe., Cafe Bollwerk, Bollwerk 23 [23.371]
 – Ludwig, pens. Bauamtarbeiter, Waffenw. 6
 – Margaretha, Bureaulistin, Bernstrasse 98, Bümpliz
@@ -49790,9 +49693,9 @@ Wälti, s. auch Walti und Welti
 – Rob., Schreiner, Rütlistrasse 16
 – Rosa, Falzerin, Sonneggring 14
 – Rosa Margr., Bureaulistin, Effingerstr. 59
-– Rosa, Ladentochter, Blumenweg la
+– Rosa, Ladentochter, Blumenweg 1a
 – Rosa, Fabrikarbeit., Werkgasse 9, Bümpliz
-– Rosa K., Telephonistin, Blumenweg la
+– Rosa K., Telephonistin, Blumenweg 1a
 – Rosa L. (Finger), Elisabethenstrasse 46
 – Rud., Sohn, Viehhändler, Neubrückstr. 59 [22.838]
 – S. (Ulrich), Wwe., Neubrückstr. 73 [23.875]
@@ -49802,7 +49705,7 @@ Wälti, s. auch Walti und Welti
 – -Werner, Ausläufer, Scheibenstrasse 31
 – Werner, Mechaniker, Bernstr 38, Bümpliz
 – Werner, Optiker, Elisabethenstrasse 46
-– Wilhelm, Monteur, Blumenweg la
+– Wilhelm, Monteur, Blumenweg 1a
 Wallisbühl & Co., Anton, Zürich, Filiale Bern, Generalvertretung der Remington-Schreibmaschine und Bureaumöbelfabrik, Kornhausplatz 14 [24.544]
 Walz, Albert (Tress), Spengler), Weberstrasse 11
 – Fritz Andr., Koch, Heckenweg 1 [45.656]
@@ -49839,13 +49742,13 @@ Wanner, Alb. Heinr. Rieh., Werkmeister, Bantigerstrasse 33
 – Gottfr., Hilfskondukteur, Blumenbergstr. 53
 — Harald Fr., Dr. jur., Opernsänger, Viktoriastrasse 67
 – Herm. Alfr., Bahnarbeiter, Scheibenstr. 54
-– Herm. Wilh. Rud.. Kaufmann, Jubiläumsstrasse 33 [34.689]
+– Herm. Wilh. Rud., Kaufmann, Jubiläumsstrasse 33 [34.689]
 – Hermann P. W., Kaufmann, Jubiläumsstrasse 89 [36.473]
 – Joh. Bend., pens Angest., Marzilistr. 2
 – Lina, Weissnäherin-Atelier, Stauffacherstrasse 1
 – Luise Bertha (Hänni), Wwe., Badgasse 25
 – Martin, Entkalken von Heizkesseln. Warmwasserleit. etc., Seftigenstrasse 57 [27.570]
-– Rob. Eman.. Hilfsarbeiter, Standstr. 48
+– Rob. Eman., Hilfsarbeiter, Standstr. 48
 – Walter, Metzger, Standstrasse 11
 Wänny, Otto (Keller), Kaufm., Laupenstr. 3
 Wanzenried, Alb., Bäcker, Seidenweg 10
@@ -49874,7 +49777,7 @@ v. Wartburg, Adolf, Hilfsarbeiter, Altenbergstrasse 82
 – Joh. Ad., Maurer, Haldenweg 18
 – Lina, Frau, Damensalon (Sodweg 3), Länggassstrasse 10 [28.947]
 – O., gew. Generalagent, Optingenstrasse 8 [33.269]
-– Paul, Hilfsarbeiter,. Elisabethenstrasse 35 .
+– Paul, Hilfsarbeiter,. Elisabethenstrasse 35
 – Walter, Elektromonteur, Em.-Friedlistr. 14 [23.309]
 – Werner (Ruegger), Muldenstr. 25 [28.738]
 – Werner, Generalagent der «Winterthur» Lebensversich.-Gesellschaft (Optingenstr. 8 [36.065]), Münzgraben 2 [27.025]
@@ -49887,20 +49790,20 @@ Wartmann, Alfr. Max W., Schlosser, Reichenbachstrasse 3
 – Ernst Otto, Fürspr. (Schwarztorstrasse 23b [25.327]), Hirschengraben 5 [20.321]
 Wasem, Ad. Ls., Architekt. Florastrasse 19 [26.165]
 – Anna (Schlegel), Wwe., Muldenstrasse 44
-– Fr.. Beamter S. B. B., Bühlplatz 1
+– Fr., Beamter S. B. B., Bühlplatz 1
 – Gottfr., Kupferschmied, Landoltstrasse 69
 – Gottfr., Mechaniker-Chauffeur, Badgasse 47
-– Gottl.. Monteur. Elisabethenstrasse 55
+– Gottl., Monteur. Elisabethenstrasse 55
 – Joh. Ad., Chauffeur, Balmweg 33
-– Joh., pens. Gasarbeiter. Bremgartenstr. 65
+– Joh., pens. Gasarbeiter, Bremgartenstr. 65
 – Johanna, Packerin, Schönauweg 6
 – Karl, Lagerist, Länggassstrasse 30
 – Rosa Margr., Ladentochter, Länggassstr. 30
 – Walter Joh., Schriftsetzer, Länggassstr. 34
 – Werner Ad., Sek.-Lehrer. Kursaalstr. 10 [22.653]
-Waser, Ad.. Buchbinder, Waffenweg 20
+Waser, Ad., Buchbinder, Waffenweg 20
 – Alice Irma, Bureaulistin, Aebistrasse 11
-– Ed., Beamter S. B. B.. Aebistrasse 11
+– Ed., Beamter S. B. B., Aebistrasse 11
 – Fritz, Vertreter, Gutenbergstrasse 10 [27.954]
 – Gebr., Glasaffichen, Lichtreklame, Sodweg 10 [23.685]
 – Gertrud, Schneiderin, Karl-Schenkstr. 7
@@ -49932,9 +49835,9 @@ Wasserfallen, Albert, Handlanger, Schöneggweg 14
 – Bertha (Jenni), Alleeweg 28
 – Ernst Friedr., Mattenhofstrasse 31
 – Ernst, kaufm. Angest., Holligenstrasse 45
-– Eug.. in Fa. Alfr. Schweighauser & Co., Weissenbühlweg 29c [27.926]
+– Eug., in Fa. Alfr. Schweighauser & Co., Weissenbühlweg 29c [27.926]
 – Friedr., Angestellter, Turnweg 39
-– Friedr.. Friedhofarbeiter, Wylerringstr. 52a
+– Friedr., Friedhofarbeiter, Wylerringstr. 52a
 – Fritz, Chauffeur, Zeigerweg 1
 – Herm., Pferdewärter, Meisenweg 29
 – Joh. Ernst, Handlanger. Schifflaube 34
@@ -49971,7 +49874,8 @@ Wassmer und Wasmer
 Watch Tower Bible & Tract Society New
 York, Zweigniederlassung Bern. Buchdr. u. Verlagsanstalt, Allmendstrasse 39 [24.934]
 Waltelet, Fr. (Bärtschi), Hopfenw. 11 [33.210]
-Wattenhofer, Friedrich (Jeker), Concierge, Karl-Staufferstrasse 14v. Wattenwyl, Andree. Rainmattstrasse 13
+Wattenhofer, Friedrich (Jeker), Concierge, Karl-Staufferstrasse 14
+v. Wattenwyl, Andree. Rainmattstrasse 13
 – Agnes Estelle (Ausley), Wwe., Herreng. 23 [24.668]
 – Bernhard (v. Wyttenbach), Sachwalter, Egelgasse 55 [31.3171
 – Blanche, Frl., Ensingerstrasse 21 [22.753]
@@ -49989,7 +49893,7 @@ Wattenhofer, Friedrich (Jeker), Concierge, Karl-Staufferstrasse 14v. Wattenwyl, 
 v. Wattenwyl, M., & Co. 📞 28.611 Liegenschaftsagentur (An- und Verkauf) und Verwaltungsbureau, Theaterplatz 2
 – Nikl. Phil. Hans, Kirchenfeldstrasse 84
 – R. (Perrot), Wwe., Rainmattstrasse 13 [21.031]
-.— Rosa Alice Antoinette, Hallerstrasse 51
+— Rosa Alice Antoinette, Hallerstrasse 51
 – Rud., Fürspi (Kräyigen, Muri [42.349]), Marktgasse 52 [21.237]
 – Sigismund D. E., Ingenieur, Thunstr. 55
 – Th. Eugenie, Frl., Schwarztorstrasse 71
@@ -50024,11 +49928,11 @@ Weber, s. auch Wäber
 – Alfr., Chauffeur, Neufeldstr. 124 [27.434]
 – Alfred G., kaufm. Angest., Bubenbergpl. 4
 – Alfr. (Gerber), Koch, Kramgasse 84
-– Alfr.. Schlosser. Wiesenstrasse 20
+– Alfr., Schlosser. Wiesenstrasse 20
 – Alfr. Th., Schriftsetzer, Altenbergstr. 35
 – Alfr., Sekretär O. P. D., Blumensteinstr. 17
 – Alfr., Techniker b. eidg. Amt für Wasserwirtschaft, Reichenbachstrasse 6b
-– Alfr.. Tramangestellter Alleeweg 9
+– Alfr., Tramangestellter Alleeweg 9
 – Alice, Telephonistin, Wittigkofenweg 1
 – Alois, Direktor, Bovetstrasse 11 [34.762]
 – Alois E., Schreiner, Brunngasse 48
@@ -50093,7 +49997,7 @@ Weber, b. auch Wäber
 – Frieda Margr. (Tschanen), Wwe., Sandrainstrasse 76
 – Friedr., Dreher. Wylerringstrasse 72
 – Friedr., Handlanger, Bottigenstrasse 31, Bümpliz
-– Friedr. Hilfsarbeiter. Kramgasse 61
+– Friedr. Hilfsarbeiter, Kramgasse 61
 – Friedr., Milchhändler, Freiburgstrasse 511, Bümpliz [46.609]
 – Friedr., Polizeikorporal, Keltenstrasse 106, Bümpliz
 – Friedr. Hans, Postangest., Gesellschaftsstrasse 84
@@ -50166,7 +50070,7 @@ Weber, s. auch Wäber
 – Joh., pens. Zuschneider im eidg. Bekleidungsmagazin, Mezenerweg 2
 – Johanna, Ladentochter, Wittigkofenweg t
 – Jost Rud., Kaufmann, Stauffacherstr. 2
-– K., pens. Mech. d. T.-W.. Lilienweg 16
+– K., pens. Mech. d. T.-W., Lilienweg 16
 – Karl Emil, Dr. jur., Beamter beim Rechtsbureau der S. B. B., Erlachstrasse 24 [36.684]
 – Karl, Beamter S B. B., Fischerweg 17
 – Karl, Büchsenmacher, Seftigenstrasse 66
@@ -50258,7 +50162,7 @@ Weg mann, Dora Ruth, Bureaulistin, Sulgenauweg 22
 – Elsa (Weidmann), Wwe., Sulgenauweg 22 [21.563]
 – Elvira E., Ladentochter, Sulgenauweg 22
 – Hedwig, Weissnäherin, Wylerstrasse 28
-– Heinr.. Techniker, Fischermätteliweg 23
+– Heinr., Techniker, Fischermätteliweg 23
 – Karl Heinrich, pens. Pfarrer, Wylerstr. 28
 – Karl Emil, Typograph, Waldheimstrasse 46
 – Sophie, Krankenpflegerin, Hopfenweg 37
@@ -50276,14 +50180,14 @@ Wegmüller, Ad., Zinkograph, Seilerstrasse 23
 – Christ., Schneidermeister, Metzgergasse 27
 – Elise, Näherin, Seidenweg 29
 – Emma, Bureauangest., Viktoriastrasse 51
-– Ernst Erw., Bureauangest.. Druckereiw. 5
+– Ernst Erw., Bureauangest., Druckereiw. 5
 – Ernst Willy. Buchbinder. Elisabethenstr. 15
 – Ernst, Chemiker, Kirchbergerstrasse 30
 – Ernst, Gipser, Wildermettweg 41
 – Ernst, Käskübler. Lagerhausw. 3, Bümpliz
 – Ernst Jakob, Hilfsmonteur, Brunngasse 8
 – Frieda, Viktoriastrasse 51
-– Friedr., Hilfsarbeiter. Wylerfeldstrasse 6
+– Friedr., Hilfsarbeiter, Wylerfeldstrasse 6
 – Friedr., Parketteur, Vertreter d. Parkettfabrik Schleitheim, Marzilistr. 8 [20.876]
 – Friedr., Wäscher, Gesellschaftsstrasse 72
 – Friedr. (Burni), Kanzlist, Gesellschaftsstrasse 31
@@ -50299,7 +50203,7 @@ Wegmüller, Ad., Zinkograph, Seilerstrasse 23
 Wegmüller, Hans, Hilfsarbeiter, Altenbergstrasse 36
 – Hans Ernst, Maurer, Bridelstrasse 2
 – Hedwig Ida, Damenschneiderin, Marktg. 17 [31.982]
-– Hermann Rob., eidg. Angestellter. Kirchbergerstrasse 41
+– Hermann Rob., eidg. Angestellter, Kirchbergerstrasse 41
 – Ida Klara, Bureaulistin, Genfergasse 10
 – Ida (Gfeller), Wwe., Einlegerin, Schützenweg 10
 – Ida Alb. (Räuber), Wwe., Genfergasse 10
@@ -50308,7 +50212,7 @@ Wegmüller, Hans, Hilfsarbeiter, Altenbergstrasse 36
 – Joh. Emil. Handlanger. Standstrasse 72
 – Joh., Verwaltungsgehilfe O. Z. D., Aarbergergasse 11
 – Joh., Metzger, Storchengässchen 5
-– Joh., Zugführer S. B. B.. Steinauweg 16
+– Joh., Zugführer S. B. B., Steinauweg 16
 – Johanna Gertr., Telegr., Greyerzstrasse 48
 – K., Schuhmacher, Steinhölzliweg 41
 – Lina, Amthausgasse 6 [29.510]
@@ -50335,7 +50239,7 @@ Wehn, Arn., Kaufm., Kramgasse 68 [27.838]
 – Henri (Wüthrich), Tiefbautechniker, Stokkerenweg 41
 – Lina (Reuning), Wwe., Jägerweg 13
 Wehner, E. R., Schreiner, Brunnmattstr. 38
-– Elsa Paul.. Bureaulistin, Eggimannstr. 25
+– Elsa Paul., Bureaulistin, Eggimannstr. 25
 – Ernst, Maler, Eggimannstr. 25 [21.877]
 – Ernst Herm., Zeichner, Eggimannstr. 25
 – Herm., Prov.-Reisender, Marktgasse 13
@@ -50374,7 +50278,7 @@ Cie., Schönauweg 12
 – Rudolf Oskar, in Fa. O. Wehrlin & Cie., Schönauweg 12
 – Wilhelm Max, Zeichner, Schönau weg 12
 – & Cie., O., Buch- u. Steindruck, Monbijoustrasse 12 [34.638]
-Wehrmüller, Gottfr. Peter. Führer S. B. B., Burgunderstrasse 136, Bümpliz
+Wehrmüller, Gottfr. Peter, Führer S. B. B., Burgunderstrasse 136, Bümpliz
 Weibel, s. auch Waibel
 – Alb., kaufm Angestellter, Lentulusstr. 41
 – Alb., Angestellter, Fährweg 37
@@ -50460,9 +50364,7 @@ Weibel, s. auch Waibel
 – -Werner, eidgen. Beamter, Bernstrasse 13, Bümpliz
 – Werner, Chauffeur Brückenstrasse 10
 – Xaver, Lok -Führer, Aebistrasse 2
-– Gebr. (Alfred u. Robert), Import industr.
-Oele, Fabrikat, v. Druckknöpfen u. techn.
-Artikel, ßeundenfeldstrasse 43
+– Gebr. (Alfred u. Robert), Import industr. Oele, Fabrikat, v. Druckknöpfen u. techn. Artikel, ßeundenfeldstrasse 43
 Weideli, Gottfr., Vorarbeiter, Rosenweg 9
 – Joh. R., sen., Schneider, Engehaldenstr. 204
 – Karl, Buchhalter, Gutenbergstrasse 9
@@ -50480,7 +50382,7 @@ Weidmann, Alfr., Dekorateur, Flurstrasse 33
 – Heinr., Schreiner, Burgunderstrasse 132, Bümpliz
 – Herbert, kaufm. Angest., Kollerweg 7
 – Herm. (Wipf), Expertisen, Viktoriastr. 86 [34.885]
-– Herm., jun.. Angestellter, Viktoriastr. 86
+– Herm., jun., Angestellter, Viktoriastr. 86
 – Rudolf, Zollbeamter, Schillingstrasse 19
 – Ulr. Rud., Dr., Chemiker, Chutzenstr. 49 [34.678]
 Weigel, Margrit (Grimm), Wwe., Klavierlehrerin, Maulbeerstrasse 14
@@ -50572,7 +50474,7 @@ Weiss, s. auch Wyss
 – J. J. (Sterchi), Vertreter d. Magazine zum
 Wilden Mann, Basel, Viktoriastrasse 63 [22.475]
 – Jb., Spengler, Gutenbergstrasse 23
-– Jean Jacq.. Heilsarmeeoffizier, Muristr. 6
+– Jean Jacq., Heilsarmeeoffizier, Muristr. 6
 – Joh. Gottl., Koch. Bollwerk 23
 – Jos., Dr. rer. pol., Länggassstrasse 21a
 – Karl, Maler, Mindstrasse 4
@@ -50614,8 +50516,9 @@ Weisskopf, Ad., Steinschleifer, Hopfenweg 29
 – Paul, Maurer, Zentralweg 29
 Weissmüller, El. (Rufener), Frau, Monbijoustrasse 27
 – Friedr., Schreiner, Gerechtigkeitsgasse 75
-– Martha, Pflegerin, Aarbergergasse 17v. Weizsäcker, Ernst. Baron, deutscher Gesandter, Brunnadernrain 31 [31.762]
-Wellauer, Alb., eidg. Beamter. Kreuzgasse 3
+– Martha, Pflegerin, Aarbergergasse 17
+v. Weizsäcker, Ernst. Baron, deutscher Gesandter, Brunnadernrain 31 [31.762]
+Wellauer, Alb., eidg. Beamter, Kreuzgasse 3
 – Emilie Paul., Bureaulistin. Freie Strasse 30
 – W., Beamter S. B. B., Freiestrasse 30 [21.927]
 Wellenbad 📞 20.175 u. Kunsteisbahn Dählhöizli - Bern A.-G., Jubiläumsstrasse 95, Sommersaison Mai—September, Wintersaison November—März
@@ -50673,13 +50576,12 @@ S. B. B., Junkerngasse 53 [23.364]
 – Arthur Alb., Dr., eidg. Beamter, Engeriedweg 11
 – Arthur A., Hauswart, Monbijoustrasse 87
 – Arthur, Polizeigefreiter, Martiweg 23
-– Aug.. Schlosser, Rodtmattstrasse 49
+– Aug., Schlosser, Rodtmattstrasse 49
 – Bend., pens. Streckenwärter, Bernstr. 18, Bümpliz
 – Bertha (Hauser), Schneiderin, Quartierhof 2
 – Bertha, Weissnäherin, Neuengasse 1
 – Ch. Jca. El., Schneider, Hallerstrasse 30
 – Christ., pens. Kantonspolizeiwachtmeister, Seidenweg 36
-Der zuverlässige Fahrplanfür Bern, in die nähere und weitere Umgebung istder Touristen - Fahrplan ( Verlag Hallwag, Bern;, der Ihnen auch interessante Aufschlüsse über genussreiche Touren gibt. . .
 # Date: 1935-12-15 Page: 26020846/537
 Wenger, Ghr., gew. Zimmermann, Hopfenw. 29
 – Christ., Chauffeur, Morgenstr. 10, Bümpliz
@@ -50701,12 +50603,12 @@ Wenger, Ghr., gew. Zimmermann, Hopfenw. 29
 – Emil Ad., Krankenwärter, Freiburgstr. 18
 – Emil, Polizeikorporal, Martiweg 23
 – Emil Hermann, Schneider, Wylerstrasse 69
-– Emma (Liechti), Konfiserie, .Bahnhofpl. 5 [23.325]
+– Emma (Liechti), Konfiserie, Bahnhofpl. 5 [23.325]
 – E. Emil, Reisender, Neuengasse 2 [27.207]
-– Ernst E.. Ausläufer, Marzilistrasse 30
+– Ernst E., Ausläufer, Marzilistrasse 30
 – Ernst, kant. Angest., Karl-Staufferstr. 10
 – Ernst, Chauffeur, Nordweg 12
-– Ernst (Reusser), Dr. med. vet.. I. Pferdearzt, Ahtlg. für Veterinärwesen, Effingerstr. 41d [28.982]
+– Ernst (Reusser), Dr. med. vet., I. Pferdearzt, Ahtlg. für Veterinärwesen, Effingerstr. 41d [28.982]
 – Ernst, Chauff., Fröschmattweg 22, Bümpliz
 – Ernst Alb., Evangelist, Rosshäusernstr. 30, Riedbach
 – Ernst, Dachdeckermeister, Bottigenstr. 352, Oberbottigen
@@ -50754,7 +50656,7 @@ Wenger, Frieda (Uehlinger), Wwe., Tscharnerstrasse 19
 – Fritz, Schlosser, Bernstrasse 18, Bümpliz
 – Fritz (Luder), Wärter, Schermenweg 10a
 – Gertrud, Bureaulistin, Lentulusstrasse 51
-. — Gertrud, Einlegerin, Dammweg 41
+— Gertrud, Einlegerin, Dammweg 41
 – Gertrud Elsa, Ladentochter, Gerechtigkeitsgasse 36
 – Gottfr. Ed., eidg. Beamter, Gesellschaftsstrasse 70
 – Gottfr., Hilfsarbeiter, Murtenstrasse 26
@@ -50814,7 +50716,7 @@ Wenger, Hans, Notar, Adj. d. Betreihungs- u. Konkursamtes Bern-Stadt, Altenbergs
 – Klara, Damenschneiderin, Rodtmattstr. 65
 – Klepha (Hirt), Wwe., Lentulusstrasse 51
 – Lina, Damenschneiderin, Bümplizstr. 44
-– Margr. Gertrud. Ladentochter. Eigerplatz 8
+– Margr. Gertrud. Ladentochter, Eigerplatz 8
 – Marg. B., Ladentochter, Lentulusrain 24
 – Marg. Rosa, Ladentochter, Muesmattstr. 44
 – Marg., Schneiderin, Wagnerstrasse 11
@@ -50873,7 +50775,7 @@ Wenger, O. (Behle), Einzieher b. städt. Gaswerk, Schulweg 5
 – Walter Herbert, Maler, Brunnhofweg 32
 – Walter, Pferdewärter, Scheibenstrasse 31
 – Werner, Bureaulist, Speichergasse 33
-– Werner Herm., Ghemigr.. Bümplizstr. 77
+– Werner Herm., Ghemigr., Bümplizstr. 77
 – Werner, Magaziner, Quartiergasse 13
 – Werner, Mechaniker, Militärstrasse 34 j
 – Willy Charles, Konditor, Eigerplatz 8
@@ -50898,7 +50800,7 @@ Wasserwirtschaft, Gryphenhihbeliweg 45
 Werbestudio 3, Spitalgasse 34 [24.448]
 Werchmann, Ad., pens. Monteur, Wiesenstrasse 22
 – Fritz, Packer O. T. D., Rodtmattstrasse 56
-Werder, Alb.. Revisor d. kant. Steuerverwaltung, Schönbergrain 2
+Werder, Alb., Revisor d. kant. Steuerverwaltung, Schönbergrain 2
 – Am., Buchdrucker, in Fa. Bühler & Werder, Ensingerstrasse 26 [33.848]
 – J., Dr., Prof., Chef der Laboratorien deseidg. Gesundheitsamtes, Humboldtstr. 41 [35.827]
 – J., Buchdruckerei (Hallerstr. 50 [29.522]), Neuengasse 9 [23.379]
@@ -50933,7 +50835,7 @@ Wermuth, Alfred (Trachsel), Hilfsarbeiter, Federweg 49
 — Ernst, Schuhmacher, Lorrainestrasse 68
 – Frieda, Wäscherin, Wylerfeldstrasse 63
 — Frieda Hel., Kassiererin, Speichergasse 11
-— Friedr.. Bauamtarbeiter, Bümplizstr. 173
+— Friedr., Bauamtarbeiter, Bümplizstr. 173
 – Fritz, Magaziner, Cäcilienstrasse 28
 – Gottl., Sattler, Elisabethenstrasse 57
 Wermuth, Heinr. Ad., Coiffeur, Dübystr. 41
@@ -50941,13 +50843,13 @@ Wermuth, Heinr. Ad., Coiffeur, Dübystr. 41
 – Herm. Friedr., Postangest., Murifeldweg 23
 – Jul. Ernst. Linotypesetzer. Birkenweg 34
 – Julie Adelheid, Lingere, Stauffacherstr. 39
-– Klara, Wicklerin, .Monbijoustrasse 95
+– Klara, Wicklerin, Monbijoustrasse 95
 – Martha, Ladentochter, Laupenstrasse 27
 – Martha (Lanz), Spezereihdlg., Mattenhofstrasse 36 [32.383]
 – Otto (Wieland), Bankangest., Jubiläumsstrasse 25 [32.439]
 – Otto Heinr., Glaser. Pestalozzistrasse 28
 – Otto Hans, Magaziner. Seftigenstrasse 28
-– Paul (Brand), Beamter. Jubiläumsstr. 56
+– Paul (Brand), Beamter, Jubiläumsstr. 56
 – Rud. Rob., Bankkassier, Nordweg 4 [22.339]
 – Walter, Hilfsarbeiter, Monbijoustrasse 68
 Wern, Agnes (Trachsel), Gesellschaftsstr. 18
@@ -50978,7 +50880,7 @@ Wernly, Julia, Dr. pbil., Florastrasse 3
 Werren, s. auch Wehren
 – Alfr., Lok.-Führer S B. B., Seidenweg 66
 – David Alfr. (Marti), Schriftenmaler, Gerechtigkeitsgasse 27
-– Friedr., Lok.-Führer S. B. B.. Aebistr. 10
+– Friedr., Lok.-Führer S. B. B., Aebistr. 10
 – Fritz, Schneidermeister, Bottigenstrasse 49, Bümpliz
 – Hans A. (Spahr), Milch-, Butter- u. Käsehandlung, Gerechtigkeitsgasse 73 [33.880]
 – Jak., Handlanger, Gerechtigkeitsgasse 61
@@ -51011,7 +50913,7 @@ Werthmüller, A., Telegr.-Beamter, Konsumstrasse 10
 – Hans, Schreinermeister, Greyerzstr. 48
 – Herm., Typograph, Viktoriarain 8
 – Karl, Kaufmann, Mindstrasse 10
-– O. B. (Maurer), Wwe.. Depotstrasse 44
+– O. B. (Maurer), Wwe., Depotstrasse 44
 – Paul E., Techniker O. P. D., Thunstr. 49
 – Penelope, Bureaulistin, Thunstrasse 49
 – Rosa (Sterchi), Wwe. Steckweg 13
@@ -51102,7 +51004,7 @@ Weyermann, Bernh., gew. Apotheker, Bubenbergplatz 4
 – Rudolf, pens. Gasarbeiter, Murifeldweg 22
 – Walter Erw., Bautechniker, Landoltstr. 48
 – Walter, Dr. jur., Fürsprecher, Schiferliweg 12 [36.777]
-– Walter. Heizungstechniker, Flurstrasse 1
+– Walter, Heizungstechniker, Flurstrasse 1
 – Walter Fritz, Mechaniker, Rütlistrasse 12
 – Werner, Dachdecker, Bottigenstrasse 72, Bümpliz
 – Willy, Monteur, Bühlstrasse 49
@@ -51178,10 +51080,10 @@ Widmer und Wiedmer, s. auch Witmer, Wittmer und Wittwer
 – Ernst. Giesser, Murtenstrasse 155q
 — Ernst, Gasarbeiter, Murifeldweg 19
 – Ernst, Instruktor, Emanuel-Friedlistr. 27 [24.054]
-– Ernst (Steinemann), Postbeamter. Militärstrasse 40
+– Ernst (Steinemann), Postbeamter, Militärstrasse 40
 – Ernst (Jakob), Telephonmonteur, Lorrainestrasse 68
 – Ernst, Versicherungsbeamter, Klaraweg 5
-– Erwin, Güterarbeiter d. S. ß. B.. Freiburgstrasse 143a
+– Erwin, Güterarbeiter d. S. ß. B., Freiburgstrasse 143a
 – Eugen, Buchbinder, Wvttenhachstrasse 37
 – F., Lederzuschneider, Fischerweg 6
 – Ferd. (Clivio), Negt., Buchdruckerweg 8, Bümpliz
@@ -51189,11 +51091,11 @@ Widmer und Wiedmer, s. auch Witmer, Wittmer und Wittwer
 — Fr. (Fahrländer), Architekturbureau, vormals Widmer & Daxelhofer (Oranienburgstrasse 9 [29.071]), Neuengasse 30, Ryfflihof [23.020]
 — Fr., pens. Maschinist beim Stadtbauamt, Quartiergasse 25 [34.693]
 – Fr. Christ., Schuhmacher, Länggassstr. 95
-– Friedr., eidg. Beamter. Quartiergasse 25
+– Friedr., eidg. Beamter, Quartiergasse 25
 — Friedr., Faktor, Steinerstrasse 14 [31.007]
 – Friedr. Ernst, pens. Magazinchef, Sulgennfl rn cjt'pQ oop v
 – Friedr., Postbeamt., Greyerzstr. 76 [28.526]
-– Friedr.. Schlosser. Fröschmattweg 42, Bümpliz
+– Friedr., Schlosser. Fröschmattweg 42, Bümpliz
 – Friedr., Vertreter, Schwalbenweg 16
 – Fritz (Hönger), Zieglerstrasse 66
 – Fritz, Fuhrmann, Könizstrasse 9
@@ -51229,7 +51131,7 @@ Widmer u. Wiedmer, s. auch Witmer, Wittmer u. Wittwer
 – Hermann Fritz, Modellschreiner, Bottigenstrasse 31, Bümpliz
 – Hermann, Vertreter, Sickingerstrasse 5 [28.426]
 – Jakob, Automechaniker, Freiburgstr. 143a
-– Jak., Bahnarbeiter der S. B. B.. Freiburgstrasse 143a
+– Jak., Bahnarbeiter der S. B. B., Freiburgstrasse 143a
 – Jakob, Gärtner, Bottigenstr. 57, Bümpliz
 – Jakob. Lokomotivführer der S. B. B., Lerchenweg 27
 – Jakob. Magaziner, Wyttenbachstrasse 37
@@ -51292,7 +51194,7 @@ Widmer und Wiedmer, s. auch Witmer, Wittmer und Wittwer
 – Regina, Gesangspädagogin, Bühlstrasse 51 [23.393]
 – Rene M., Handlanger, Burgunderstr. 128, Bümpliz
 – Rob., Ausläufer, Aarbergergasse 3
-– Rob.. Kaufmann, Bierhübeliweg 29 [21.762]
+– Rob., Kaufmann, Bierhübeliweg 29 [21.762]
 – Robert, Malermeister (Monbijoustrasse 9 [34.992]), Bundesgasse 45
 – Roland Adr., kaufm. Angest., Buchdruckerweg 8, Bümpliz
 – Roland (Badertscher), Dienstchef b. Oberpostinspektorat. Hallerstrasse 37 [34.702]
@@ -51366,7 +51268,8 @@ Wild, Ad. H. H., Missionsarbeiter, Allmendstrasse 39
 – Marie Martha, Telegraphengehilfin, Mittelstrasse 6a
 – Martha, Haspelweg 40
 – Paul J. J., kaufm. Angest., Effingerstr. 25
-– Walter A. K., Instruktionsoffizier, Militärstrasse 28v. Wild, Annie C., Frl., Justingerweg 11 [31.845]
+– Walter A. K., Instruktionsoffizier, Militärstrasse 28
+v. Wild, Annie C., Frl., Justingerweg 11 [31.845]
 Wildberger, Heinrich, Geometer der Landestopographie, Schattenweg 7
 Wildbolz, A., Revisor d. O. Z. D., Bundesg. Iß
 – Ad. Arth., Arch., Nydecklaube 9 [35.921]
@@ -51422,7 +51325,7 @@ Wilhelm, Anna, Modistin, Mühlemattstr. 18
 – Othmar (Fasnacht), Prokurist, Ensingerstrasse 16a [35.959]
 – Rob., Auto-Elektriker, Spitalackerstr. 59
 Wilhelmi, Hermann Max, Kasinoverwalter, Haspelweg 46 [31.464]
-Wilk, M. (Alioth). Angestellter. Wagnerstr. 11
+Wilk, M. (Alioth). Angestellter, Wagnerstr. 11
 Wilka, Georg, Damen-Frisiersaion (Maulbeerstrasse 14), Bollwerk 35 [27.619]
 Will, Joh., Schneider, Gutenbergstrasse 5
 Willemin, Albert Ch., Mechaniker, Kyburgstrasse 5
@@ -51432,7 +51335,7 @@ Willen, Aug., Hauswart b. Dr. Wander A.-G., Holzikofenweg 36a
 – Fritz August, jun., Chauffeur, Weissenbühlweg 44
 – Ida Marg., Bureaulistin, Holzikofenw. 36a
 – Lina, Schneiderin, Holzikofenweg 36a
-Willenegger, Elise, Beamtin E. W. B., Belpstrasse 35 . [26.010]
+Willenegger, Elise, Beamtin E. W. B., Belpstrasse 35 [26.010]
 – Gottfr., Schreiner, Schönbergrain 2
 – Gottfr., Zahntechniker, Schönbergrain 2
 Willener, Alb. Jak., Postangest., Moserstr. 10
@@ -51582,14 +51485,14 @@ Wirth, Alfr., Bahnangestellter der S. Z. B., Thormannmätteliweg 29
 – Elisabeth, Schwarztorstrasse 30 [28.086]
 – Ernst, Rangierarbeiter S.B.B., Könizstr. 47
 – Felix Ad., Sattler, Gerechtigkeitsgasse 77
-– Friedr.. Bureaulist, Länggassstrasse 32a
+– Friedr., Bureaulist, Länggassstrasse 32a
 – Friedr. Alois, Generalagent der «Helvetia», Schweiz. Unfall- u. Haftpflicht-Vers-Anst., Wildermettweg 20 [36.909]
 – Friedr., Hilfsarbeiter, Kramgasse 50
 – Fr., pens. Zugführer, Burkhartweg 15, Bümpliz [46.503]
 Wirth, Hans, eidg. Beamter, Flurstrasse 8
 – Herm., kaufm. Angestellter, Lerberstr. 12
 – Herm., Sekretär d. Verbands Schweiz. Metallgiessereien, Ensingerstr. 42 [24.296]
-– Joh. Jos.. Monteur, Bahnhöheweg 102, Bümpliz
+– Joh. Jos., Monteur, Bahnhöheweg 102, Bümpliz
 – M., Schwarztorstrasse 30 [28.086]
 – Magdalena (Schudel), Wwe., Zieglerstr. 66
 – Margarethe Olive, Bureaulistin, Keltenstrasse 102, Bümpliz
@@ -51617,7 +51520,7 @@ Wirz, Ad., gew. Chef des Gütertarifbureausder S. B. B., Moserstrasse 23 [34.747
 – Edwin Werner, Beamter d. S. B. B., Freiburgstrasse 330, Bümpliz
 – Else, Bureaulistin, Waldhöheweg 27
 – Elsa, Sekretärin, Gesellschaftsstrasse 35
-– Emil. Tramangestellter. Bahnhöheweg 98, Bümpliz
+– Emil. Tramangestellter, Bahnhöheweg 98, Bümpliz
 – Emilie (Schürmann), Steinauweg 20 [31.831]
 – Ernst Fritz, Bankangest., Dalmazirain 34
 – Ernst (Berset), Postangest., Dalmazirain 34
@@ -51692,7 +51595,7 @@ Witschi, Adolf, Hilfsarbeiter, Bottigenstr. 226, Bümpliz
 – Bertha, Schneiderin, Beaumontweg 36
 – Elisabeth, Schwarzenburgstrasse 18
 – Elisabeth, Verkäuferin. Moritzweg 26
-– Emma, Ladentochter. Tillierstrasse 18
+– Emma, Ladentochter, Tillierstrasse 18
 – Ernst Ed., Angestellter V. B., Krippenstr.24
 – Ernst, Beamter S B. B., Berchtoidstr. 31
 – Ernst Hs., Heizungsmonteur, Burgernzielweg 6
@@ -51711,7 +51614,7 @@ Genf, Engestrasse 49 [29.405]
 – Friedr., Angestellter, Länggassstrasse 14
 – Friedr. Jak., Asphalter, Gewerbestrasse 20
 – Friedr., Ausläufer, Herrengasse 20
-– Friedr., Gasmeister, Hubelmattstrasse 44 .
+– Friedr., Gasmeister, Hubelmattstrasse 44
 – Friedr., Monteur, Scheibenstrasse 35
 – Fritz (Calame), Maler, Hochfeldstrasse 5
 – Fritz (Zimmermann), Sekretär d. S. B. B., Wabernstrasse 93 [20.853]
@@ -51746,7 +51649,7 @@ Witschi, Hans (Brönnimann), Hauptkassier der Hypothekarkasse des Kantons Bern, 
 – Karl, Melker, Uferweg 54
 – Karoline Adele, Privatpflegerin, Sennweg 3
 – Lina (Bläuenstein), Wwe., Bundesrain 16
-– Margr.. ßureaulistin, Moritzweg 26
+– Margr., ßureaulistin, Moritzweg 26
 – Margr., Ladentochter, Lentulusrain 5
 – Marie Lina, Filialleiterin. Lentulusrain 5
 – Marie, Kassierin, Belpstrasse 16
@@ -51836,7 +51739,7 @@ Wiltwer, s. auch Widmer, Witmer u. Wittmer
 – Hans, Pächter, Holligenstr. 87 [34.083]
 – Hans, Schreinerei u. Rep.-Werkstätte für
 Sportgeräte (Weihergasse 8), Gerberg. 16 [21.973]
-– Heinrich Viktor, Drogist, Burkhartweg 13, Bümpliz .
+– Heinrich Viktor, Drogist, Burkhartweg 13, Bümpliz
 – Hermann, Chemigraph, Morellweg 10
 – Hermine, Damenschneiderin, Schwarzenburgstrasse 77
 – Hugo E., Spengler, Sulgeneckstrasse 36
@@ -51872,14 +51775,14 @@ Sportgeräte (Weihergasse 8), Gerberg. 16 [21.973]
 – Rosina, Friedheimweg 17
 – Rosina, Kasernenstrasse 21a
 – Rud., Trambilletteur, Schwarzenburgstr. 77
-– Sam., Milch-, Butter- u. Weinhdlg.. Elisabethenstrasse 35 [31.017]
+– Sam., Milch-, Butter- u. Weinhdlg., Elisabethenstrasse 35 [31.017]
 – Samuel, Bauamtarbeiter, Könizstrasse 81
 Vladimir, Elektromech., Breitenrainstr. 31
 Walter Felix, Bahnarbeiter, Murtenstr. 85
 Wittwer, s. auch Widmer, Witmer u. Wittmer
 – Walter, Architekt S. J. A. (Junkemg.
 Marktgasse 46 [25.
-– Walter, Garagearbeiter. Lentulusrain 6
+– Walter, Garagearbeiter, Lentulusrain 6
 Witz, Otto (Russi), Fürspr., Oberrichter, Bühlstrasse 59 [22.694]
 – Hans, Bureaulist, Viktoriastrasse 41
 – Robert Jean (Matter), Beamter S. B. B., Neubrückstrasse 73
@@ -51897,7 +51800,7 @@ Wohlgemuth, Anna Ella, Blumenbergstr. 39
 – Ernst, Elektrotechniker, Blumenbergstr. 39 [25.002]
 – Lebrecht Emil, Mechaniker, Standstr. 31
 – Ulrich Christoph, Kunstmaler, Gerechtigkeitsgasse 45
-Wohlwend, Hans Jak., Bereiter. Kasernenstrasse 44
+Wohlwend, Hans Jak., Bereiter, Kasernenstrasse 44
 – Jakob W., Schriftsetzer, Kesslergasse 29
 Wohlwender, Max, Spengler, Jurastrasse 6
 Wohnbaugenossenschaft alleinstehender u. berufstätiger Frauen Berns. Tiefmattstr. 12 [24.896]
@@ -51946,7 +51849,7 @@ Wolf, s. auch Wolff
 – Josef, Zimmermann, Gerechtigkeitsgasse 33
 – Leonore G., Ladentochter, Wiesenstrasse 27
 – Lisette (Marti), Gerechtigkeitsgasse 3
-– Luise (Ledermann). Wwe.. Optingenstr. 37
+– Luise (Ledermann). Wwe., Optingenstr. 37
 – Marie (Hirsbrunner), Wwe., Mattenhofstrasse 22
 – Marie Louise (Kunz), Wwe., Privatiere, Glockenstrasse 12. Bümpliz
 – Moritz, Werkzeugmacher, Chutzenstrasse 47
@@ -51966,7 +51869,7 @@ Wolfensberger, Anna Rosa, Heilsarmeeoffizierin, Muristrasse 6
 – Jakob, Gärtner, Schiösslistrasse 7
 – Paul, Mechaniker, Spitalgasse 9
 Wolfer, Anna Marie (Zingg), Wwe., Fischermätteliweg 12
-– Emilie (Gross), Angestellte, Stauffacherstrasse la
+– Emilie (Gross), Angestellte, Stauffacherstrasse 1a
 – Friedr., Schlosser, Rodtmattstrasse 52
 – Hans, Maschinenmeister, Flurstrasse 15
 – Hans Ulr., Mechaniker, Metzgergasse 66
@@ -51983,8 +51886,8 @@ Wölfli, Christ Ludw., Handlanger, Gerechtigkeitsgasse 35
 – Friedr., Heizer, Zeitglockenlaube 6
 – Friedr. Wilh., Hilfsarbeiter, Weidmattw. 10, Bümpliz
 – Gottl., Maurer, Scheibenstrasse 38
-– Hedwig Anna. Ladentochter. Zeitglockenlaube 6
-– Joh.. Hilfsarbeiter, Kasthoferstrasse 4
+– Hedwig Anna. Ladentochter, Zeitglockenlaube 6
+– Joh., Hilfsarbeiter, Kasthoferstrasse 4
 – L. Christian, Pflästerer, Stauwehrrain 8
 – Robert, Heizer, Belpstrasse 53
 – Rud., Heizergehilfe, Sulgenrain 30
@@ -52006,7 +51909,7 @@ Woodtli, Alfr., Mechaniker. Pestalozzistr. 40
 – Hugo, Kaufmann, Sickingerstrasse 3
 – Jakob Emil. Glaser, Cedernstr. 9, Bümpliz
 – Otto, kaufm. Angest., Gerechtigkeitsg. 37
-– Walter. Techniker der S. B. B., Burkhartweg 7, Bümpliz
+– Walter, Techniker der S. B. B., Burkhartweg 7, Bümpliz
 – Werner, kaufm. Angestellter, Könizstr. 43a
 Woog, Carry (Diedesheimer), Wwe., Guteni ercstrasse 29 [33.022]
 – Gaston Georges, Bankprokurist, Gutenbergstrasse 13
@@ -52085,7 +51988,7 @@ Würgler, Alb., pens. Kupferdrucker. Thunstrasse 87
 – Klara Margr., Bureaulistin, Thunstrasse 87
 – Lydia Hulda, Bureaulistin, Falkenplatz 7
 – Marguerite, Jubiläumsstrasse 33
-– Oskar, Schriftsetzer, Stauffacherstr. la
+– Oskar, Schriftsetzer, Stauffacherstr. 1a
 – Otto (Lüdi), Direktor der Kantonalbank, Jubiläumsstrasse 33 [33.533]
 Würschinger, Ernst Joh., Spengler, Murtenstrasse 35
 – Sig. (Krähenbühl), Spenglerei, Freiburgstrasse 73 [36.020]
@@ -52100,7 +52003,7 @@ Würsten, Christina, Näherin, Bürkiweg 12
 – Elise (Nussbaum), Wwe., Tulpenweg 1
 – Friedr. Alb., Schuhmacher, Bühlstrasse 27b
 – Gertrud (Aerni), Wwe., Beaulieurain 11 [20.908]
-– Johann Peter, gew. Bäckermeister. Neubrückstrasse 55
+– Johann Peter, gew. Bäckermeister, Neubrückstrasse 55
 – Gertrud, Fabrikarb., Ladenwandstrasse 53
 – Joh. Rud., Automechan., Holligenstrasse 41
 – Manfred, Lehrer am städt. Progymnasium, Brügglerweg 7 [24.015]
@@ -52117,7 +52020,7 @@ Wüst, s. auch Wüest
 – G. (Christen), Herren- u. Damen-Coiffeurgeschäft (Viktoriarain 1), Spitalgasse 33 [35.347]
 – Fritz Jos., Ingenieur, Sennweg 19
 – Robert (Krüger), Ingenieur, Lorystrasse 8 [20.763]
-– Walter. Bankbeamter, Simplonweg 5
+– Walter, Bankbeamter, Simplonweg 5
 – Walter (Hubacher), Schneider, Seidenw. 18
 Wüthrich, Ad., Lokomotivheizer, Bundesbahnweg 29
 – A. M. (Krähenbühl), Wwe., Konradweg 11
@@ -52161,7 +52064,7 @@ Wüthrich, Ad., Lokomotivheizer, Bundesbahnweg 29
 – Ernst Heinr., Bauglas., Gerechtigkeitsg. 52
 – Ernst Friedr. (Schläfli), Angestellter, Lorrainestrasse 9
 – Ernst, Elektriker, Seilerstrasse 22
-– Ernst, Fabrikarbeiter. Kasthoferstrasse 6
+– Ernst, Fabrikarbeiter, Kasthoferstrasse 6
 – Ernst, Handlanger, Gerbergasse 7a
 – Ernst, Hilfsarb., Freiburgstr. 430, Bümpliz
 – Ernst Walt., Hilfsarbeiter, Länggassstr. 58
@@ -52179,8 +52082,8 @@ Wüthrich, Ernst, Obertelegraphist, Simonstrasse 17
 – Friedr., Bäckermeister, Dapplesweg 2 [31.958]
 – Friedr. G., Bankangestellter, Militärstr. 26
 – Friedr., Dekorat., Scheibenstr. 16 [28.685]
-– Friedr.. Fabrikarbeiter, Seidenweg 64
-– Friedr.. Lehrer, Kursaalstrasse 15 [31.455]
+– Friedr., Fabrikarbeiter, Seidenweg 64
+– Friedr., Lehrer, Kursaalstrasse 15 [31.455]
 – Friedr. Alfr., Magaziner, Heckenweg 13
 – Friedrich Richard (Witschi), Mechaniker
 0. T. D., Landoltstrasse 61 [35.189]
@@ -52213,8 +52116,8 @@ Wüthrich, Ernst, Obertelegraphist, Simonstrasse 17
 – Hans, Maurer, Kehrgasse 9, Bümpliz
 – Hans, Milchträger, Niederbottigenweg 101, Bümpliz
 – Hans, Postbeamter, Murtenstrasse 1
-. — Hans, Schlosser, Schläflirain 9
-– Hans, Sohuhmachermeister. Simonstr. 1 [27.116]
+— Hans, Schlosser, Schläflirain 9
+– Hans, Sohuhmachermeister, Simonstr. 1 [27.116]
 – Hans Friedr. (Baer), Alpenstr. 19 [29.028]
 – Heinr. Alfr., Schreiner, Randweg 13
 – Helene Agnes, Lehrerin, Forsthausweg 9
@@ -52277,7 +52180,7 @@ Wüthrich, Peter, Landwirt, Niederbottigenweg 93, Niederbottigen
 – Rosa, Gemüsehdlg., Jubiläumsstrasse 40
 – Rosa Hedwig, Ladentochter, Länggassstrasse 65
 – Rosa, Lingere, Bahnhöheweg 26, Bümpliz
-– Rud., Bahnvorarbeiter S. B. B.. Bernstr. 26, Bümpliz
+– Rud., Bahnvorarbeiter S. B. B., Bernstr. 26, Bümpliz
 – Rud., Tiefdruckschleifer, Beundenfeldstr. 40
 – Samuel, Versich.-Beamter, Neufeldstr. 129
 – Sigrid, Kindergärtnerin, Bubenbergplatz 5
@@ -52330,7 +52233,7 @@ Wyder und Wider
 – Joh. R., Hilfsarbeiter, Murtenstrasse 153g
 – Joh., Hilfsarbeiter, Pappelweg 4
 – Jos., Handlanger, Freiburgstr. 349, Bümpliz
-– Karl Alfr., eidg. Angest.. Gerbergasse 9
+– Karl Alfr., eidg. Angest., Gerbergasse 9
 – L. & J, Frl., Zähringerstr. 17 [33.952]
 – Magdalena (Müller), Wwe., Hallerstr. 32 [26.294]
 – Margaretha, Ladentochter, Dahliaweg 7
@@ -52347,7 +52250,8 @@ Wyder und Wider
 – Waller Rud., Tramangest., Muristrasse 91
 Wydler, Heinrich, Dekorateur, Manuelstr. 70 [28.312]
 – Heinr., Büro Stauffacher (Attinghausenstrasse 19), Gurtengasse 6 [35.468]
-– Rosa M., Krankenpflegerin, Schanzenbergstrasse 31v. Wyl, Alfr.,»Schlosser, Waffenweg 17
+– Rosa M., Krankenpflegerin, Schanzenbergstrasse 31
+v. Wyl, Alfr.,»Schlosser, Waffenweg 17
 Wylemann, Klara (Schweizer), Wwe., Engeriedweg 21 [27.253]
 – Klara, Bureaulistin, Engeriedweg 21
 Wyler, s. auch Weiler
@@ -52358,9 +52262,9 @@ Wyler, s. auch Weiler
 – Andre Hubert, Berner Warenhalle. Tuchu. Bettwarenhdlg., Versand, Schanzenbergstrasse 7
 – Anna (Röthlisberger), Wwe., Alpeneckstrasse 15 [33.168]
 – Arnold, eidg. Beamter, Scheuermattweg 8
-– Bertha. Fabrikarbeiterin, Blockweg 4
+– Bertha, Fabrikarbeiterin, Blockweg 4
 – Christ., Handlanger, Muldenstrasse 57
-– Ed.. Fabrikarbeiter, Pflugweg 8
+– Ed., Fabrikarbeiter, Pflugweg 8
 Wyler, s. auch Weiler
 – Elsa Kl., Verkäuferin, Badgasse 45
 – Emil, Bauzeichner, Badgasse 45
@@ -52389,7 +52293,7 @@ Wyler, s. auch Weiler
 – Oskar Alb., Bauzeichner, Wylerstrasse 28
 – Otto, Handels-Agentur, Wabernstrasse 6
 – Paul, Schreiner, Bahnstrasse 63
-– Rob., Hilfsarbeiter. Landoltstrasse 67
+– Rob., Hilfsarbeiter, Landoltstrasse 67
 Wyleregg, Restaurant, Wylerstrasse 109 [23.577]
 Wymann, A. F., Sattler, Blockweg 4
 – Ad., Handlanger, Marzilistrasse 2b
@@ -52452,7 +52356,7 @@ Wyniger, Christian, pens. Bauamtarbeiter, Muldenstrasse 48
 – Klara, Angestellte. Holzikofenweg 16
 – Margaretha Joh., Büreaulist., Gesellschaftsstrasse 3
 – Mathilde, Verkäuferin, Pestalozzistrasse 8
-– Otto, Bankangestellter. Holzikofenweg 16
+– Otto, Bankangestellter, Holzikofenweg 16
 – Rob., Hilfsarbeiter, Altenbergstrasse 132
 – Rosa Marg., Angestellte, Holzikofenweg 16
 – Rud., Kommis, Pavilloenweg 11
@@ -52475,13 +52379,13 @@ Wyser, s. auch Wysser
 – Jos., techn. Adjunkt beim städt. Gaswerk, Sandrainsti’asse 15 [23.520]
 Wyss, s. auch Weiss
 – Adele (Jäggi), Wwe., Schanzenstrasse 6
-– Alb.. Chauffeur-Mechaniker. Felsenauw. 20
-– Alb.. Gewürzkrämer. Monbijoustrasse 71
+– Alb., Chauffeur-Mechaniker. Felsenauw. 20
+– Alb., Gewürzkrämer. Monbijoustrasse 71
 – Alb., kaufm. Angestellter, Gewerbestr. 23
-– Alb.. Schreiner, Gerechtigkeitsgasse 40
-– Alfr., Bahnarbeiter, Reichenbachstrasse la
+– Alb., Schreiner, Gerechtigkeitsgasse 40
+– Alfr., Bahnarbeiter, Reichenbachstrasse 1a
 – Alfr., Spengler, Murifeldweg 19
-– Alfr.. Mechaniker, Allmendstrasse 50
+– Alfr., Mechaniker, Allmendstrasse 50
 – Alfr., Schreiner, Blumenbergstrasse i6
 – Alice, Bureaulistin, Schützenweg 39
 – Alice. Stenotypistin, Weissenbühlweg 14
@@ -52496,7 +52400,7 @@ Wyss, s. auch Weiss
 – Barbara Luise, Wäscherin, Engerain 48
 – Bernhard, Führergehilfe B. L. S., Burgunderstrasse 69, Bümpliz
 – Bertha, Bureaulistin, Gutenbergstrasse 7 [36.678]
-– Bertha. Coiffeuse. Schosshaldenstrasse 76
+– Bertha, Coiffeuse, Schosshaldenstrasse 76
 – Bertha, Hilfsarbeiterin, Freiburgstrasse 72a
 – C. Ottilie S (Schnyder), Privatiere, Niggelerstrasse 16
 – Christ. Gottl., Chauffeur S. O. B., Lorystr. 8
@@ -52512,22 +52416,16 @@ Wyss, s. auch Weiss
 – Elise, Ladentochter, Belpstrasse 53
 – Elise (Baumann), Wwe., Schläflirain 3
 – Elis. (Baumgart), Wwe., Privat., Matzenriedstrasse 95a, Oberbottigen
-Fachmännische Beratungin allen vorkommenden Fragen der Branchedurchsfettbachen
-GerxcJitlgkeitsg. 59 Telephon 21.040
 # Date: 1935-12-15 Page: 26020865/556
-Wyss
-556
 Wyss, s. auch Weiss
 – Elise (Sägesser), Wwe., Willadingstr. 41 [22.741]
 – Elise (Winzenried), Wwe., Sulgeneckstr. 62 [25.988]
 – Elsb., Heilgymnastin, Gryphenhübeliw. 27
 – Emil Ad., Mechaniker, Gewerbestrasse 34
-– Emma, Priv., Bonstettenstrasse 17 (Villa
-Helena) [35.637]
+– Emma, Priv., Bonstettenstrasse 17 (Villa Helena) [35.637]
 – Ernst Herm., Bahnbeamter, Gesellschaftsstrasse 74 [28.725]
 – Ernst Jak., Dr. med., Arzt, Viktoriastr. 47
-– Ernst, Fürsprech, jurist. Sekretär d. städt.
-Baudirektion, Hallerstrasse 41 [36.329]
+– Ernst, Fürsprech, jurist. Sekretär d. städt. Baudirektion, Hallerstrasse 41 [36.329]
 – Ernst (Buchkremer). Dr. med., Spezialarztfür innere Krankheiten, Schwarztorstr. 26 [34.226]
 – Ernst, Dr. jur., Fürsprech, Adjunkt dereidg. Steuerverwaltung, Jubiläumsstr. 11 [36.347]
 – Ernst, Elektriker, Kesslergasse 25
@@ -52537,13 +52435,13 @@ Baudirektion, Hallerstrasse 41 [36.329]
 – Ernst Arn., Sattler- u. Tapezierermeister, Quartierhof 8
 – Ernst, Schriftsetzer, Eigerplatz 10
 – Erwin Fritz, Maler, Dietlerstrasse 34
-– Ferdinand, Buchhalter. Grünerweg 9
+– Ferdinand, Buchhalter, Grünerweg 9
 – Fr., Packer, Weissenbühlweg 14
 – Fr., Sattler- und Tapezierermeister, Quartierhof 8 [34.222]
 – Franz Ed., Chauffeur, Gutenbergstrasse 7
 – Franz, Dr. med., Spezialarzt für Bruchleiden, Schwarztorstrasse 18 [34.472]
 – Franz, Gipser, Federweg 55
-– Franz, Schneidermeister. Gerbergasse 40
+– Franz, Schneidermeister, Gerbergasse 40
 – Frieda, Damensalon, Marktg. 24 [28.331]
 – Frieda, Damenschneid., Giessereiweg 20
 – Frieda, pens. Lehrerin, Statthalterstr. 36, Bümpliz [46.554]
@@ -52557,7 +52455,7 @@ Baudirektion, Hallerstrasse 41 [36.329]
 – Friedr. Alb., Portier, Berchtoldstrasse 50
 – Friedr., Tramführer, Dietlerstrasse 34
 – Fritz, jun., stud. rer. pol., Moserstrasse 16
-.— Fritz, Beamter bei der Landestopographie, Wattenwylweg 34
+— Fritz, Beamter bei der Landestopographie, Wattenwylweg 34
 – Fritz, Giesser, Hohgantweg 5a
 – Fritz, Krankenwärter, Bundesrain 16
 – Fritz, Postbeamter, Holligenstrasse 85i—Fritz, Schlosser, Aehrenweg 16, Bümpliz
@@ -52639,13 +52537,13 @@ Wyss, s. auch Weiss
 – Olga, Lehrerin, Hallerstrasse 41 [25.6201
 – Olga Martha (Riesen), Wwe., Gewerbestrasse 23
 – Oskar Ernst, städt. Beamter, Güterstr. 44
-– Oskar Joh., Dr., eidg. Beamter. Altenbergstrasse 120 [36.819]
+– Oskar Joh., Dr., eidg. Beamter, Altenbergstrasse 120 [36.819]
 – Oskar, in Fa. Schneiter & Wyss, Morellweg 8 [34.516]
 – Oskar, Schlosser B. N. B., Freiburgstr. 75
 – Othmar, Schreiner, Militärstrasse 53
 – Paul L., Angestellter, Belpstrasse 14
 – Paul (Trachsel), Gym.-Lehrer, Riedweg 5 [28.221]
-– Paul Alfr., Angestellter. Wattenwylweg 34
+– Paul Alfr., Angestellter, Wattenwylweg 34
 – Paul, Pianist, Viktoriastrasse 51
 – Paul, Coiffeur, Amthausgasse 18
 – Paul A., Handlanger, Bubenbergplatz 4
@@ -52685,7 +52583,7 @@ v. Wyss, Helene, Privatiere, Steigerweg 7
 Wyssa, Ernst, Metzger, Bernstr. 103, Bümpliz
 Wyssbrod, Flora Hedwig, eidgen. Beamtin, Mühlemattstrasse 18
 Wyssen, Lina, Bureaulistin, Schwarztorstr. 11
-– Reinh. (Derron), Hilfsarbeiter. Langmauerweg 17a
+– Reinh. (Derron), Hilfsarbeiter, Langmauerweg 17a
 Wyssenbach, s. auch Weissenbach
 – Friedr. E., Bankangestellter, Fellenbergstrasse 13
 – Friedr. Wilh., Fabrikarbeiter, Tavelweg 6
@@ -52716,7 +52614,7 @@ Wyssmann, s. auch Wiesmann u. Wismann
 – Fritz, Hilfsarbeiter, Lorrainestrasse 8
 – Fritz, Automechaniker, Seidenweg 35
 – Fritz, Hilfsarbeiter, Schmiedweg 7
-– Gottfr.. Fabrikarbeiter. Hochfeldstr. 69
+– Gottfr., Fabrikarbeiter, Hochfeldstr. 69
 – Hulda, Telephonistin, Jurastrasse 14
 – Joh. Friedr., Postbeamter, Bovetstrasse 9
 – Karl Rud., Bureaulist, Sennweg 13
@@ -52746,7 +52644,8 @@ Wyttenbach, Adolf, Kunstmaler. Monbijoustrasse 43 [35.625]
 – Marie Martha, Sekundarlehrerin, Schwarztorstrasse 7 [35.233]
 – Math. (Knobel), Wwe. d. Bankiers, Steigerweg 2
 – Werner Karl, Mechan., Breitenrainstr. 81
-– Werner, Primarlehrer, Bantigerstrasse 32v. Wyttenbach, Aug. Fr. A., Privatier. Thunstrasse 61 [35.817]
+– Werner, Primarlehrer, Bantigerstrasse 32
+v. Wyttenbach, Aug. Fr. A., Privatier. Thunstrasse 61 [35.817]
 – A. (Bovet), Bankier, Schosshaldenstr 32 (Egelberg) [31.441]
 – Arth. (v. Wattenwyl), Dr. jur., Fürsprecher, bürgerlicher Kommissionsschreiber, Brunnadernstrasse 25 [36.0451
 – Ludw. Chr., gew. Kaufm., Bubenbergpl. 4
@@ -52813,44 +52712,44 @@ Fueter, Mittelstrasse 59
 Zahnd, Friedr., Schneidermeister, Brunng. 6
 – Fritz. Bankbeamter, Balmweg 11
 – Fritz, Bureaalist, Hochfeldstrasse 7
-– Gottl.. Ausläufer, Lorrainestrasse 57
+– Gottl., Ausläufer, Lorrainestrasse 57
 – Gottl. Rob., Tapezierermstr., Gesellschaftsstrasse 10
 – Hans, Hilfsarbeiter, Stöckackerstrasse 82, Bümpiiz
 – Hans, Spengler, Stöckackerstr. 95, Bümpiiz
 – Hans, Hutmacher, Mittelstrasse 21
-– Joh.. Militärstrasse 63
+– Joh., Militärstrasse 63
 – Joh., Spengler, Steckweg 17
 – Joh. Albr., Privatier, Werkg. 30, Bümpiiz
 – Johann, Handlanger, Quartiergasse 17
 – Karl, Bauhandlanger, Talweg 3
 – Karl Walter, Chauffeur, Rodtmattstr. 57
 – Karl. Dachdecker. Rosenweg 12
-– Karl Friedr., Postbeamter. Gesellschaftsstrasse 7
+– Karl Friedr., Postbeamter, Gesellschaftsstrasse 7
 – Karl. Postbureaudiener, Turnweg 6
 – Karoline Maria, Posamenterin, Jubiläumsstrasse 88
 – Lina. Näherin, Schifflaube 34
 – Magdalena (Jenni), Wwe., Ralligweg 16
 – Maria A. Th., Bureaulistin, Militärstr. 22
-– Marie (Kummer) Wwe.. Hohgantweg 5a
+– Marie (Kummer) Wwe., Hohgantweg 5a
 – Martha KaroL Kasernenstrasse 21a
 – Moritz, Hilfsarbeiter, Kehrg. 53. Bümpiiz
 – Moritz, Karrer, Weidmattweg 2, Bümpiiz
 – Niklaus, Zügler, Scheibenstrasse 28
 – Olga Kl. EL, Gehilfin bei der O. P. D., Mittelstrasse 21
 – Otto, Hilfsarbeiter, Stöckackerstrasse 82, Bümpiiz
-– Philipp Joh., Vertreter. Landoltstrasse 48
+– Philipp Joh., Vertreter, Landoltstrasse 48
 – Richard E. (Bisaz), eidg. Beamter, Jubiläumsstrasse 58
 – Rosa, Damenschneiderin, Freiburgstr. 129 [28.413]
 – Rosa Emma, Verkäuferin, Brunngasshalde 63
 – Rud., Polizeikorporal, Reichenbachstr. 4
 – Ulr., Handlanger, Weidmattw. 10, Bümpiiz
 – Walter, kaufm. Angest., Stöckackerstr. 95, Bümpiiz
-– Willy. Sped.-Angestellter. Freiburgstr. 71
+– Willy. Sped.-Angestellter, Freiburgstr. 71
 Zahner, Josef, Prokurist der Gewerbekasse, Kornhausstrasse 8 [26.371]
 – Rob., Vizedirektor, Biirglenstr. 33 [31.908]
 Zahno, Anna Marie M., Frau. Steigerweg 10
 Zähringerhof, Restaurant. Gesellschaftsstr. 20 [21.435]
-Zala, Remigio, eidg Beamter. Zielweg 23
+Zala, Remigio, eidg Beamter, Zielweg 23
 Zaldumbide, Gongala, Gesandter von Ecuador, Bellevue-Palace
 Zambelli, Antonio, Früchtehändler, Sulgenrain 30
 – Francesco, Gipser, Sulgenräin 30
@@ -52883,13 +52782,13 @@ Zaugg, Adolf, Beamter, Friedlistrasse 33
 – Adolf, Bahnarbeiter, Rodtmattstrasse 37
 – Adolf, Lek-Führer, Trachselweg 15
 – Adolf, eidg. Angestellter, Finkenrain 13
-– Alb., Bahnarbeiter. Breitenrainstrasse 44
+– Alb., Bahnarbeiter, Breitenrainstrasse 44
 – Albert, Elektrotechniker, Hochschulstr. 4
 – Albert, Hausierer, Nydeckhof 31
 – Albert, Schlosser, Wiesenstrasse 2
 – Alfred, Hilfsarbeiten, Neuengasse 45
 – Alfr. Alb., Bankangest., Brünnenstr. 123, Bümpiiz [46.613]
-– Alfr.. Hilfsarb.. Bahnhöheweg 36, Bümpiiz
+– Alfr., Hilfsarb., Bahnhöheweg 36, Bümpiiz
 – Alfred, Schreiner, Wylerfeldstrasse 42
 – Alfred Ernst. Spengler, Gruberstrasse 6
 – Alice Elsa, Bureaulistin, Kramgasse 78
@@ -52900,10 +52799,10 @@ Zaugg, Adolf, Beamter, Friedlistrasse 33
 – Bertha, Ladentochter, Graffenriedweg 8
 – Bertha, gew. Lehrerin, Melchenbühlweg 56
 – Christ. Ulrich. Chauffeur, Brückenstr. 12
-– Christ.. Handlanger. Brunngasse 36
+– Christ., Handlanger. Brunngasse 36
 – Christ., Postangestellter, Bahnhöheweg 36, Bümpiiz
 – Eduard, Hilfsarbeiter, Unt. Aareggweg 17
-– Ed.. Schreiner. Lorrainestrasse 64
+– Ed., Schreiner. Lorrainestrasse 64
 – Emma, Frl., Rodtmattstrasse 54
 – Emma, Schneiderin, Murtenstrasse 60
 – Erna, Damenschneiderin, Seftigenstr. 45
@@ -52926,7 +52825,7 @@ Zaugg, Ernst, Lokomotivführer, Rohrweg 5
 – Frieda, Arbeiterin, Brunngasse 36
 – Friedr., Ausläufer, Parkstrasse 1
 – Friedr. Wilh., Bankangest., Karl-Schenkstrasse 9
-– Friedr., Bankprokurist, .Jennerweg 11
+– Friedr., Bankprokurist, Jennerweg 11
 – Friedr., Briefträger, Militärstrasse 24
 – Friedr., Chauffeur S. O. B., Weissensteinstrasse 66
 – Friedr., Fuhrmann, Sonneggring 15
@@ -52996,18 +52895,18 @@ Zaugg, Jakob (Wüthrich), Bäckerei u. Zwiebackfabrikation, Graffenriedweg 8 [22
 – Otto, Hilfsarbeiter, Standstrasse 31
 – Otto, Hilfsarbeiter, Wangenstr. 86, Bümpliz
 – Otto, Schlosser, Schönauweg 3
-– Otto Andr.. Schreiner, Mittelstrasse 28
+– Otto Andr., Schreiner, Mittelstrasse 28
 – Paul Ad., Fabrikarbeiter, Badgasse 33
 – Paul R., Gärtner, Breiteweg 22
 – Paul Hans, Kaufmann, Viktoriarain 3
 – Paul Theod., Schuhmacher, Militärstr.24
 – Paul Friedr., Tapezierer, Wangenstr. 86, Bümpliz
 – Paul, Vertreter, Neufeldstrasse 111
-– Roh., Pferdewärter. Parkstrasse 1
+– Roh., Pferdewärter, Parkstrasse 1
 – Rosa Gertr., Kindergärtnerin, Hallerstr. 14
 – Rosa Lina (Nafzger), Wwe., Mittelstr. 19
 – Rosa, Verkäuferin, Parkstrasse 1
-– Rosa (Stucki), Wwe.. Bümplizstrasse 167
+– Rosa (Stucki), Wwe., Bümplizstrasse 167
 – Rud., Dampfwalzenführer, Wiesenstr. 66
 – Rud., Elektromonteur, Güterstrasse 34
 – Rud., Handlanger, Rehhagstr. 13, Bümpliz
@@ -53031,7 +52930,7 @@ Zaugg, Walter, Hausierer, Marzilistrasse 2
 – Werner, Maschinenmeister, Murtenstr. 60
 – Willy A., Coiffeur, Schwarztorstrasse 95
 – Willy, Maler, Felsenaustrasse 25
-– & Cie., Eisenwaren, Haushaltungsartikel, Werkzeuge, Maschinen u. techn. Artikel, Kramgasse 78 .
+– & Cie., Eisenwaren, Haushaltungsartikel, Werkzeuge, Maschinen u. techn. Artikel, Kramgasse 78
 Zbären, Ernst, Hilfsarbeiter, Pappelweg 8
 Zberg, Albert, Küfer, Schönauweg 8
 Zbinden, Ad. (Fischler), Kaufmann, Tscharnerstrasse 7 [24.540]
@@ -53050,7 +52949,7 @@ Zbinden, Ad. (Fischler), Kaufmann, Tscharnerstrasse 7 [24.540]
 – Anna (Portmann), Wwe., Privatiere, Hallerstrasse 54
 – Bertha, Damenschneid., Länggassstr. 32a
 – Bertha, Fabrikarbeiterin, Bümplizstr. 58
-– Christ.. Güterarbeiter. Weissenbühlweg 23
+– Christ., Güterarbeiter, Weissenbühlweg 23
 – Christ., Maurer, Mühlemattstrasse 68
 – Eduard Gottfr., Kaufmann, Wylerstr. 83
 – Eduard Osk., Angestellter, Militärstr. 64
@@ -53060,7 +52959,7 @@ Zbinden, Ad. (Fischler), Kaufmann, Tscharnerstrasse 7 [24.540]
 – Emil Ernst, Hilfsarbeiter, Stalden 9
 – Emilie, Ladentochter, Krippenstrasse 16
 – Emma, Lehrerin, Weissensteinstrasse 120
-– Emma, Frl.. Schifflaube 30
+– Emma, Frl., Schifflaube 30
 – Ernst, Bankangestellter, Lorrainestr. 34
 – Ernst, Bahnarbeiter, Freiburgstrasse 347, Bümpliz
 – Ernst, Handlanger, Bottigenstr. 47, Bümpliz
@@ -53083,7 +52982,7 @@ Zbinden, Ernst, Telegraphist, Neubrückstr. 57
 – Friedr. Willy, eidgen. Beamter, Effingerstrasse 41d [20.187]
 – Friedr., Chauffeur, Brqnngasse 48
 – Friedr., Giessereiarbeiter, Burgfeldweg 15
-– Friedr., pens. Pferdewärter. Friedhofw. 24a
+– Friedr., pens. Pferdewärter, Friedhofw. 24a
 – Friedr., Strassenwalzepführer, Könizstr.131
 – Fritz, Ausläufer, Lorrqinestrasse 15
 – Fritz, Briefträger, Frohbergweg 4
@@ -53103,7 +53002,7 @@ Zbinden, Ernst, Telegraphist, Neubrückstr. 57
 – Hedwig Lina. Falzerin. Holzikofenweg 7
 – Hedwig, Verkäuferin, Krippenstrasse 16
 – Helene Math., Bureaulistin, Balm weg 11
-– Herm., Postangestellter. Länggassstr. 70a
+– Herm., Postangestellter, Länggassstr. 70a
 – J., pens. Wegmeister, Krippenstrasse 16
 – J. A-, Magaziner, Bühlstrasse 39
 – Joh. Kurt, Assistent, Mittelstrasse 32
@@ -53126,7 +53025,7 @@ Zbinden, Ernst, Telegraphist, Neubrückstr. 57
 – Maria Rosalie (Wenker), Bureaumaterial, Balmweg 11 [26.201]
 – Marie, Damenschneiderin, Krippenstr. 16
 – Marie, Fabrikarbeiterin, Bühlstrasse 39
-– Marie (Stöckli), Wwe., Milchhdlg.. Schifflaube 30
+– Marie (Stöckli), Wwe., Milchhdlg., Schifflaube 30
 – Marie, Wwe., Riedbachstr. 102, Bümpliz
 – Martha Emilie, Damenschneiderin, Holzikofenweg 7
 # Date: 1935-12-15 Page: 26020871/562
@@ -53161,7 +53060,7 @@ Zbinden, Martha, Pflegerin, Riedbaehstr. 102, Bümpliz
 – Wagner, Hedwig, Holzikofenweg 7
 Zeder, Ad., Filialleiter, Bollwerk 23
 – Friedr., Packer, Stationsweg 42
-— Jos. Ant., Schuhmachermeister. Bibliothekgässcben 3 [33.241]
+— Jos. Ant., Schuhmachermeister, Bibliothekgässcben 3 [33.241]
 Zeeb, Emma Bertha, Angestellte, Gerechtigkeitsgasse 31
 – Martin, Küferei u. Weinhandlung, Gerechtigkeitsgasse 31 [34.517]
 Zeender, Caroline, Frl., Schanzeneckstr. 25
@@ -53215,7 +53114,7 @@ Zehnder, Albr., Gipser- u. Malermstr., Rodtmattstrasse 69 [28.398]
 – Hermann Friedr., Elektrotechniker, Alleeweg 22
 – Herm., Gipser- u. Maler, Breiteweg 26
 – Hermine, Damenschneiderin, Polygonw. 23
-– J.. Dr. jur.. Fürsprecher (Sulgenrain 10 [31.715]), Marktgasse 17 [34.666]
+– J., Dr. jur., Fürsprecher (Sulgenrain 10 [31.715]), Marktgasse 17 [34.666]
 – J., Landw., Niederbottigenw. 96, Riedbach
 – Joh., jun., Landwirt, Niederbottigenweg 96, Bümpliz
 – Joh., Gipser u. Maler, Attinghausenstr. 23
@@ -53248,7 +53147,7 @@ Zehr, Ernst Adolf, Angest., Stauffacherstr. 2
 Zehrer, Joseph, Schneidermeister, Mattenhofstrasse -25
 Zeier, Emma Rosa (Zürcher), Modes, Bollwerk 17 [31.484]
 – Felix, Kurzwaren en gros und detail, Bollwerk 17
-Zeindler, Aug.. Werkstättechef, Zielweg 29 [35.166]
+Zeindler, Aug., Werkstättechef, Zielweg 29 [35.166]
 – Hans, Beamter, Grundweg 14
 – Luise A. (Schwarz), Lehrerin, Zeughausgasse 22
 Zeiser, Rosa, Glätterin, Marienstrasse 31
@@ -53338,7 +53237,7 @@ Zentralverband des Schweiz. Transport- und Verkehrsgewerbes (geschäftsführende
 Zentralverwaltung der Schweiz. Mobiliar-Versicherungs-Gesellschaft, Schwanengasse 14 [21.311]
 Zentral-Waschanstalt A.-G., Schwarztorstr.33 [21.975]
 Zerbe, Walter Leo Joh., Buchdrucker-Fachlehrer, Balderstrasse 44
-Zesiger, Ernst, Postangestellter, Stauffacherstrasse la
+Zesiger, Ernst, Postangestellter, Stauffacherstrasse 1a
 – Gottfr., Schleifer, Gerechtigkeitsgasse 5
 – Ida Martha, Speziererin, Thunstrasse 43a [33.274]
 – Joh., gew. Bereiterchef, Blumenbergstr. 37 [24.021]
@@ -53395,14 +53294,13 @@ Zihler, A. B., Sackfabrik (Papiermühlestr. 12g) «Chalet Soleil» [35.466]), Pa
 – Jak. Aug., Textilwaren, spez. Leinen und Halbleinen, Alleeweg 15 [22.723]
 – Josef, Architekt, Architektur- u. Baubüro (Willadingweg 19 [31.066]), Brunnadernstrasse 59 [24.425]
 – Joseph, Monteur, Bahnstrasse 59
-Moserstr. 12 - Telephon 27.171
 # Date: 1935-12-15 Page: 26020874/565
-Zihlmann, Franz Josef. Bankbeamter, Schärerstrasse 3
+Zihlmann, Franz Josef, Bankbeamter, Schärerstrasse 3
 – Math., Tscharnerstrasse 11
 Ziliiani, Vittorio Rob., Handlanger, Länggassstrasse 82
 Zimmerli, Friedr., Direktor, Jubiläumsstr. 68 [34.571]
 – Friedr., Heizer S. B. B., Fabrikstrasse 34
-– Georg Nathanael, Dr. jur., eidg. Inspektor, Oberweg 3 .
+– Georg Nathanael, Dr. jur., eidg. Inspektor, Oberweg 3
 – Gottl., pens. Beamter S. B. B., Freie Str. 27
 – Gustav, Hilfsarbeiter, Postgasse 16
 – Hans, Bankangestellter, Stockerenweg 1
@@ -53414,11 +53312,11 @@ Zimmerli, Friedr., Direktor, Jubiläumsstr. 68 [34.571]
 – Marg. Mathilde, Damenschneiderin, Kramgasse 65
 – Martha, Humboldtstrasse 39
 – Susy L., Musiklehrerin, Jubiläumsstr. 68
-– Walter. Heizungstechniker, Spitalackerstrasse 69
+– Walter, Heizungstechniker, Spitalackerstrasse 69
 Zimmermann, Adolf, Kanzlist, Mezenerweg 8
 – Adrian Siegfr., Schriftsetzer, Spitalgasse 3
 – Alb., Bahnarbeiter, Kirchbergerstrasse 69
-– Alb., Wagenführer S. S. B.. Graüenriedweg 14
+– Alb., Wagenführer S. S. B., Graüenriedweg 14
 – Alb., Wirt, Muesmattstrasse 40 [22.326]
 – Alex. Max, Feinmechaniker, Haspelweg 30
 – Alex. (Schönauer), gew. Wirt, Amthausgasse 2 [23.687]
@@ -53459,7 +53357,7 @@ Zimmermann, Emma Rosa, Verkäuferin, Beaumontweg 38
 – Ernst, Installateur, Aarbergergasse 46
 – Ernst Hs., Kaufmann, Monbijoustrasse 70
 – Ernst, Kondukteur S. B. B., Moserstr. 6
-– Ernst, Kondukteur der S. S. B.. Freiburgstrasse 73
+– Ernst, Kondukteur der S. S. B., Freiburgstrasse 73
 – Ernst, Maurerpolier, Gerbergasse 4
 – Ernst Alb., Mechaniker, Badgasse 33
 – Ernst Jak., Mechaniker, Hopfenweg 29
@@ -53481,7 +53379,7 @@ Zimmermann, Emma Rosa, Verkäuferin, Beaumontweg 38
 – Friedrich Ernst (Salzmann), Kaufmann, Greyerzstrasse 36 [21.399]
 – Friedr., Lehrer, Engeriedweg 2a [35.619]
 – Friedr., Mechaniker, Beaumontweg 38
-– Friedr., Pferdewärter. Blumenbergstr. 51
+– Friedr., Pferdewärter, Blumenbergstr. 51
 – Friedr. Arth., Spezereihdlg., Engehaldenstrasse 206 [29.846]
 – Fritz, Bahnarbeiter, Kasthoferstrasse 18
 – Fritz Ad. (Bigler), Bankangestellter, Karl-Staufferstrasse 16
@@ -53534,7 +53432,7 @@ Postgasse 63 [28.684]
 – Joh. Gottfr., Scheibenstrasse 25
 – Jos. (Herold), Direktor, Rossfeldstr. 24 [36.604]
 – Joseph Alois. Angest., Sandrainstrasse 77
-– Jul., Instr.-Setzer E. W. B.. Hochfeldstr. 11 [33.032]
+– Jul., Instr.-Setzer E. W. B., Hochfeldstr. 11 [33.032]
 – Karl, Installateur, Standstrasse 11
 Zimmermann, Karl [34.526] Konstruktionswerkstätte, Press- und Stanzwerke, Storenfabrik (Badgasse 27), Wasserwerkgasse 31
 – Karl, Monteur, Forsthausweg 12
@@ -53592,7 +53490,7 @@ Zimmermann, M. (Gyger), Damenschneiderin, Hochfeldstrasse 11
 – Walter, Mechaniker, Blockweg 5
 – Walter, Tapezierer, Hofweg 5a
 – Werner, Angestellter, Simonstrasse 7
-– Werner Rud.. Angest. E.-W., Federw. 29d
+– Werner Rud., Angest. E.-W., Federw. 29d
 – Werner, Mechaniker, Mürtenstrasse 7
 – Willy, Bäcker, Hubelmattstrasse 50.
 – Willy, Heizungsmonteur, Pestalozzistr. 36
@@ -53623,7 +53521,7 @@ Zingg, Ad., Kaufm., Veilchenweg 7, Bümpliz
 – Emma Rosa, Schwanengasse 8
 – Elisabeth, Schänzlistrasse 31
 – Erika, Klavierlehrerin, Bubenbergplatz 10 [29.219]
-– Ernst Alb. (Baumgartner), Schreiner-Vorarbeiter. Tavelweg 37
+– Ernst Alb. (Baumgartner), Schreiner-Vorarbeiter, Tavelweg 37
 – Ernst FL, Elektrotechniker, Eman.-Friedlistrasse 23
 – Ernst R. U., Kaufmann, in Fa. Zingg &
 Co., Sandrainstrasse 50
@@ -53631,7 +53529,7 @@ Co., Sandrainstrasse 50
 – Ernst, Reisender, Rohrweg 12
 – F. E. (Lüthy), Handelsm., Sandrainstr. 50
 – Frieda, Kassierin, Bubenbergplatz 10
-– Friedr., Pferdewärter. Breitfeldstrasse 35
+– Friedr., Pferdewärter, Breitfeldstrasse 35
 – Fritz Hans, Metzger, Kasernenstrasse 40
 – Gottfr., Schmied, Breiteweg 10
 – Gottfr., Schreiner, Gerbergasse 24
@@ -53709,7 +53607,7 @@ Zoologisches Institut, Muldenstr. 8 [33.986]
 Zopfi, Heinrich, Buchdrucker, Wyttenbachstrasse 16
 – Walter, Zeichner, Wyttenbachstrasse 16
 Zoss, A., Frau, Institut für Bäder, Massage, Schönheitspflege, Marktgasse 44 [28.812]
-– Ad.. Zähringerstrasse 49
+– Ad., Zähringerstrasse 49
 – Adolf, Bundesbeamter, Dalmazirain 11
 – Alb. (Schläfli), Rechercheur, Militärstr. 50
 – Albert, Angestellter, Gäcilienstrasse 31
@@ -53722,10 +53620,10 @@ Zoss, A., Frau, Institut für Bäder, Massage, Schönheitspflege, Marktgasse 44 
 – Hans, Chauffeur. Postgasse 34
 – Hans, Billetdrucker S. B. B., Martiweg 17
 – Jakob, Revisionsgehilfe, Marzilistrasse 6
-– Joh.. Bahnarbeiter, Martiweg 17
+– Joh., Bahnarbeiter, Martiweg 17
 – Marie (Schwarz), Wwe., Hebamme, Thunstrasse 44 [31.806]
 – M. (Müller), Privatier, Dalmazirain 32
-– Paul Alb.. Früchte- und Gemüsehandlung, Zähringerstrasse 49 [23.892]
+– Paul Alb., Früchte- und Gemüsehandlung, Zähringerstrasse 49 [23.892]
 – Paul Otto, Stationswärter, Landoltstr. 71
 – R. Albert, Oberlehrer d. städt. Hilfsschule, Cäcilienstrasse 31 [34.082]
 Zoulficar, Bertha, Wwe., Cigarrengeschäft (Länggassstrasse 30), Mittelstrasse 13
@@ -53735,7 +53633,7 @@ Schürzen (Dammweg 21 [29.689]), Beundenfeldstrasse 31a [31.354]
 – Gottl. (Braun), Schreiner, Stockerenweg 4
 Zübelen, Jean A. G., Ingenieur, Hallerstr. 53
 Zuber, Bertha, Bureaulistin, Zähringerstr. 69
-– Friedr.. Maurer, Altenbergstrasse 32
+– Friedr., Maurer, Altenbergstrasse 32
 – Fritz. Architekt, Altenbergstrasse 126 [33.357]
 – Gertr. Johanna, Bureaulistin. Altenbergstrasse 126
 – Gottfr., Bahnarbeiter, Rickenweg 17
@@ -53771,7 +53669,7 @@ Zuckschwerdt, E. Ad., Kaufmann, Gryphenhübeliweg 24 [24.913]
 – Max, Ausläufer, Bühlstrasse 23
 Zufferey, Joseph, Instr.-Offizier, Viktoriastrasse 39 [29.827]
 Zulauf, Ernst Felix, Pension. Werkmeister, Effingerstrasse 95 [20.294]
-– Friedr., Ingenieur d. S. B. B.. Brückfeldstrasse 24
+– Friedr., Ingenieur d. S. B. B., Brückfeldstrasse 24
 – Hans Erich, Angestellter, Kirchenfeldstr.74
 – Hans. Tapisserie- und Broderie-, Kunstund Fahnenstickereigeschäft (Kirchenfeldstrasse 74 [23.527]), Bärenpl. 4 [22.335]
 – Klara L., Ladentochter, Effingerstrasse 95
@@ -53837,7 +53735,7 @@ Zumstein Briefmarkenund philat. Verlag Zumstein & Cie., Marktgasse 50 [22.944], 
 – Christian, Confiseur-Pätissier, vormals H. Wildbolz, Gerechtigkeitsgasse 62 [24.125]
 – Elise (Ischy), Wwe., in Fa. Zumstein & Cie., Briefmarkenhandlung, Choisystr. 10 [33.964]
 – Frieda Rosa, Einlegerin, Jurastrasse 59
-– Frieda, Kanzlistin E. W. B.. Dietlerstr. 20 [45.324]
+– Frieda, Kanzlistin E. W. B., Dietlerstr. 20 [45.324]
 — Gottfr., Maler, Frohbergweg 10
 – Joh., Milchhändler, Gewerbestrasse 33
 – Johanna, Säuglingspflegerin, Dietlerstr. 20
@@ -53852,7 +53750,7 @@ Zumstein, Klara, EmpfangsfräuL, Gewerbestrasse 33
 – Rosa (Eberhard), Wwe., Friedenstrasse 28
 – Rud. (Bossard), Vertreter, Belpstrasse 41
 – W. (Hofmann), Bankbeamter, Balmweg 29
-– Walter, Dr. jur.. Fürsprecher (Jubiläumsstrasse 69 [36.330]), Beim Zeitglocken 2 [24.044]
+– Walter, Dr. jur., Fürsprecher (Jubiläumsstrasse 69 [36.330]), Beim Zeitglocken 2 [24.044]
 Zünd, Gebhard Gottl., Möbelhandlung (Murtenstrasse 1 [29.611]), Kapellenstrasse 18 [20.059]
 – Jos. Ad., Angestellter, Landoltstrasse 50
 – Oskar, kfm. Angestellter, Monbijoustr. 132
@@ -53884,7 +53782,7 @@ Zurbuchen, Anna Maria, Fabrikarb., Länggassstrasse 70b
 – Ernst, Bäck. (Humboldtstr. 17 [25.842]), Neuengasse 45 [35.519]
 – Ernst, Magaziner, Cäcilienrain 3
 – Ferd., Hilfsarbeiter, Gerbergasse 48
-– Friedr.. Schneider, Schönburgstrasse 28
+– Friedr., Schneider, Schönburgstrasse 28
 – Fritz W., städt. Angestellter, Emanuel-Friedlistrasse 23
 – Gottfr., Postangestellter, Burgernzielw. 18
 – Joh., Schlosser, Länggassstrasse 69
@@ -53967,7 +53865,7 @@ Zürcher, s. auch Züricher
 – Hans, Dreher, Rodtmattstrasse 106
 – Hans, Haushaltungsartikel u. Lederwaren, Brunngasse 40
 – Hans, Hilfsarbeiter, Landoltstrasse 28
-– Hans, Hilfsarbeiter. Wylerringstrasse 55
+– Hans, Hilfsarbeiter, Wylerringstrasse 55
 – Hans P., Hotelsekretär, Obstbergweg 3
 – Hans, Hutmacher, Bühlstrasse 25 i
 – Hans, Maschinenmeister, Rodtmattstr. 83 I
@@ -53987,15 +53885,13 @@ Kavallerie-Remontendepots, Humboldtstr. 7 [24.435]
 – Joh., Metzger, Bümplizstrasse 117
 – Joh. Steph., Bankangest., Wylerstrasse 83
 – Joh., Wagenführer, Rohrweg 6
-– Josef Xaver, Buchhalter. Helvetiastr. 19a
+– Josef Xaver, Buchhalter, Helvetiastr. 19a
 – Josef Aug., Sattler, Tapezierer und Antiquar, Schwarzenburgstrasse 8 [24.563]
 – Jos. A., Vikar, Taubenstrasse 4
 – Julia, Weissnäherin, Freiburgstrasse 18
 – Karl Jch., Abwart. Hochbühlweg 3
 – Karl (Schmid), Coiffeur, Belpstrasse 38
 – Karl W., Hilfsarbeiter, Elisabethenstr. 34
-– Anlagenfür Privat und öffentliche Gebäude in jeder gewünschten modernen Ausführung zu annehmbaren Preisen durchsfettbacher
-Gerechtigkeitsg. 59 Telephon 21.040
 # Date: 1935-12-15 Page: 26020880/571
 Zürcher, s. auch Züricher
 – Karl, Metzgerei u. Charcuterie, Kramg. 4 [34.844]
@@ -54031,9 +53927,9 @@ S. B. B., Erlachstrasse 26
 – Traug., Bürobedarf, Papier u. Papierwaren, Frohbergweg 11 [27.257]
 – Traugott Fr., Webermeister, Frohbergw.il
 – Ulrich Ernst, Beamter S. B, B., Mühlemattstrasse 16
-– Verena M.. Arbeitslehrerin, Lentulusstr. 31
-– Walter. Automechan., Elisabethenstr. 34
-– Walter (Knutti), Bäckerei-Kondit.. Mindstrasse 10 [24.987]
+– Verena M., Arbeitslehrerin, Lentulusstr. 31
+– Walter, Automechan., Elisabethenstr. 34
+– Walter (Knutti), Bäckerei-Kondit., Mindstrasse 10 [24.987]
 – Walter Sam., Bankangest., Tiefmattstr. 12
 – Walter Louis, Beamter S. B. B., Länggassstrasse 92
 – Walter, Elektriker, Murtenstrasse 153e
@@ -54092,8 +53988,7 @@ Zurschmiede, Adolf, Konditor, Marzilistr. 8c
 – Adolf, Gärtnergehilfe, Freiburgstrasse 56
 – Alfred, Hirschengraben 8 [26.129]
 Zurukzoglu, St. J., Dr. med., Privatdozent, Anshelmstrasse 11 [24.573]
-Zust, Karl, Ingenieur, Chef der Sektion für
-Ausrüstung der Kriegstechnischen Abteilung, Humboldtstrasse 9 [24.779]
+Zust, Karl, Ingenieur, Chef der Sektion für Ausrüstung der Kriegstechnischen Abteilung, Humboldtstrasse 9 [24.779]
 # Date: 1935-12-15 Page: 26020881/572
 Züst, Emil, Schriftsetzer, Freiburgstrasse 53
 Züttel, Heinrich, Beamter der Schweiz. Oberzoildirektion, Liebeggweg 15
@@ -54121,7 +54016,7 @@ Zutter, Arnold Chr., Handlanger, Murtenstrasse 125
 Zwahlen, Adolf, Magaziner, Zeughausgasse 19
 – Alfred (Loosli), Bäckermeister, Moserstr.-Schläflistrasse 2 [21.233]
 – Alfred, Mezenerweg 10
-– Anna Karol.. Ladentochter, Freiestr. 39
+– Anna Karol., Ladentochter, Freiestr. 39
 – Anna Lydia (Holzer), Wwe., Greyerzstr. 20
 – Arnold, kaufm. Angest., Sulgenauweg 18
 – Arn., Schuhmachermeister (Kesslerg. 11), Stadtbachstrasse 8
@@ -54191,7 +54086,7 @@ Zweifel, Adolf Beda, Missionsarbeiter, Allmendstrasse 39
 # Date: 1935-12-15 Page: 26020882/573
 Zweifel Frieda (Weber), Wwe., Jubiläumsplatz 6 [34.647]
 – Heinrich, Zylindermacher, Felsenaustr. 24
-– Johann Thomas, Beamter. Karl-Schenkstr.l
+– Johann Thomas, Beamter, Karl-Schenkstr.l
 – Lena, Bureaulistin, Felsenaustrasse 24
 – Margaretha, Ladentochter, Wylerstrasse 55
 Zweili, Arnold (Weiss), Bankkassier, Reichenbachstrasse 74 [35.976]


### PR DESCRIPTION
After this change, 323 of 53584 records (0.6%) in the 1935 scan are still failing charset checks.