### PR TITLE
Givenname affix support.

### DIFF
--- a/src/process.py
+++ b/src/process.py
@@ -21,6 +21,17 @@ class Processor(object):
         self.families = self.read_families()
         self.firstnames = self.read_firstnames()
         self.given_name_abbreviations = self.read_given_name_abbreviations()
+        self.accepted_affixes = { # accepted fragments in firstnames
+          "Frau": True,
+          "Frl": True,
+          "Frl.": True,
+          "Gebr.": True,
+          "Gebrüder": True,
+          "Schwest.": True,
+          "Schwestern": True,
+          "Wittwe": True,
+          "Wwe.": True
+        };
         self.read_addresses()
         self.unknown_families = Counter()
         self.max_family_name_wordcount = max(
@@ -168,6 +179,8 @@ class Processor(object):
             if frag in self.given_name_abbreviations:
                 continue
             if self.firstnames.get(frag.lower()):
+                continue
+            if self.accepted_affixes.get(frag):
                 continue
             all_frags_found = False
         if all_frags_found:


### PR DESCRIPTION
- Add affix support for givenname lookups.

before:
records: input 1892373 -> output 465768 = 25%
family names: total 605365; known: 302067 = 50%
firstnames: total 1100821; known: 818868 = 74%

after:
records: input 1892373 -> output 466500 = 25%
family names: total 605365; known: 302067 = 50%
firstnames: total 1100821; known: 822964 = 75%