### PR TITLE
Clean up some OCR errors in 1861 scan

### DIFF
--- a/proofread/1861-04-15.txt
+++ b/proofread/1861-04-15.txt
@@ -13,20 +13,20 @@ Adam Milchhdl., Schpltzg. 210
 — Hufschmid, Käfichgäßl. 22
 Aebersold G. Pacht., Schßh. 92
 — Mgdl., Kräm., Aarzhle 28
-— Gr., Gewächshdl., i'larb. 55
+— Gr., Gewächshdl., Aarb. 55
 — I. E., Strumpfwb., Müllerlaube 23
 Aebersold I., Steinh., Schoßhallde 106
 Aebi A. B., Bettm., Hlzm. 243
 — I. R., Uhrenm., Hlzm. 243
-— Fz. L., Regt., Jnselg. 136
-— C. J.L.,Ml.,Hcrrng. 233
+— Fz. L., Regt., Inselg. 136
+— C. J. L., Ml., Herrng. 233
 — J.R.,Vergold., Gerbg. 143
 — I. S., Schr., Herreng. 300
-— R., Fürspr., Jnselg. 136 i>
+— R., Fürspr., Inselg. 136 b
 — M., Schneiderin, Aarbergerg. 69
 — J., Cigarrinhdl., Jkg. 183
 Aebischer A., Rent., Sptg. 161
-Aeschbach J., Schrein., Ag.17u
+Aeschbach J., Schrein., Ag. 17a
 Aeschbacher E., Zeughausarb., Schifflaube 56
 — Kanzlist, Matte 56
 — Lehrer, im Stadtpolizeigebäude
@@ -46,12 +46,12 @@ v. Almen Gr., Kanzl., Mtzg. 91
 Allenbach G., Spez., Spitalgasse 124
 Allemann R., Lederhändl., Bärenplatz
 — F., Sekr., 5lramgasse 179
-— Anna, Rent., Hcrreng. 203
+— Anna, Rent., Herreng. 203
 Althaus Ulrich, Schuhsticker, Schifflaube 42
 — Frau, Mchlhndl. u. Spez., Schauplatzgasse 212
 — Wtw. und Sohn, Metzger, Altenb. 164
 Altherr H. I., Spgl., Stld. 14
-Altmüller geb. Hauri, Rent., Schauplatzgassc 2<i3
+Altmüller geb. Hauri, Rent., Schauplatzgassc 203
 Ambühl R., Revisor, Marktgasse 30
 Amacher R., Schnd., Stld. 211
 Ammann J., Rent., Käsichg. 26
@@ -93,7 +93,7 @@ Bächler F. G., Flachmaler, Schauplatzgasse 224a
 Bächler J., Schneid., Spchg. 3
 Baggesen K. A., Pfr. a. Mstr., Herrengasse 322
 Bähler Elise, Mod., Käfigg. 24
-— Alb. Amtsnot., Schu!g. 296
+— Alb. Amtsnot., Schulg. 296
 — F., Courrier, Postg. 36
 — R. F., Küfer, Brunng. 36
 — I., Pächter, Altenberg 133
@@ -104,7 +104,7 @@ Bähler Elise, Mod., Käfigg. 24
 Baldesperger F., Schneider, Neuengasse 112
 — Karol., Modiste, Bollw. 83
 Ballif J. F. A., Regt., Kramgasse 210
-Balmer J. D., Äanzlist, Metzgergasse 121
+Balmer J. D., Kanzlist, Metzgergasse 121
 — H., Gärtner, Marktg. 31
 Balsiger L., Müller, Aarzl. 71
 — S. F., Rechtsag. u. Notar, Com.-Büreau, Sptlg. 162
@@ -134,7 +134,7 @@ Baumann A., Schloß. u. Spez. Matte 127
 — Jb., Lumpens., Anatg. 12
 — Jb., Aasbeseitiger, Thormann-Mätteli
 — -Werthmüller, Spezierer, Spitalgasse 174
-— Speziercr, Nydeckgasse 201
+— Spezierer, Nydeckgasse 201
 — R., Schuhm., Bollwerk 82
 — S. Bäcker, Länggasse 215
 — Frau, Schröpf., Brung. 32
@@ -222,14 +222,14 @@ Bergsträßer, Buchb., Matte 42
 # Date: 1861-04-15 Page: 1395921/67
 Beringer F. J., Reg., Mktg.62
 — W., Negt., Marktg. 62
-Berla G-, Chocoladefabr., Gerechtg. 86
+Berla G., Chocoladefabr., Gerechtg. 86
 Berner C. F. S., Spezierer, Spitalg. 164
-— -Henzi Ä. I., Spezierer, Kramg. 216
+— -Henzi A. I., Spezierer, Kramg. 216
 — A. F., Amtsnotar, Spitalgasse 165
 Bernhard I. I., Zimmerm., Hollig. 155
-— Chr., Bäcker, Kcßlg. 287
+— Chr., Bäcker, Keßlg. 287
 — R., Zimmerm., Längg. 213
-— D-, Messerschm., Neub. 243
+— D., Messerschm., Neub. 243
 — M., Schneid., Keßlerg.287
 — Fr., Strumpfwaarensabr., Länggasse 313
 Bertsch, Ndg., Bärenplah240ir
@@ -238,7 +238,7 @@ Bertschinger I. A., Registratur, Marktg. 61
 Betschen, Musikl., Schrfrg. 115
 — M. Kostgeb., Schrfrg. 115
 — Abwart, Spitalgasse 162
-Betscher Luise, Zimmer-Verm., Aarbcrg. 62
+Betscher Luise, Zimmer-Verm., Aarberg. 62
 Beutler J. C., Schneid., Kramgasse 156
 — I., Bedienter, Keßlg. 250
 — I., Flößer, Matte 51
@@ -277,7 +277,7 @@ Bigler Chr. Instrumentmacher, Zeughg. 11
 — I. I., Schnd., Aarbg. 78
 — N., Wegmstr., Sollig.139
 — S. F. I., Schnd., Ag. 25
-— M. Obsthdl., Ältb. 140
+— M. Obsthdl., Altb. 140
 — C. Modist., Zwiebg. 56
 — gb. Lehmann, Rt., Mt. 44
 — I., alt Sternenwth., Kramgasse 168 (Postgebäude)
@@ -323,7 +323,7 @@ Blaser B., Schuhm., Matte 11
 — Speisewirth, Stld. 221
 — S., Schmied, Altenb. 172
 Blaser C.C., Fing., Sptlg. 139
-— M., Speziercrin, Matte 44
+— M., Speziererin, Matte 44
 — Magd., Kräm., Brung. 20
 — Amtsnot. u. Amtsschaffner, Aarbergerg. 22
 Blatter, I. R., Kassier, Gerechtig. 117
@@ -406,9 +406,9 @@ v. Bonstetten-de Vigneule F., Rent., Judeng. 129
 Bonvin u. Comp., Weinhndl., Rathhausplatz
 — Limonadefbr., Kirchg. 273
 Bönzli M., Mod., Aarbg. 35 u
-Borel U., Ührenm., äuß. Bollwerk 264
+Borel U., Uhrenm., äuß. Bollwerk 264
 Bormann B., Schr., Brg. 1
-Born M.R., Schnd.Krmg.221
+Born M.R., Schnd., Krmg.221
 Boß E., Eisenbhn.-Kondukteur, Metzgerg. 134
 — J. C., Schuhm., Metzg. 66
 — J., Schreiner, Brunng. 34
@@ -477,13 +477,13 @@ Brunner L. F., Schreib., Kornhauspl. 50
 — S. F. R., Fürspr., Kramgasse 213
 — geb. Platel, Wtw., Kramgasse 206
 Brupbacher R. F., Werkführer, Holligen 149
-Bücher A., Bildh., Kramg. 141
+Bucher A., Bildh., Kramg. 141
 — J.Jb., Schnd., Sptla. 155
 — A. F., Schuhm., Mrktg. 77
 — I. A., Schnd., Brunng.25
 — I. R., Spengl., Grchg. 81
 — I. R., Oberst, Kramg. 144
-— hv. Trachselwald), Fräul., Junkerng. 170
+— (v. Trachselwald), Fräul., Junkerng. 170
 — Jgfr., Lehrerin, Brg. 36
 — I., Spez., Spitalg. 154
 Burkhalter, I., Schuhmacher, Schaupltzg. 207
@@ -538,12 +538,12 @@ Burkhalter V., Kübler u. Hecht., Matte 5
 — R., Bettmach., Brung. 25
 — S., Tuchhdl., Keßlerg. 253
 — Steinhauer, Brung. 34
-Burkhardt F., Cigarrenmachcr, Aarziehle 28
+Burkhardt F., Cigarrenmacher, Aarziehle 28
 — Jb., Lohnwasch, Altb. 147
 — R., Lohnbcd., Junkg. 149
 — Anna B., Lehrerin, bei der kl. Schanze 184
 — R., Kramerin, Grchtg. 117
-— I., Schuhm.,Läuferpl.22?
+— I., Schuhm., Läuferpl. 227
 Bürki A. F., Großrath, Judeng. 128
 — -Jenner, Judeng. 128
 — Chr., Buchhlt., Kramg.160
@@ -647,7 +647,7 @@ Crinsoz G., Kanzl., Krmg. 209
 Cueni A. I., Schrb., Bill. 166
 Cürchod L., Telegr.-Direktor, Gercchtg. 85
 Dachs F. W., Regt., Grchtg. 65
-Dähler C. R., Gürtl., Bg! 30
+Dähler C. R., Gürtl., Bg. 30
 — Frau, Strohhutsabrikant, Kramg. 185
 — J. C., Archit., Rabbenthal
 — I. B., Trödl., Junkg. 195
@@ -751,7 +751,7 @@ Dünki I. E., Buchbd., Marktgasse 78 u. 81
 — L. C. L., Amtsgerichtschrb., Kramg. 168
 # Date: 1861-04-15 Page: 1395929/75
 Dünki A. E. C., BuM., Kramgasse 168
-— I., Kamins., Brunng. 13
+— I., Kaminf., Brunng. 13
 Dünz D. E. S., Armenpflg., Aarbg. 6l
 — R. A., Schneid., Aarz. 36
 — I. L., Substitut, Aarbg. 37
@@ -792,7 +792,7 @@ Edele I., Musikdir., Mrktg. 94
 Edinger F., Lehr., b. Linde 169a
 Edler R., Uhrenm., Krmg. 187
 v. Effinger geb. v. Wagner, Ww. Rent., Maisonette 169
-— allié Jenncr, Gemeindspr. Kirchg. 260
+— allié Jenner, Gemeindspr. Kirchg. 260
 — L. R., Gutsbes. v. Wildegg, Junkerng. 150
 Egg H., Kanzlist, Zeughg. 9
 Eggen, Wwe., Möbel- u. Bettwaarenhändl., Aarbg. 15
@@ -870,19 +870,19 @@ Fankhauser Chr., Gärtn., Keßlerg. 239
 — Wittwe, Sattler, Aarb. 64
 — Mrg., Chemisière, Süd. 10
 — H., Wirth, Kästchg. 106
-— Ä., Speisew., Zwblg. 41
+— A., Speisew., Zwblg. 41
 — Wtw., Küchl., Fwbstg. 41
 — S., Schuhm., Postg. 28
 — Charlotte, Lehr., Läng. 214
-— geb. Mcttler, Wäscherin, Matte 87
-Faßbind, Sekr-, Ncueng. 91
+— geb. Mettler, Wäscherin, Matte 87
+Faßbind, Sekr., Neueng. 91
 — Fanny, Ladengeh., Marktgasse 71
-Faßnacht S-, Werkmstr., schw. Thor 100
+Faßnacht S., Werkmstr., schw. Thor 100
 — I., Schneider, Aarbg. 40
 — S. H., Schnd., Nng. 105
 — Frau, Hebamme, Aarbg. 40
 Fay, nordamerikan. Gesandter, Gerechtigkcitsgasse 85
-Fehlbaum, I., Kammmacher, Metzgcrg. 76
+Fehlbaum, I., Kammmacher, Metzgerg. 76
 — A., Büreauchef, Grchtg. 76
 — I. S., Schreiner, Postg.57
 Fehlmann A. M., Schneiderin, Schauplatzg. 213
@@ -891,10 +891,10 @@ Fehr I. C., Tel.-Büreauchef, Gerecktg. 70
 — geb. Wäber, Linq., Kramgasse 203
 v. Fellenberg-Rivier, L. R., Pros., Roscnbühi 157 b
 — E. L., gew. Kuchthauspred., Junkerng. 185
-— (v.Hofwyl) E-, Jkg. 185
-— (v.d. Wegmühlc) Gehg.90
-— geb. Zeer!eder, Junkg. 179
-Fester D., Schuhm., Sptg. 177
+— (v. Hofwyl) E., Jkg. 185
+— (v. d. Wegmühle) Gchg. 90
+— geb. Zeerleder, Junkg. 179
+Feller D., Schuhm., Sptg. 177
 — Tapezierer, Gerechtg. 85
 — Schriftsetzer, Spitalg. 169
 Feller, D., Lieh., Metzgerg. 94
@@ -911,18 +911,18 @@ Felsch I., Schnd., Schpltzg.208
 Ferrand C., Coiff., Krmg. 214
 Ferraris I., Gypser, Gchtg.116
 Ferrier A.R., Rt. Kornhpl.121
-Fetscherin A. A. Vater,». Sohn, Hafnerm., Aarbg. 68
+Fetscherin A. A. Vater u. Sohn, Hafnerm., Aarbg. 68
 — C., Schlosserm.,Bllw. 262
 — E.,Buchbd., Reueng. 107
-— -Ris Keinr., Kandelsm., Markst,. 41
+— -Ris Heinr., Kandelsm., Markst,. 41
 — C. L., Rotar, Kästchg. 96
-— -Lichtenhabn G.W., Lehr., Salzbüchsli
+— -Lichtenhahn G. W., Lehr., Salzbüchsli
 — F. R. A., Schlossermcister, Kästchg. 20
 — C. C. P., Quincailleriehändl., Marktg. 34
-- J. F.,V V A, Bibliothek., Altenb. 115
+- J. F., VDM, Bibliothek., Altenb. 115
 Fey P., Train-Insp., Bllw. 263
 — L.. Spiegelhdl., Grchtg. 98
-Fiala Max., Äuchhl.-Commis, Marktg. 51
+Fiala Max., Buchhl.-Commis, Marktg. 51
 — F., Modistin, Spitalg.153
 Fiechter P., gew. Kondukteur, Postg. 33
 Fiesinger F., Lehrer, Falkenplätzli 217
@@ -931,7 +931,7 @@ Figuet C. H., Tapez., Mt. 120
 Filippini-Pedrazzi, Fümiste, Gerechtg. 110
 # Date: 1861-04-15 Page: 1395932/78
 Finger A., Sckneid., Aarz. 26 u. Marktg. 92
-v. Fischer-Oostcr A. F. R.,Hotell. 292
+v. Fischer-Ooster A. F. R.,Hotell. 292
 — -Bondeli L. C. A., Bang., Spitalg. 129
 — -Lüthard, C. F. E., Hotellaube 232
 — E. F. L., Dr., Professor, Bvllw. 264
@@ -962,21 +962,21 @@ Fischer Frz., Offiz., Keßlg. 246
 — Luise u. Carol., Schneider., Metzgerg. 71
 Fleuti I., Schneid., Zeugh. 12
 — Schwest., Schn., Kfig. 103
-Flogcrzi,A., Kellerh., Jkg.160
+Flogerzi, A., Kellerh., Jkg.160
 Flohr I. A., Klaviermacher, Monbijou 94
 Flückiger I., Schr., Aarz. 22
 — Dr., Staatsapoth., Inselgasse 132
 — Sekr., Aarz. 43 b
-— Lumpenbl., Speicherg. 6^
+— Lumpenhl., Speicherg. 6 g
 — I., Schneid., Aarbg. 20
-— S., Maler ». Gvps., Gerberngr. 139
-— Bäurisch-Schn. Krmg. 221
-— J.U., Metzg. 89
+— S., Maler u. Gyps., Gerberngr. 139
+— Bäurisch-Schn., Krmg. 221
+— J. U., Metzg. 89
 — Chr., Schneid., Aarbg 59
 — F., Negt., Altenb. 164
 — P., Fuhrhl., Längg. 252
 Flügel C., Notar, Mßlerg. 282
-—'S.,Alt-Dekan, Krmg. 143
+— S., Alt-Dekan, Krmg. 143
 — F., Tuchnegt., Kramg.223
 — C.G.R., Brodb., Kßg. 281
 — S. F., Almos., Krmg. 157
@@ -984,35 +984,35 @@ Flügel C., Notar, Mßlerg. 282
 Fluri L., Lehrer, Zeughpl. 251
 — Feuerwerker, Matte 81
 Fontanellaz, D., Weinhändl., Metzgerg. 126
-v. Forer E. C. A., gew. Hptm. in Neapel, Judcng. 125
-Fornaro geb. Leurct, Rentiere, Jnselgasse 136
-Fornerod C., Bd.-Rath-, Rabbenthal
-Forster-Rommel H.,Negotiant, Marktg. 71 u. 54
+v. Forer E. C. A., gew. Hptm. in Neapel, Judeng. 125
+Fornaro geb. Leurct, Rentiere, Inselgasse 136
+Fornerod C., Bd.-Rath., Rabbenthal
+Forster-Rommel H., Negotiant, Marktg. 71 u. 54
 — -Schauenberg, Färb., Postgasse 58
 Fotsch B., Strumpfstuhlschlssr., Hollig. 149
 # Date: 1861-04-15 Page: 1395933/79
 Frank L., Messerschm., Keßlergasse 276
 — Ed., Musikdirekt., schwarz. Thor 101
 Franke L., Tanzlehrer, Zeitglockenthurm 228
-Frauckiger, B., Notar, Rabbenthal.
-— A., Sessels!., Gerechtg. 69
-— F., Strohflech., Stldj 211
+Frauckiger, B., Notar, Rabbenthal
+— A., Sesselfl., Gerechtg. 69
+— F., Strohflech., Stld. 211
 Frautschi, Angest. auf d. Centralpolizei, Käfichg. 105
 Frei M., Damenschn., Brunng. 9
 — L., Schreinermstr., Schauplatzg. 209
 — Jb., Schreiner, Matte 58
 — -Herose, Bundesrath, Gerechtg. 132
-Freiburger I. G., Lithograph und Negotiant, Metzg.94
+Freiburger I. G., Lithograph und Negotiant, Metzg. 94
 Freiburghaus Chr., Leinewb., Stalden 203
 Freidig I. I., Adjunkt, Arz. 26
-Freudenbcrgcr Frau, Kßlg. 238
+Freudenberger Frau, Kßlg. 238
 Freudenreich-Falconnet A., Rt. Spitalg. 154
 — Fräul., Ncnt., Junk. 177
 Freudiger Jb., Schuhmacher, Müllerl. 133 u. 134
 Frey-Hubacher R. A., Jdg. 130
 — C., Sekr. d. Tel.-Direkt., Altenb. 164 u
 — I., Zins.-Red. Tiefenau
-— A., Tcl.-Jnsp., Grchtg.65
+— A., Tel.-Insp., Grchtg.65
 — 2-, Zugführ., Altb. 142 n
 — Wtw. d. Lohnt., Judg. 127
 Freytag I. I., Quincaill.- u. Spielzeughrndlg., Marktgasse 86 u. 72
@@ -1027,7 +1027,7 @@ Frikart PH., Wirth, Aarbg. 67
 v. Frisching, Major, Junkg. 171
 Fritschi Jb., Schr., Aargst.128
 — Schmiedmstr., Käfichg. 110
-Frölich A. G-, Schulvorsteher, Monbijou 94
+Frölich A. G., Schulvorsteher, Monbijou 94
 Frutiger, Jb., Schuhm., Postgasse 23
 Fuchs L. M., Ober-Postcontrll., Spitalg. 135
 — F. N., Schuhm., Kßlg.289
@@ -1040,13 +1040,13 @@ Fueter E. F., Eisennegotiant, Falkenplätzlein 217 b und Marktgasse 58
 — geb. Bücher, Wtw. d. Pros., Marktg. 42
 — Wtw. des Apothekers, Gerechtg. 119
 Furer I. F., Hutm., Rng. 103
-— C.F.,Amtsn., Marktg. 64
-— I- R., Juckcrb., Mrktg.65
-Furrer I., vr., Bundesrath, äußere Billette 166 d
+— C. F., Amtsn., Marktg. 64
+— I. R., Juckerb., Mrktg. 65
+Furrer I., vr., Bundesrath, äußere Billette 166 b
 — geb. Bühlmann, Mehlhdl., Marktg. 35
 Füri I. I., Lehrer, Schoßh. 95
-Gaffner F., Sternenwirkh, Aarbergerg. 34
-Gaag Ä., Spielkartenfabrikt., Altenb. 158
+Gaffner F., Sternenwirth, Aarbergerg. 34
+Gagg A., Spielkartenfabrikt., Altenb. 158
 # Date: 1861-04-15 Page: 1395934/80
 Gagnebin, Oberr., Kramg. 180
 Gambazzi H., Caffeew., Kramgasse 175
@@ -1054,13 +1054,13 @@ Gammeter Frau, Keßlerg. 256
 Gander Chr., Wirth i. d. Enge
 — Jb., Schn. Matte 42
 Ganguillet A., Ncg., Mrktg. 39
-— E-, Obcringcn., Nng. 121
+— E., Oberingen., Nng. 121
 Garnier, Oberricht., Zcughg.8
 Garraud, I. Cbr., Schreiner, Falkenplatzti 212
 Garraux J., Echr., Gerechtigkeitsgasse 131
 — I. F., Schr., Flkenegg 223
 — gb. Gfeller, Bäurischichn., Gerbg. 131
-Gartenmann, Jnnkerng. 185
+Gartenmann, Junkerng. 185
 Gaschen I. R., Lohnbedienter, Speicherg. 6
 — I., Graveur, Aarbg. 33
 Gasser Cbr., Kanzl., Aarbg. 28
@@ -1080,71 +1080,72 @@ Gatschet F.M.,Rt., Kßlg. 240
 — F. A., gewes. Ealzkassier, Bierhübcli 265
 — -Allemandi, Frau, Junkerng. 172
 — L.S.A., gew. Präs. d. Feld- u. Forstcom., Marktg. 56
-Gaudard-Schmittcr, F. A., Negot., Mktg. 68 u. Flkpl217ä
+Gaudard-Schmitter, F. A., Negot., Mktg. 68 u. Flkpl217ä
 Gaudard I. A. E., Spengler, Keßlerg. 284
 — F. F., Amtsnotar, Herrngasse 321
 Gäumann Chr. Schuhmacher, Obstberg 30
 Gautschi S., Lohnkutsch., Käfichg. 99
 — gb. Jakob, Hebam., Kfg. 99
 Gebner, S., Condit., Mktg.37
-Geiser N.,Amtsnt.,Kring. 225
-— I., Sehr., Salzm. 236 '
-— F. 2l., Schnd., Kcßlg. 167
-Geißler I. F., Schuhmacher, — Metzg. 124
-Gelhaar Jgfr., Linicrerin, Gerechtg. 98
+Geiser N., Amtsnt., Krmg. 225
+— I., Schr., Salzm. 236
+— F. A., Schnd., Keßlg. 167
+Geißler I. F., Schuhmacher, Metzg. 124
+Gelhaar Jgfr., Liniererin, Gerechtg. 98
 Gempeler, R., Dachd., Schauplatzg. 216
 Gerber S., Kappenm., Zwieb.gäßchen 61
-— Ä. L., Strobbutfabrikant, Insclg. 134'
-— Dr. Pros., Bollw. 265. , — Frau, Hcbam., Neucng. 95
-— M., Modist., Speichg. 7 '
+— A. L., Strohhutfabrikant, Inselg. 134
+— Dr. Prof., Bollw. 265
+— Frau, Hebam., Neucng. 95
+— M., Modist., Speichg. 7
 — N., Krämer, Aarbg. 61
 — I., Steinst., Postg. 30
-— Cbr., Schnd., Zeughg.9
+— Cbr., Schnd., Zeughg. 9
 — Jb. Schmied, Speichg. 7
-— Z. Jb. E., Silberschmieds, Schifflaube 51
+— Z. Jb. E., Silberschmied, Schifflaube 51
 — S., Regt., v. Schlößli üb. die Muesmatte 179
 — E., Schneid., Postg. 34
-— Vikar, Jnnkerng. 195
-— A., Schreiner,Aarbg. 72
-— G., Kutscher, Grcchtg. 139
-— D. L^, Schnd., Aarbg. 51
-— S., Bäcker, Hcrreng. 304
-— C., Tabak- u. Cigarrcnhdl., Marktg. 77
+— Vikar, Junkerng. 195
+— A., Schreiner, Aarbg. 72
+— G., Kutscher, Grechtg. 139
+— D. L., Schnd., Aarbg. 51
+— S., Bäcker, Herreng. 304
+— C., Tabak- u. Cigarrenhdl., Marktg. 77
 — geb. Drechsler, Modistin, Marktgasse 77
 # Date: 1861-04-15 Page: 1395935/81
-Gerber gb. Dennler, Ww., Nt., Spitalg. 168
-— ? , 2!»gest. a. d. Jnsti, dir. Kreuzg. 103
-— Gebr., Käökdl.,Strb. 179
-— U., Milcbbdl., (?n,gc 10
-— H., Butterhdl., Gr.htg. <7,
-— U., Weipiuül., Ketzlg. 291
+Gerber gb. Dennler, Ww., Rt., Spitalg. 168
+— L., Angest. a. d. Justizdir., Kreuzg. 103
+— Gebr., Käshdl., Stdb. 179
+— U., Milchhdl., Enge 10
+— H., Butterhdl., Grchtg. 75
+— U., Weißmül., Keßlg. 291
 — U., Pächter, Slltcnb. 181
 — M., Kram., Scbauplg. 811
-Gerig Ww., Fonrn/crs. Matte
-Gerster <5. B., Architekt, Spci-chcrgassel
-— S. Ä., Amtsn., Judg. 115
-— S. F., Rent., Mctzg. 180
+Gerig Ww., Fournier f. Matte
+Gerster C. B., Architekt, Speichergasse l
+— S. R., Amtsn., Judg. 115
+— S. F., Rent., Metzg. 180
 — S. W., Schrb., Jdg. 115
 — Jgfr. Maria, Judeng. 115
-— S. A., P.uarticrattitschef, Gerechtg. 91
-Gerwer B. Chr., Pros. Scharfriäiterg. 111
-— C. F./Sberrichtcr, eidgen. Oberst, Bvliw. 265
-— 9., Schreib., Gerechtg. 1l»8
-Gcx M. Schneid., Mehg. 61
-Gseller B., Küfer, Markte,. 38
+— S. A., Quartieramtschef, Gerechtg. 91
+Gerwer B. Chr., Prof., Scharfrichterg. 111
+— C. F., Oberrichter, eidgen. Oberst, Bollw. 265
+— L., Schreib., Gerechtg. 103
+Gex M. Schneid., Metzg. 61
+Gfeller B., Küfer, Marktg. 33
 — H., Pächter, Altenb. 187
-— I. Jb., 9irhvgr., Mktg. 80
-— I., Schubm.,' Stald. 217
-— I. F., Schubm., Arbg. 58
+— I. Jb., Lithogr., Mktg. 80
+— I., Schuhm., Stald. 217
+— I. F., Schuhm., Arbg. 58
 — I., Pächter, Holiig. Illl
 — I., Bäcker, Schpltzg. 219
-— I. ?., Schneid., 2lr^. 218
-— Wittwe u. Söhne, Stein!, Schaupltzg. 283
-— R., S chwc im»., S cbg .217
-Gilgen J., Schuh,»., 2Retzg.88
-— Jb., Schneid., Spitz. 166
+— I. L., Schneid., Arz. 218
+— Wittwe u. Söhne, Steinh., Schaupltzg. 283
+— R., Schweinm., Schg. 217
+Gilgen J., Schuhm., Metzg. 88
+— Jb., Schneid., Spitg. 166
 — R., Schneid., Aarbg. 56
-Gillicron, D., Rt., Holiig. 1K>
+Gillieron, D., Rt., Holiig. 1K>
 Giobbe I., Taphdl., Schg. 217
 Girardet F. Uebers.,Krmg.111
 Giordani, Gipser, Gerechtigkeitsg. 116
@@ -1157,17 +1158,17 @@ Glan'pnann I., Strumpfwb., Matte 19
 Glaser, Schuhn,., Schg. 208
 Glättli H., Hafner, Holiig. 189
 Glauser, Pferdblt., Junkg. 117
-— G.F., Kamins., Brunng. 3
+— G.F., Kaminf., Brunng. 3
 — I., Steinh., Matte 16
 — P., Hoizhdl., Postg. 85
 — S., Vehrer, Postg. 28
 — C., Schnd., Krauig. 221
-— Chr., Mctzg., Brunng. 3
+— Chr., Metzg., Brunng. 3
 Glai, Jb., Koblenhändl., Äüllerlaube 88
 — Rnd., Speisew., Stld. 221
 Glinz I., Buchb., Sptlg. 177
-Gloor I. H., Kappenmachcr, Spitalg. 113
-— geb. Götti, Krankenwärt., Äarbg. 10
+Gloor I. H., Kappenmacher, Spitalg. 113
+— geb. Götti, Krankenwärt., Aarbg. 10
 — Wtw., Spitalg. 167
 Glotz, Kubier, Schaupltzg. 2i!3
 Glur Jb., Schlosser, beiin unt. Thor 225
@@ -1184,20 +1185,20 @@ Gorge N., Revisor, Quästor V. Hochschule, Ilarbg. 52
 Gosteli Jb., Schnd., Matte 81
 # Date: 1861-04-15 Page: 1395936/82
 Gosteli, Kondukt., Käfichg. 98
-Gotticr Chr., Färber, Hllg. 149
+Gottier Chr., Färber, Hllg. 149
 Götz Chr., Kaffeew. Krmg.161
 v. Goumoens - v. Tavel, Wwe., Reut., Billette 168
-— E. R., Vcrwl., Krmg. 142
+— E. R., Verwl., Krmg. 142
 — -v.Stürlersv.Chcsaux)A., Rent., Kreuzg. 105
 — A. C., Rent., Kramg. 152
 — Luise, Kramg. 167
 — - gb. o.Sinuer, Frau, Kramgasse 172
-Gräs G-, Schreiner, Bubenbergrain 64
+Gräs G., Schreiner, Bubenbergrain 64
 — L. H., Schr., Metzg. 136
 Graf L. Th., gew. StandeSkas. Markta. 91
-— C., Mcsserschm.,Krmg. 169
+— C., Messerschm., Krmg. 169
 — Jgfr., Inselg. 138
-— I. P. E-, Schriftsetz., Altenb. 170
+— I. P. E., Schriftsetz., Altenb. 170
 — N., Schmied, Altenb. 117
 — v. Graffenried B. A., Billette 103
 — u. Comp., Kramg. 146
@@ -1213,9 +1214,9 @@ Graf L. Th., gew. StandeSkas. Markta. 91
 — C. A., Arch., Junkg. 181
 — F., Rent., gew. Offizier in Frankreich, Kramg. 186
 — F. A. Hasnerm., Hrg. 306
-Granicher, G-, Schweinmetzg., Schauplatzg. 207
+Granicher G., Schweinmetzg., Schauplatzg. 207
 Granicher B., Sattl., Lgg. 267
-— F- G., Jng., Gcrecbtg. 102
+— F- G., Ing., Gerechtg. 102
 Grau S., Krämer, Bruung. 30
 v. Graviseth, Frl., Junkg. 176
 Graydon, Rent., z. d. Th. 183
@@ -1231,16 +1232,16 @@ Grieser I. M., Schuhmacher, Matte 24
 Grimm I. M., Milchhändler, Neu eng. 107
 — F. R., Wattcnfabr., Kramgasse 147
 — geb. Lutfiorf Rt. Mtzg. 130
-— C-, Kräm., Nydeckg. 234
+— C., Kräm., Nydeckg. 234
 — S., Gärtner, Längg. 201
 Griesel M., Schmied, Spitalgasse 162
-Groß C-, Arzt, Junkerng. 183
+Groß C., Arzt, Junkerng. 183
 Großenbacher Jb., Weißmüller, Aarz. 77
 Großenbacher I. F., Schneid., Matte 83
 — N., Kondukt., Metzg 77
 — Jb., Bäcker, Herreng. 304
 — F. E., Aorbm., Matte 80
-— A. B-, Kräm., Mrktg. 31
+— A. B., Kräm., Mrktg. 31
 — Mehlhändl., Sptlg. 125 u
 Großglaufer N. G., Tabakfab., Längg.200
 — Zimmerm., Längg. 154
@@ -1264,7 +1265,7 @@ Grüner I. F., Graveur, Bollwerk 267
 — W. R., Sattl., Keßlg.244
 — R., Abwart der Stadtbibl., Kramg. 215
 Gründer, I., Neueng. 122 b
-Gschwind M., Gilctmacherin, Aarbcrg. 29
+Gschwind M., Gilctmacherin, Aarberg. 29
 — W., Calandr., Aarbg. 29
 Gubler, Sämcidermst., Stld.6
 Güdel N., Büchsenmacher, Gerechtg. 90
@@ -1290,39 +1291,39 @@ Gutknecht C., Buchdruck., Metzgerg. 91
 — Schreiner, Marktg. 92
 Gutmaun Schwestern, Schnd., Metzg. 106
 — Schlosser, Matte 95
-Gwinncr Jb., Farbenfabrik., Altenb. 174
+Gwinner Jb., Farbenfabrik., Altenb. 174
 — J.,Flachm., b. u.TH.226
 — G. D., Buchb., Postg.43 d
-Gygcr F., Thierarzt u. Speisewirth, Aarbg. 46
+Gyger F., Thierarzt u. Speisewirth, Aarbg. 46
 — Frau Pfarr. u. Töchtern, Marktg. 64
 — Clise, Cravattenmacherin, Marktg. 64
-Gylam R-, Abwart d. Baudir., Kirchg. 314
-Haag G., Ncg., Altenbcrg 180
-— geb. Fischer Frau, Rcnt., Kramg. 139
+Gylam R., Abwart d. Baudir., Kirchg. 314
+Haag G., Ncg., Altenberg 180
+— geb. Fischer Frau, Rent., Kramg. 139
 — -Keller, Neueng. 113
-— S. R.,Jng., Postg. 43 »
-— C. G-, Schreib., Stald. 17
+— S. R., Ing., Postg. 43 »
+— C. G., Schreib., Stald. 17
 — A., Schuhm., Neueng. 108
 Haari, Wwe., Steinbrech., am Spiegel
 # Date: 1861-04-15 Page: 1395938/84
-Haas I., Notar, Altcnb. 160
-— G-, Zuckerbäck, Grchtg.135
-— I-, Mnsika!icnh.,Keß'g.257
+Haas I., Notar, Altenb. 160
+— G., Zuckerbäck, Grchtg.135
+— I., Mnsika!icnh.,Keß'g.257
 — F. (5., Fürspr., Metzg. 101
 — Frau, Corsetm., Brng. -12
-Habeggcr I., Wcgkn. Hllg. 148
-— Frau, Schneiderin, Aarbcrgcrg. 82
+Habegger I., Wcgkn. Hllg. 148
+— Frau, Schneiderin, Aarbergerg. 82
 — N., Bnlterhdl.,Neueng. 90
 — Ib., Metzg., Neubrücke
-Häberli Chr., Reg., Gcrcht.125
-— Chr., Sattler, Bvllw. 81
+Häberli Chr., Reg., Gercht.125
+— Chr., Sattler, Bollw. 81
 — Chr., Courtier, Metzg. 120
 — Ib., Ilhrenhdl., Sptg. 142
 — Cdr., Commis, Spt'g.142
 — I!., Zimmermeister, Schauplatzg. 238
 Hablützel D. 13 F., Kanzlist, RathhSp'tz. 52 !
-— C-, Bicrbr., Ratbhspltz.52
-— I., Bicrwirth, Matte 92
+— C., Bierbr., Ratbhspltz.52
+— I., Bierwirth, Matte 92
 Hadern Jb., Schreiner, Ätg. 91
 — geb. Fankhanser, Käshdl., Aarz. 15
 Häselen-Schenk, Blasinstrumentm., Marktg. 80 u. 40
@@ -1331,28 +1332,28 @@ Häselen-Schenk, Blasinstrumentm., Marktg. 80 u. 40
 — C., Adjunkt, Aarbergg. 43
 Häfelin F., Kanzlist, Schg. 198
 — C., Adjunkt, Junkerng. 158
-Hagen C-, Prof., Falkenpl. 217
+Hagen C., Prof., Falkenpl. 217
 Hager L. G., Bäcker, Schifft. 47
 — Chr.,Schneid., Neueng.92
-— D., Zimmcrniann, Bollwerk 263 o
+— D., Zimmermann, Bollwerk 263 o
 Hahn-Lchnyder R. L., Amtsnotar, Kornhauspl. 48
 Hähni I., Amtsnotar, Käfg. 28
 Halber, Erbschaft, Zuckerbäcker, Marktgassc 65
 Haldi, Frau, Aarbergg. 52
 Haldimann A., Lith., Stald. 3
-— I-, Flößer, Salzmag.238
+— I., Flößer, Salzmag.238
 — I., Mechaniker, Matte 47
 Hakler I. E. F., Spitalprediger, Schwarzthor 10!, Ablage im Burgerspital
 — Bs F., Vater, Neck. Du., Buchdruckereibes., Marktgasse 39
 — R. F., Sohn, Buchdrucker, Aarbergg. 49
-— I., Mühlem., Staldcn 13
+— I., Mühlem., Stalden 13
 — Frau, Hebamme, Stald. 13
 v. Hallwyl-v. JmhosTH., Rentier, Kramg. 192
 Hambcrger I., Lehrer, Falkenplätzli 272
 — geb. König, Renk., Kreuzgasse 103
 Hämmert!, I., Briefträger, Brunng. 28
--- E., Kanzlist, Zwiebg. 94
-Hanharl I. i^b., Kupferschmd., Staldcn 2
+— E., Kanzlist, Zwiebg. 94
+Hanhart J. Jb., Kupferschmd., Stalden 2
 Hänni, Frau, Kostgcb., Metzgergasse 77
 — J., Schuhm., Metzg. 77
 — geb. Josl, Rent., Schg. 227
@@ -1362,7 +1363,7 @@ Hänni, Frau, Kostgcb., Metzgergasse 77
 — N., Speisewirth u. Sattler, Speicherg. 6o
 — I., Barbier, Käfichg. 103
 — G., Bannwart, Hollig. 156
-— A-, Hebamme, Zeuqhg. 9
+— A., Hebamme, Zeuqhg. 9
 — I., Rechtsagt., Aarberg. 47
 — I.H., Schreiber, Poitg. 32
 — A., Schncidr., Jdg. 113u
@@ -1372,10 +1373,10 @@ Hänni, Frau, Kostgcb., Metzgergasse 77
 Hanslin-Kurz, Wittwe, Glaser, Kirchgasse 272
 # Date: 1861-04-15 Page: 1395939/85
 Hanslin gb. Mühlemann, Kostgeber., Brunng. 19
-Hänzi N,, Salzwaagmcistcr, Billette
+Hänzi N,, Salzwaagmeister, Billette
 Harder, geb. Bücher, Sptlg.161
 — geb. Wcnger, Schg. 201
-Harrcr, geb. Kablützel, Rent., Marktg. 94
+Harrer, geb. Kablützel, Rent., Marktg. 94
 Harri, Spczierer, Stalden l
 Hartmann C. D. E., Privat.
 — F., Schneider, Altenb. 172
@@ -1384,13 +1385,13 @@ Hartmann C. D. E., Privat.
 Hasler A., Amtbnot. u. Rechtsagent, Marktg. 91
 — Chef derTelcg.-Werkstätte, Postg. 32
 — I. R., Schndr., Stald. 15
-Häslcr, Pferdhlt., Schulg.332
+Häsler, Pferdhlt., Schulg.332
 — Schreiner, Spitalg. 136
 Hässig, geb. König, Junkg. 182
 — L. G., gew. Buchhändler, Metzgerg. 102
 Haßlinger, Wittwe und Sohn, Schlosser, Käfichq. 102'
 Häubi Jb., Metzger, Stald. 17
-Haudcnschild, Neueng. 86
+Haudenschild, Neueng. 86
 Hauert S., Daebd., Anatg. 11
 Haueter D., Sattl., Grcktg. 71
 — Frau, Göllerkm., Frick 77
@@ -1421,14 +1422,14 @@ Heger A., Schuhm., Matten 37
 Hegg Schwest., Strickwaarenhandlung, Kramg. 197
 — Joh. Eman., Commis der >Lalzhandi., Kramg. 197
 — F., Wcgknecht, Längg. 198
-Heim R. A.', Tap., Grchtg. 96
-— F. C.,Bricftrg.,Altbg.182
+Heim R. A., Tap., Grchtg. 96
+— F. C.,Brieftrg.,Altbg.182
 — C. D., Brieftrg., Krzg. 103
 — Schwest., Schneiderinnen, Marktg. 57
 — Frau, Hebamme, Gerechtg.
 — M., Schneid., Metzg. 80
 Heimel C., Amtsnotar, Kramg. 175
-Heinigcr, geb. Brugger, Schuhmacher, Kramg. 175
+Heiniger, geb. Brugger, Schuhmacher, Kramg. 175
 — Postcommis, Kramg. 175
 — 2. R.,Armenpstg., Mtt. 45
 — 2. F., Maler, Brunng. 6
@@ -1449,9 +1450,9 @@ Hemmann F. E., Quartieraufseher, Brunng. 35
 Hemmerling M., Broderie- und Wollwaarenhdl., Mktg. 57
 Hendrich C. F., Schreiner, Schauplg. 204
 Henzi I. F., Gutsbes., gew. Ammann, Stadtbach 181, Ablage Marktg. 63
-— R.,Or.lH6c1., Jnselg.1361>
-— B., cidg. Pulvervcrwalt., Rabbenthal 155
-— Ww.d. Pros., Jnsg. 136e
+— R.,Or.lH6c1., Inselg.1361>
+— B., eidg. Pulververwalt., Rabbenthal 155
+— Ww.d. Pros., Insg. 136e
 — F. S.,Ktsbuchh.,Mtzg.130
 — S., Schuhhdl., Krmg. 159
 — R.F.,Amtsnt.,BUw.263n
@@ -1471,7 +1472,7 @@ Hermann-Genton, Bäcker, Spitalgasse 163
 — Cmilie, Modiste, Kßlg. 281
 — Mechaniker, Kästchg.25
 — I. F., Krämer, Keßlg. 291
-Herrmann A. N., Untcrweibel, Matte 38
+Herrmann A. N., Unterweibel, Matte 38
 — A., Advokat, Speicherg. 8
 Hermingard, Elisc, Sptlg. 139
 Herrenschwand, Frau u. Tocht., Bollw. 263o
@@ -1479,7 +1480,7 @@ Herrenschwand, Frau u. Tocht., Bollw. 263o
 Herndl M., Schuhm., Bg. 3
 Herter, geb. Roth, Gastwirthin zum Affen, Kramg. 184
 — I., Metzger, Zwiebg. 59
-Hertig J.,Jnstrum., Schg. 227
+Hertig J., Instrum., Schg. 227
 — Jb., Metzger, Metzg. 89
 Hery, 2ckweft.,Ling., Postg.24
 — I., Parfümeriehdl., Kramgasse 141 u. 142
@@ -1504,26 +1505,26 @@ Hidbcr B., vr. Lehrer, Junkerng. 177
 Hiltiold I., Auswandergsagt., — Aarbergg. 43
 Hiltbrunner-Oppliger, Hbam., Aarbergg. 28
 — S., Hufschmied, Bllw. 83s
-— I-, Fetthändler, Aarbg. 33
+— I., Fetthändler, Aarbg. 33
 Hirs C., Ghpser, Marktg. 31
 Hirsbrunner Ehr., Flachmaler, bei'r Linde
 — F., Stcinhauer, Aarz. 46
-— C., Drechsler, Altcnbg. 74
+— C., Drechsler, Altenbg. 74
 — Metzger, Schifflaube 43
 Hirschgartner H., Bildhauer, Monbijou 94
 Hirschi H., Instrukt., Zghg. 5
 — Fr., Schauplg. 226
-HirstgcrJ.S.,Grtn., Läng 114
+Hirstger J. S., Grtn., Läng 114
 — Träg. d. Intelligenzblattes, Inselgasse 131
-Hirt C.,Mühlcm., Matte 57
+Hirt C., Mühlem., Matte 57
 — N., Lehrer, Länag. 201
 — S., Schuhm., <Ltald. 215
 — B., Speisen'., Stald.221
-Hirtcr I., Schiffmstr., Mit. 42
+Hirter I., Schiffmstr., Mit. 42
 Hirtuni u. Neyncns, Kleidhdl., Junkerng. 162
 Hochstcttler C., Gasanzünder, Schauplg. 203
 Hockstraßer Jb., Schrn., Junkerng. 193
-— J-Ä-, Schneider, Kßg. 277
+— J. Ä., Schneider, Kßg. 277
 Holoch, Messerschm., Krmg.211
 Hodel L., Buchbinder, Neueng. 104 6
 Hodler I., Schuhni., Metzg. 84
@@ -1544,7 +1545,7 @@ Hofer M., geb. Brand, Speisewirthin, Judeng. 113
 — J., Bürstenm., Schg. 221
 — I., Büchsenschm., Matte 46
 — I., Schuhm., Brunng. 24
-— P., Mchlhdl., Klapperl. 29
+— P., Mehlhdl., Klapperl. 29
 — F., Schneider, Brunng. 19
 — N., Gürtler, Metzg. 75
 — I., Trödler, Speichern. 6b
@@ -1553,7 +1554,7 @@ Hofer M., geb. Brand, Speisewirthin, Judeng. 113
 — I. H., Kammmch., Stald. 4
 — geb. Siggenthaler, Kappenmacherin, Zeughspl. 250
 Hoffmann G., Barbier, Bärenplatz 109 u. Storcheng. 160
-— H., Schuhm., Altcnb. 16
+— H., Schuhm., Altenb. 16
 — I., Gärtner, Frick 67
 — Ww., Spez., Gerechtg. 127
 — F., Säuvcinm., Marktg. 31
@@ -1580,12 +1581,12 @@ Hölzer Ib., Speisew., 2lg. 21
 — geb. Flückiger, Kostgeber., Spitalg. 162
 Honegger E., Sekr. n. llkcgistr. d?Telegr.-Dir.,Krmg.212
 Hops-Steiger, Kramg. 179
-Horisberger, Frau, Brodeuse, Aarbcrgcrg. 52
-Hößli, Lohnkutsckcr, Krmg. 169
+Horisberger, Frau, Brodeuse, Aarbergerg. 52
+Hößli, Lohnkutscher, Krmg. 169
 Hoßscld Ei Ä., Lehrn., Aarz. 34
-Hostettler E., Hebamme, Metzgcrgassc 8i>
-Hotz E-, Schuhm., tzirrtztg. 113
----König, Brunng.29
+Hostettler E., Hebamme, Metzgergasse 8i>
+Hotz E., Schuhm., tzirrtztg. 113
+— -König, Brunng. 29
 Howald, Frau, Haft,., Sulgb.
 — K., 'Rvtar, Herreng. 321
 Howard, getv. Klaviermacher, Bollw. 264
@@ -1593,7 +1594,7 @@ Hubacher R., Spez., Mktg. 68
 — E., Wcinbdl., Nng. 116 u
 — Frau, Ncnensi. 116 n
 Huber I. R., Färber, Mtt. 118
-— H. D-,Lhnktskh., Fghsg. 13
+— H. D., Lhnktskh., Fghsg. 13
 — Peter, Buchdrucker
 — u. Cie., Bchhdl., Grchtg. 94
 — F., Hafner, Matte 127
@@ -1602,14 +1603,14 @@ Huber I. R., Färber, Mtt. 118
 — N., Barbier, Metzg. 116
 — A. B. M., Schneiderin, Gerechtg. 127
 — M., Lehrerin, Längg. 212
-— Steinhauer, Aarbcrgg. 52
+— Steinhauer, Aarbergg. 52
 — Hufschmid, Käfichg. 22
 Hubler-Käsermann, Ellenwaarenhandlung, Marktg. 72
 Hünerwadel G., Buchdruckereibesitzer, Spitalg. 178
 — -Frikart, Frau, Kramg. 148
 Hug F. D., Srganistn. Dintenfabrikant, Renen,; 91
 — W., Kanzlist, Marktg. 89
-— E. L., Vt., Kamins., Bg. 16
+— E. L., Vt., Kaminf., Bg. 16
 — Tobn, Kaniinf., Mtzg. 125
 — Wittwe, Pensionshälterin, Aarbergerthor
 — L., Bettmach., Schg. 213
@@ -1630,45 +1631,45 @@ Hummel G., Metzg., Keß lg. 182
 — E., Bnchb., Marktg. 33
 — Fb., Bäcker, Reucng. 122b
 — Jgsr., Kostgeb., Metzg.123
-Hunspcrger Jb., Schuhmacher, Keßlg. 246
+Hunsperger Jb., Schuhmacher, Keßlg. 246
 — Dachdecker, Postg. 23
-Hunzigkcr Abraham, Otegot., Junkerng. 186
+Hunzigker Abraham, Otegot., Junkerng. 186
 Hunziker I- Ä., Rnt., Läng. 214
 — Rot. u. Anrspr., Mrktg. 88
 — R., Schreiner, Brunng. 19
-— C-, Lohnbcd., Zwiebg. 56
+— C., Lohnbcd., Zwiebg. 56
 —-Lchmid, Spielwaarnhdl., Kramg. 210
 # Date: 1861-04-15 Page: 1395943/89
-Hunzikcr M., Lehrerin, Zwiebelng. 56
-Hurni Jb., Zimmcrm., Schindermätteli
+Hunziker M., Lehrerin, Zwiebelng. 56
+Hurni Jb., Zimmerm., Schindermätteli
 — P.,Zimmerm., Aarbg. 19
 — P., Schweinm., Aarbg. 20
 — Jb., Sckwcinm., Grchtg.87
 — Jb., Spcisew., Aarbg. 58
 — I., Küfer, Brunng. 26
 Hürst P., Bäcker, Brunng. 6
-Hüser, Obcrstlt., Kramg. 221
-Hutmachcr I., Lehrer, Postg. 16
+Hüser, Oberstlt., Kramg. 221
+Hutmacher I., Lehrer, Postg. 16
 — geb. Weniger, Krämerin, Keßlg. 241
 Huttcnlochergb.Wäber, Pfläst., Aarz. 21
-Huttcr L., Zckngslhr., Mktg. 44
+Hutter L., Zckngslhr., Mktg. 44
 Hyseli, F., Sprach!., Zghg. 10
-Jacot des Combes L., Ncnt., Jnselg. 136a
+Jacot des Combes L., Ncnt., Inselg. 136a
 Jacquct G., Hutm., Krmg. 155
 Jäger I., Rent.,Längg.202
 — F.,Tapez., Neucng.1l>6
-Jäggi Cman. Fried., Ämtsnot. Pelikan 230 u. Kirchg. 268
+Jäggi Cman. Fried., Amtsnot., Pelikan 230 u. Kirchg. 268
 —-I. E. A., Amtsnot., Kirchgasse 268
 — I. F. E., Ncgot., Schönbnrg.
-— M., Waisenoatcr, Waisenhaus.
-— R-, Postangest., Käfg. 102
-—-Chariatte, Schnd., Marktgasse 44
-—-Lautcrburg, Kramg. 189
-—-Grüner, Hotell. 229
+— M., Waisenoater, Waisenhaus.
+— R., Postangest., Käfg. 102
+— -Chariatte, Schnd., Marktgasse 44
+— -Lauterburg, Kramg. 189
+— -Grüner, Hotell. 229
 Jaggi I., Milchhdl., Grchtg.69
-— Jnftrkt.-Major, Zeughausplatz 251 u.252
+— Inftrkt.-Major, Zeughausplatz 251 u.252
 Jaggi Cbr., Hutm., Postg. 35
-— Frau, Feinwasck., Bg. 25
+— Frau, Feinwasch., Bg. 25
 Jahn A., eidg. Archtvargehülfe u. Doz. an d. Hochschule, Altenb. 172
 Jakob I., Strumpfwb., Bg.22
 — A. C., Schneid., Aarbg. 35
@@ -1682,15 +1683,15 @@ Jausn Chr., Trödler, Aarbergerg. 27
 JavetR., Buchb., Keßlg. 261
 Jeance! I. L., Gärtn., Mir. 35
 Jeandrevin F., Tuchngt., Krmgasse 209
-Jeanncret C. F., Weinhändler, Nathhspl. 51
+Jeanneret C. F., Weinhändler, Nathhspl. 51
 Jeanmaire, Knckl., Aarbg. 47
 Jecker-Stähli, Posamentirer, Marktg. 44
-Jenni Chr., Buchdruck., Metzgcrg. 96
-— Bäcker, Junkcrng. 146ct
+Jenni Chr., Buchdruck., Metzgerg. 96
+— Bäcker, Junkerng. 146ct
 — R., Bäcker, Rhdeckbrck.234
 — R., Buchdrucker u. Schriftgießer, Gercchtg. 115
 — F., Buchb., Brunng. 31
-— Glaser, Mctzg. 133
+— Glaser, Metzg. 133
 — A., Drechsler, Metzg. 87
 — G., Metzger, Metzg?120
 — I., Schrn. u. Glas., Bg. 24
@@ -1701,9 +1702,9 @@ Jenni Chr., Buchdruck., Metzgcrg. 96
 — M., Schneiderin, Frick 70
 # Date: 1861-04-15 Page: 1395944/90
 v. Jenner G.N. (oonPruntrut), Oberstlieut., Rnt., Gerechtigkeitsg. 85
-— I- E- F-, Papierhändler u. Buchb., Gerechtg. 111
+— I. E. F., Papierhändler u. Buchb., Gerechtg. 111
 — B. L. N., gew. Polizei-Inspektor, Gerechtg. 100
-— F.G.H., Schnd., Mtzg. 72
+— F. G. H., Schnd., Mtzg. 72
 — -Marcuard C. D. F., Bnq>, Marktg. 49
 — I. E. R., Schreiber, Zeughauspl. 250u
 — N. G. E., Zuckerb., Brunngasse 30
@@ -1724,7 +1725,7 @@ Imhoof F. Ch., Kleidertrödler, Längg.201
 — I., Schreiner, Stald. 10
 — F.H., Regt., Hotell. 233
 — I. S., Schuhm.,Metzg. 76
-— geb. Messcrli, Gemüiehdl., Schifft. 44
+— geb. Messerli, Gemüsehdl., Schifft. 44
 — I. L., Sesselficht., Spchg. 4
 — F., Polizeidn., Sptlg. 245
 Im Hoff, Frau (v.lRöhrswyl), Kramg. 192
@@ -1736,7 +1737,7 @@ Indermüs>lc I., Strohhutfabr., bei der kl. Schanze 186
 — -v. Wyttenbach,F.B., Rnt., Kramg. 215
 Ineichen A. A., Lehrer u. Literat, Aarbergg. 45
 Ingold H., Zimmrinst., Stadtbach 178
-— A., Schuhm., Mctzg. 80
+— A., Schuhm., Metzg. 80
 — Jb., Abw. d. Ostwestbahn-büreaux, Zeughg. 13
 — I. Jb., Schlüsselwirth, Metzg. 68
 Joder Chr., Bchb., Altenb. 163
@@ -1747,9 +1748,9 @@ Joneli J., Lehrer, Marktg. 80
 JonquiereD.J.G., gw.Eisenneqt., Zwiebg. 55
 -J.'D., Or. Lleci., Pros., Herreng. 312
 — Eman., Speicherg. 7
-Jordan D-, Messerschm., Gerberngr. 140
+Jordan D., Messerschm., Gerberngr. 140
 Jordi J., Schuhm., Mktg. 82
-— K-, Buchb., Käfichg. 104
+— K., Buchb., Käfichg. 104
 Jörg I., Buchb., Postg. 30
 Joß F. B., Schuhm., Badl.94
 — M., Modiste, Grchtg.139
@@ -1785,9 +1786,9 @@ Isler J.H., Schnd., Spchg.6b
 — Kanzl., Speicherg. 6b
 — I., Wirth, Käfichg. 109
 Juni M., Schneid., Sptlg. 140
-— S., Körbcr, Längg. 215 b
+— S., Körber, Längg. 215 b
 Jucker I., LohnkutschJ', Zghg. 15
-— -Huber, Standesweibel, Aarbcrgg. 37
+— -Huber, Standesweibel, Aarbergg. 37
 Julius R. S.,Knzl., Mtt.117F
 Jung, Frau, Blumenhändler., Neueng. 93
 Jungi R., Bäcker, Grchtg. 126
@@ -1800,9 +1801,9 @@ Käch F., Schwnm., Neueng. 104
 Käch I., in. Bollw. 78
 Kähli P., Lhnktsch., Junkg.147
 Kähr I., Dachdecker, Postg. 24
-— J.S., Schuhm-, Postg.24
+— J. S., Schuhm., Postg.24
 Kaiser, Eisenhdl., Spitalg. 153
-Kaltbrunner D-, Sekrt., Obstberg
+Kaltbrunner D., Sekrt., Obstberg
 Kammermann, Fuhrm., Speicherg. 2
 v. Käncl Chr., Wirth, Kornhauspl. 152
 — Chr., Mtzg., große Schaal
@@ -1810,15 +1811,15 @@ v. Käncl Chr., Wirth, Kornhauspl. 152
 — I., Graveur, Metzg. 122
 Käser C.E., Spengl., Mtzg.76
 — -Steinmann, Gemeinderath, Gerechtigkg.-IOI
-— Cbr.,Weinbl., Gerecht.101
-— Jb.,Weinhdl.,Sptlg.174
+— Cbr., Weinbl., Gerecht.101
+— Jb., Weinhdl., Sptlg.174
 - I. I., Schneid., Abg. 72
-— I., Gypscr, Aarbergg. 37
-— E., Splwrnhdl.,Krmg.200
-— geb. Scheideqger, Glätter., Aarbcrgg. 5ö
+— I., Gypser, Aarbergg. 37
+— E., Splwrnhdl., Krmg. 200
+— geb. Scheidegger, Glätter., Aarbergg. 5ö
 Käsermann U., Kanzlist, Langmauer 227
 Kamm I., Gypser, Aarbg. 50
-Kappelcr I., Bildh., Mkta. 47
+Kappeler I., Bildh., Mkta. 47
 Karlen I. Jb. , Reg.-Rath, Thierspital
 — gb. Zaugg, Ww., Bärenpl.
 Kastenhofer J. I., Trödler, Aarbergg. 40
@@ -1828,9 +1829,9 @@ Katz S., Zahnarzt, Sptlg. 172
 Kauert Nikl., Müller u. Mehlhändler, Zeughausq. 9
 Kaufmann I., Lehrer, Äg. 113
 — F. A., Schrb., Grchtg. 145
-— C., Spez.,Mktg. 66 u. 71
-— C.H.,Mehlhdl., Metzg. 67
-— C. H., Spez-, Zwiebg. 62
+— C., Spez., Mktg. 66 u. 71
+— C.H., Mehlhdl., Metzg. 67
+— C. H., Spez., Zwiebg. 62
 # Date: 1861-04-15 Page: 1395946/92
 Kaufmann, Notar, a. d. Amtsaerichtsschreiberei
 — Schwestern, Gerechtg.127
@@ -1874,7 +1875,7 @@ Klemens I. G., Strumpfweber u. Regt., Marktg. 36
 Klemm L., Commis, Käfg. 25
 Klingele F., Storchenw., Spitalg. 157
 Klötzli R., Conditor u. Kellerwirth, Gerechtg. 95
-Kloßner Elise, Blondcnfabr., Altenb. 171
+Kloßner Elise, Blondenfabr., Altenb. 171
 — A. M., Schndr.,Krmg.150
 Knecht, Jgfr., Judeng. 125
 Kneubühl Chr., Schnd., Schauplatzg. 212
@@ -1928,10 +1929,10 @@ König A., Amtsnotar u. Sachwalter, Kramg. 203
 — W., Sohn, Mlr., cpchg. 4
 — A. C., Architekt, schw. Thor
 — Fr. R., Gypssr u. Maler, Aarz. 18
-— W., Dr.gnr., Fürsprecher, Gcrechtg'. 81 u. 82
+— W., Dr.gnr., Fürsprecher, Gerechtg. 81 u. 82
 — -Ba» E. R., Apotheker, Pg. 43 u
 — S. K., Regt., Zwiebg. 58
-- C. L.R., Wcmnegt., Jndeng. 113 s.
+- C. L.R., Wcmnegt., Judeng. 113 s.
 König I. R. F., Dr. ölml., Gerechtigkcitsgasse 130
 — I. R. M., Ührenm., Kornhauspl. 147
 — geb.Hirtin, Frau, Kßg.237
@@ -1945,7 +1946,7 @@ König I. R. F., Dr. ölml., Gerechtigkcitsgasse 130
 — J.R., Archit.,Haspeln,.92o
 — Anna, Hebamme, Mktg.82
 — Barb., Wittwe, Krämerin, Schauplg. 207
-Kopp I. J.,'Rcnt., gew. Vergolder, Kramg. 159
+Kopp I. J., Rent., gew. Vergolder, Kramg. 159
 — I., Schneider, Kramg. 175
 — S., Regt., Spitalg. 153
 Körber Ioh., Buchhbl., Laugmauer 230
@@ -1966,15 +1967,15 @@ Kraut G., Metzger, Mstzg. 134
 # Date: 1861-04-15 Page: 1395948/94
 Krebs A., Rechtsag., Schg. 217
 — A., Wirth, Postg. 43
-— Chr.,TröLl., Reueng.116
+— Chr., TröLl., Reueng.116
 — Chr., Dcichd., Reueng. 116
 — I., Scknd., Gerbg. 143
 — I., Polizeidiener-Corpor., Spitalg. 144
 — I. U., Wirth z. Linde 138
-— -Berger S>, Hutmacher, Storcheng. 206
+— -Berger S., Hutmacher, Storcheng. 206
 — Gebr., Hutm., Sptlg. 133
 — S., Müller, Matte 29
--Müller, Feinwsch., Mt.29
+— -Müller, Feinwsch., Mt. 29
 — S., Büchsenschm., Brg. 8
 — F. L., Musikl., Krmg. 153
 Krieger C.G. Dr., Homöopath, Junkerng. 182 b
@@ -2001,7 +2002,7 @@ Küenzi M. A., Wasch., Matte 105 a
 — J.G., Pvsam., Keßg.257
 — Jb., Zeugschm., Matte 51
 — C. W. C., Zgsckm., Mi. 51
-— Chr-, Schiffer, Aarz. 52
+— Chr., Schiffer, Aarz. 52
 — g. Funk, Krämerin, Mt.114
 — Rosa, Baumw.-Handlung, Marktg. 88
 Küfer, Frau, Ouincaill.-Hdlq., Marktg. 88
@@ -2020,7 +2021,7 @@ Küpfer I. F., Rittm., Ng. 101
 — Feilenhauer, Bärenpl. 109
 — F. R., Substit. d. Gemd.kanzlei, Gerechtg. 70
 — Spengler, Postg. 41
-— C-, Amtsnot., Kramg. 165 u. Schütte 254
+— C., Amtsnot., Kramg. 165 u. Schütte 254
 — Charl., Schauplg. 134
 — P.A., Metzg., Krmg. 152
 — G., Matratzenur., Altb.173»
@@ -2050,7 +2051,7 @@ Kupferschm dtU. Stl.,Mt. 111
 — Baumat.-Hdlg.,Jdg.113n
 Kurt Wtw., Trödl., Aarbg. 73
 Kurz, Reg.-Rath, Staatskanzl.
-— I- F-, Kanzlist, Aarbg. 63
+— I. F., Kanzlist, Aarbg. 63
 — C. A., Oberst u. Fürspr., Kramg. 160
 — Herm., Fürsprecher, Sohn, Kramg. 180
 — Bankdirektor, Marktg. 54
@@ -2059,10 +2060,10 @@ Kurz, Reg.-Rath, Staatskanzl.
 — R., Bettmach., Aarbg. 35
 — geb. Stooß, Regt., Marktgasse 54
 Kutter, Ingenieur, Obstberg
-Kutzli, auf d. Intelligcnzblatt-Büreau, Zeughauspl. 247
-— -Mürner, Schrifts., Brunngasse^lO
-Kyburz, schukm., Anatg.10 n
-Kyd M. A.,Mod.,Gerbg. 125
+Kutzli, auf d. Intelligenzblatt-Büreau, Zeughauspl. 247
+— -Mürner, Schrifts., Brunngasse 10
+Kyburz, Schuhm., Anatg. 10 a
+Kyd M. A., Mod., Gerbg. 125
 Lahner U., Schn., Spcichg. 6 s
 Lädermann F., Schmied, Spitalgasse 171
 — I., Schneid., Matte 114
@@ -2071,19 +2072,19 @@ Läderach Chr., Gärtner, Heiligen 112
 Lager D. S., Hafner, Arbg. 41
 — F. G., Hafner, Aarbg. 41
 Lamarche C. F. W., Lithogr., zw. d. Thoren 182
-Lämmlin M., Schn., Mtzg-131
+Lämmlin M., Schn., Mtzg. 131
 — Schwest., Gerechtigk. 93
 Lambelet E., Drog., Bärenpl.
 Landolt geb. Gaspard, Rent., Marktg. 46
 Lang A., Schneid., Metzg. 65
 — A. G., Spez., Grchtg. 85
 — D., Kammm., Grchtg. 144
-— I., Speisen,., Schplg.199
+— I., Speisen,., Schplg. 199
 — K. M., Wattenfb., Mtzg. 94
-— gb.>Ltauffer, Kräm., Mt.86
+— gb.>Ltauffer, Kräm., Mt. 86
 Läng gb.Montet, Schneiderin, Brunnad. 4
 Langet Wtw., Rent., Gchg. 122
-Langenegger, Kamins., Mtzg.78
+Langenegger, Kaminf., Mtzg. 78
 Langhans G., Landsaßen-Almosner, Schauplatzg. 202
 — C. L., Ncg.ui Buchsührer, Kramg. 149
 — -Stählt, Mod., Krmg. 149
@@ -2100,12 +2101,12 @@ Largin I. I., VuMalt. Brück' seid 230
 Lasche, Lehrer, Falkenpl. 217
 Lauber S. L., Haarflch., Mt. 91
 — C., Haarflechterin, Mtt. 31
-Lauster Äl., Mctzg., Aarbg. 67
-— Jgfr., Spcz., Metzg.122
+Lauster Äl., Metzg., Aarbg. 67
+— Jgfr., Spcz., Metzg. 122
 — Catch., Kräm., Metzg. 90
 Lauster J.C.,Lchlosters Schauplatzgasse 198
 Lauper N., Mehlhl., Kng. 92
-Lauterburg E. F., Flachmaler, Wcycrmannshaus 133
+Lauterburg E. F., Flachmaler, Weyermannshaus 133
 — F.G.,Eisenneg.,Zghg. 18
 — C. G. R., Ingen., schwarz Thor 101
 — C. A., Posam., Kramg. 171
@@ -2119,7 +2120,7 @@ Ledermann Frau, Dekatierer»«, Spitalg. 175
 Lehman« Chr., L. C., Inselprediger, Casinopl. 131
 — S.J.G., Lekrer, Mrktg. 59
 — F., Bäcker, Längg. 252
-— F., Rent., Junkcrng. 19
+— F., Rent., Junkerng. 19
 — F., Schreiner, Kirchg. 261
 — F., Schuhm., Aarbg. 22
 — F., Äanzlist, Postg. 25
@@ -2128,15 +2129,15 @@ Lehman« Chr., L. C., Inselprediger, Casinopl. 131
 — Jb.,Kanzlist, Postg. 35
 — I., Müller, Matte 28
 — F., Journalist, Stld. 6
-— bhr.,Uhrenm., Zghpl. 253
-— Geschwister, Mctzg. 97
+— bhr., Uhrenm., Zghpl. 253
+— Geschwister, Metzg. 97
 — Frau, Kleiderhdl., Schauplatzg, 229
 Lebmann R., Postwagenni., Postg. 31
 — N., Goldarbelter, Mt. 254
 — S., Dr., Reg.-Rath, Rabenthal 155
 — S., Müller, Sulgcnb.101
 — S. R., Gypser, Matte53
-— geb. Lörtscher, Krämcrin, Matte 11
+— geb. Lörtscher, Krämerin, Matte 11
 Lehner U., Schnd., Aarbg. 16
 Leibundgut, Wirtb, Keßlg. 236
 — Oberrichter, Marktg. 92
@@ -2145,7 +2146,7 @@ Leibzig P. H., Weinhl., Marktgasse 52
 Leimbacher J. C., Kalligraph, Brunng. 17
 Leitner, Frau, Sprachlehrerin, Kramg. 225
 Leizmann I., Dr., Pros., alt. Viehmarkt 185
-Lemp geb. Mühlemann, Lebr., Spitalg. 16 >
+Lemp geb. Mühlemann, Lehr., Spitalg. 16 >
 — H., a. d. Mii.-Dir., Spitalg. 160
 — V., Hebam., Brunng. 27
 — I., Wagner, Bollwerk83
@@ -2154,7 +2155,7 @@ Lengfelder I., Corsctmacherin, Zeughpl. 253
 Lenz I., Fimmerm.,Hollg.117
 — C. A., Sehn., Brung. 26
 — Zeitungstrg., Gerbgrb.111
-v. Lentulus-Pourtales, Wtw., Rent., Junkcrng. 195
+v. Lentulus-Pourtales, Wtw., Rent., Junkerng. 195
 Lenzinger, Strumpswb. u. Negot., Spitalg. 176
 Leon, Schneid., Brunng. 19
 Leonhard F., Glätterin , Aarberaerg. 37
@@ -2168,24 +2169,24 @@ Leroy L. E., Kanzlist, Nng. 94
 Lesers F., Kräm., Brunng. 21
 LeuF., Kanzlist, Brunng. 18
 — J.U., Schuhn,. Grbg. 141
--V., Wirthin, Jnseli'
+-V., Wirthin, Inseli'
 — I., Speisew., «peichg. 61
 Leuch R. L. F., Apoth., Kramgasse 193
 — N. G. R., Arzt u. gewes. Quart.-Aufs., Junkg. 158
-Leuenbcrger R. L. F., Schrb., Kirchg. 272
+Leuenberger R. L. F., Schrb., Kirchg. 272
 — G., Papierhl., Krma. 166
 — I. I. U., Rentier, Hotellaube 234
 — I., Pros., Rabbenthal 155
 — I., Telcgr., a. Boüw. 264
 — J., Postadj., Zeughg. 5
 — S., Echuhm., Zghg. 16 u
-— I., Schuh,n., Mctzg. 134 u. Kramg. 143
+— I., Schuhm., Metzg. 134 u. Kramg. 143
 — I. U., Schuhn,., Matte 39
 — E. Seifenhl., Herrcna.331
-— Metzger, Mctzg. 100
-— Frau, BLurisrh-Schncid., Mctzg. 101
+— Metzger, Metzg. 100
+— Frau, BLurisrh-Schneid., Metzg. 101
 — geb.Hcminann, Frau Mar. Kathar., Kramg. 165
-Leuteneggcr N., Siebmacher, Marktg. 78
+Leutenegger N., Siebmacher, Marktg. 78
 Leuthold U., Amtsnot., Kornhausplatz 152
 Leuw F. R., gew.Pfr.,Marktgasse 52
 — Frau, Inselgasse 136 d.
@@ -2203,24 +2204,24 @@ Lieäiti, A. S., O.uartieraufs., Matte 110
 — Chr., Wagner, Hollig. 126
 — C. G., Büreauches, Gerechtg. 138
 — C. Fi, Schuhm., Matte 114
-— F. C>, Spengler, Schauplatzg. 197
+— F. C., Spengler, Schauplatzg. 197
 — F., Kondukt., Postg. 34
 — I., Milchhdl., Neueng. 96
 — I. Büchsenm., Nng. 109
 — S., Postbürcauchef., Gerechtg. 141
-— C-, Sekretär d.Mil.-Dir., Schauplatzg. 209
+— C., Sekretär d. Mil.-Dir., Schauplatzg. 209
 — Jb., Abwart, Kaserne 1
-— A.M., Kräm., Grchtg.137
+— A. M., Kräm., Grchtg.137
 — geb. Christen, Hebamme, Schaupltzg. 212
 Lienhard S., Kutsch., Jkg.150
-Licr B., Spcz., Spitalg. 136
-Licutaud, Sprrchlehr., Neuengasse 92
+Lier B., Spcz., Spitalg. 136
+Lieutaud, Sprrchlehr., Neuengasse 92
 v. Linden L., eidgen. Oberst, Neu eng. 122 u
-Linde,imann I., Schnd-, Stalden 24
+Linde,imann I., Schnd., Stalden 24
 Linder P., Oekonom, a. Krankenhaus
 — A., Steinh., Hollig. 140
 — B., Schneid., Metzg. 74
-— I., Spez., Staldcn 216
+— I., Spez., Stalden 216
 — A., Lehrerin, Brunng. 17
 # Date: 1861-04-15 Page: 1395952/98
 Linder geb. Mathey, Schneid., Herreng. 304
@@ -2229,7 +2230,7 @@ Lindt I. R., Apoth., Mrktg. 94
 — I. P., Äerichtspräs., Hotellaube 230
 Lindt F. A., Handelsmann, Marktgasse 72
 Link F., Ellenwhdlg., Mktg. 74
-— Schubm., Metzg. 65
+— Schuhm., Metzg. 65
 Locher J.K., Spez., Krmg. 176
 Loder C., Mech., Gerbg. 137
 — Frau, Lobnw., Matte 58
@@ -2247,10 +2248,10 @@ Loosli I., Schnd., Mrktg. 37
 — P., Kanzlist, Stalden 214
 Losenegger-Bay, Kramg. 186
 Luchsinger H., Wagn., Matte 6
-Lücon H., Lcbrer, Kramg.159
-Ludwig E., Pfarrera.,^'' Herreng. 319 ^
-— F. E„ Buchb.^^ ' '83
-— M., Schnd., « -Mo
+Lüçon H., Lehrer, Kramg. 159
+Ludwig E., Pfarrer a. ???, Herreng. 319
+— F. E., Buchh., ??? 83
+— M., Schnd., ??? 168
 Lüdi I., Trödler, Aarbg. 72
 Luginbühl, Spez., Aarbg. 54
 — Gypseru. Mal., Metzg. 128
@@ -2266,7 +2267,7 @@ Lüthard Em. u. Comp., Sachwalter, Kramg. 175
 — R., Koch, Zeitglockth. 228
 — M., Kapellmstr., Falkcnpl. 222
 — P., Müsiklehrer, Aarz. 84
-Lüthi Wtw., Rcnt., Matte 106
+Lüthi Wtw., Rent., Matte 106
 — A., Notar, Stcmpelverw., Ncueng. 87
 — P., Schneid., Metzg. 80
 — Jb., Arzt, Krmg. 175 (Gallrrie Rebold)
@@ -2274,18 +2275,18 @@ Lüthi Wtw., Rcnt., Matte 106
 — N., Schuhm., Metzg. 67
 — F. L., Uhrenm., Kafichg. 27
 — J., Butterhdl., Nng.111
-— S., Lcbküchlcr, Sptlg. 134
-— I- U., Hufschm., Läng. 243
+— S., Lebküchler, Sptlg. 134
+— I. U., Hufschm., Läng. 243
 — I., Spez., Ltalden218
 — I., Steinh., Längg. 212
-— C. I., Schubm.,Ärz. 83
+— C. I., Schuhm., Arz. 83
 — I., Butterhdl., Mrktg. 52
 — I., Weißmüll., Stald. 218
 — S., L-chuhm., Zeughg. 13
 — P., Schlosser, Staldeff 13
 Lüthold-Rommel, Weinhandl., Kornhspl. 152
 Lütscher J., Sekr., Grchtg. 116
-Lustenbcrger, Musiker, Schauplatzg. 220
+Lustenberger, Musiker, Schauplatzg. 220
 Lutstorf Ä. R., Vat., Geschäftsmann, Stalden 7
 — E. L., Sohn, Geschäftsm., Ncueng. 87
 — -Richard, Maria, Corsetmacherin, Neueng. 87
@@ -2304,24 +2305,24 @@ Lutz A.,V. V.U.,gw.Waisenvater, Junkg. 183
 — G.,Hdlsm. Aargstld. 128ä
 — geb. Steck, Wittwe, Marktgasse 84
 — gcw. Pfarrer, Altb. 1735
-Maag S., Schubm., Sptg.1^3
-Mader, Säaenfeiler, Matte 7"?
+Maag S., Schuhm., Sptg. 1733
+Mader, Sägenfeiler, Matte 77
 Mäder J.,Sekr., Aarz.26
 — I. B., Küfer, Krnhpl. 42
 — I. R., Gasaufs., Aarz. 92
 — A. M., Mod., Brunng. 18
-Madöri J. I., Barbier, Kornhauspl. 47
-— Wtw., Zeughg.9
+Madöri J. J., Barbier, Kornhauspl. 47
+— Wtw., Zeughg. 9
 Mantel Wtw., Spengler, Aarberg. 24 u. 25
-Manche F., Glaser, Keßlg. 295 !
+Manthe F., Glaser, Keßlg. 295 !
 Mann F., Commis, Stalden 5
-Manuel F.A.E.,Rt.,Ng. 113
-— -v. Wattenwyl L. G., Rt., Jnnkerng. 168
-— R. N., Neck. I1r., Junkerngasse 151
-— C., 1)r. inr., Amtsrichter, Brunnad. 15
-Majores Günth., Handscinchm., Metzg. 76
-Mani geb. Kloßner, Blondem«., Aarbg. 63
-Marbach M., Schn., KLfa. IM
+Manuel F. A. E., Rt., Ng. 113
+— -v. Wattenwyl L. G., Rt., Junkerng. 168
+— R. N., Med. Dr., Junkerngasse 151
+— C., Dr. jur., Amtsrichter, Brunnad. 15
+Majores Günth., Handschuhm., Metzg. 76
+Mani geb. Kloßner, Blondenm., Aarbg. 63
+Marbach M., Schn., Käfg. 100
 Marcuard F. L., gew. Major, Spitalg. 127
 — u. Comp., Banq., Kramgasse 192
 — E. H. E., Banq., Gerechtigkeitsg. 108
@@ -2331,36 +2332,36 @@ Marcuard F. L., gew. Major, Spitalg. 127
 Maron A., Schuhm., Sptg. 153
 Marthaler Chr., Kappenmach., Aarbg. 66
 — Kürschner, Metzgerg. 89
-— Fran, Schnd., Jnfelg.139
+— Fran, Schnd., Infelg. 139
 — Fr., Hafner, Keßlerg. 286
-Marti C., Lberrich., Grchg. 115
+Marti C., Oberrich., Grchg. 115
 — Frau, Violinsp., Schg. 216
 — Jb., Schmied, Sulgenb. 88
 — Frau, Schnd. u. Sackzeich., Neueng. 110
-— geb. Messerli, Frau, Junkcrng. 190
-— Sohn, Jnnkerng. 190
-— I. Drechsler, Speichern. 6
-— A.M., Krämerin, a. Bollwerk 122 n
-— M., Sckmd., Sptlg. 160
+— geb. Messerli, Frau, Junkerng. 190
+— Sohn, Junkerng. 190
+— I., Drechsler, Speichern. 6
+— A. M., Krämerin, a. Bollwerk 122 a
+— M., Schnd., Sptlg. 160
 — M., Lehrerin, Marktg. 88
 — geb. Dieffenbach, Schnd., ?chg. 261
-— Spez., Aarbg. 61
+— ?, Spez., Aarbg. 61
 — Joh., Mechan., Sptg. 164 b
 — Frau, Bäurischschneiderin, Spitalg. 164 b
-Martin G., Schirmst., Marktgasse 89
-— I. C. H., Schuhm. Ng.109
-Martz I. D., Sehr., Schg 235
-Maser D.A., Sachw., Äietzg. 133 u. Stalden 17 j
+Martin G., Schirmsb., Marktgasse 89
+— J. C. H., Schuhm., Ng. 109
+Martz J. D., Schr., Schg. 235
+Maser D. A., Sachw., Metzg. 133 u. Stalden 17
 # Date: 1861-04-15 Page: 1395954/100
 Maßhard R., Müller, ob. Sulgenbach 107
-Mathys I., Kondkt., Hrg. 302
-— Ä., Fürspr., Keßlg. 278
+Mathys J., Kondkt., Hrg. 302
+— A., Fürspr., Keßlg. 278
 — N., Schuhm., Stald. 108
-— Jos., Notar, KornkSpl. 48
-— Maria, L-chneid., Jkg. 186
-— G.. Ilhrcnfb., Gercchg.138
-Matti C., Antiquar,Kestlg.242
-— -Müller, Frau,Bollw. 81
+— Jos., Notar, Kornhspl. 48
+— Maria, Schneid., Jkg. 186
+— G., Uhrenfb., Gerechg.138
+Matti C., Antiquar, Keßlg. 242
+— -Müller, Frau, Bollw. 81
 Matz C. H,, Coiffeur, Kornh.platz 50 u. Marktg. 58
 Mauderli F., Lehn,, Mrktg.40
 — I., Gürtler, Neueng. 83
@@ -2369,10 +2370,10 @@ Mauerhofer J.G.,Not., Obergerichtswbl., Nydeckg. 201
 Maure A., Schleif., Brng. 35
 Maurer A., Sesselm., Mtzg. 89
 — Gärtner, Längg. 154
-— I-, Spengler, Kstlcrg. 286
+— I., Spengler, Kstlerg. 286
 — I. F. G., Neueng. 117
-— Glaser, Junkcrng. 158
-— Frau, Coiffcuse, Brng. 35
+— Glaser, Junkerng. 158
+— Frau, Coiffeuse, Brng. 35
 — G., Postcom., Keßlg., 286
 — I., Drechsler, Lpcichg. 6e
 — I. L., Postcom., Nng. 94
@@ -2386,7 +2387,7 @@ v.Map-o.Tavcl G.G.A., Sachwalter, Spitalg. 130
 — Frtu., Spitalg. 137
 — -Wurstemberger (v. Urssllcn) A. R. B., Rent., Junkerng. 176
 — -v.Tschiffeli, d.Staatssckr. Wwe., Marktg. 34
-— H-, Jng., Junkg. 158
+— H., Ing., Junkg. 158
 - -V. Grastenried, debil.llr. Wwe., Marktgasse 40
 — v. May (von Hünigen), Fräul., Heiligen 151
 — (v. Rued), Bollw. 265
@@ -2394,7 +2395,7 @@ v.Map-o.Tavcl G.G.A., Sachwalter, Spitalg. 130
 Meckle Chr., Schuhm. Mrkg. 35
 Medina, Tapezier., Splg. 127
 Meister Frau, Leichenbitt.,Keßlerg. 283
-Melev - Werthmüllcr, F. A., Laudwirth, v. d. unt. Th. 4
+Melev-Werthmüller, F. A., Laudwirth, v. d. unt. Th. 4
 Mendel J. I., Musikl. (Organist), Bollw. 265
 Menn I., Kanzlist, Hrng. 362
 Menz Ör., Doz., Falkenplätzli 215 (Hugendubelhaus) "
@@ -2407,7 +2408,7 @@ Merz D. R., gew. Oberlehrer, Marktg. 76
 — Frd., Schlosser, Kfg. 105
 Messer R. G., Polizeid., Spitalg. 136
 — A., Schneiderin, Schg. 198
-MefscrliC.hr., Schn. Mrktg. 48
+Messerli Chr., Schn. Mrktg. 48
 — Chr., Müller, Matte 107
 — I., Sattler, Zeughg. 9
 — gb.Felber, Kräm., Mßg.125
@@ -2416,7 +2417,7 @@ Meßmer R. A., Postcassier, Gerechtg. 78
 — G., alt-Landam., Mrkg.59
 de Mestral- o. Wurstemberger, G. A., gw. Oberförst., Gerechtg. 64
 — -Goumoens, Psr. Grcht. 84
-Mctkfessel G.A., Musikdirekt., Gcrechtg. 93
+Mctkfessel G.A., Musikdirekt., Gerechtg. 93^
 — Ad., Kunstgärt., Grchg.93
 # Date: 1861-04-15 Page: 1395955/101
 Mittler Wtw., Herreng. 307
@@ -2430,9 +2431,9 @@ Meyer S. Chr., Privatlehrer, Marktg. 51
 — I., Photogr., Keßlerq. 254
 — F.,Ghps. ».Mal., Nq.121
 — -Rohrer Frau, Sptlg. 151
-— Frau, Bettfedcrnh. Schauplatzg. 200
+— Frau, Bettfedernh. Schauplatzg. 200
 — I., Photograph, Sptq.142
-— I - I -, Archiv., b. schw,'TH vr
+— I. I ., Archiv., b. schw,'TH vr
 — Alb., Sckr.,b.schw. Thor
 — Fr.,Schr.,Brunng. 3
 — I., Schneid., Kramg.104
@@ -2440,14 +2441,14 @@ Meyer S. Chr., Privatlehrer, Marktg. 51
 — J.,Schnd.,Postg.38
 — J.,Kräm.,Keßlg. 254
 — I., N c g t., Kramg. 220
-— Bäcker, Mctzg. 131
+— Bäcker, Metzg. 131
 — -Liebi I. I., Eisennegot., Bierhübeli 266 u. 267
 — L., Negt., Metzg. 117
 — B., Trödl., Stald. 4
 — P., Kammmach., Brunnq. 6
-Meyerhoscr F. P., Schr.,Salzmagazin 236
+Meyerhoser F. P., Schr., Salzmagazin 236
 — G.C.,Kanzlist,Stald.3
-— S.,Theatcrkass., Metzg.72
+— S., Theaterkass., Metzg.72
 — M., Schneiderin, Jkg.149
 Meyhöfer R., Kanzlist, Länggasse 215
 Metzcner, Tabakfabr., Spchg. 3
@@ -2457,17 +2458,17 @@ Mickaud 8. G., Weinh., Marktgasse 43
 MichelJ.M., Schuhmach.,Gerechtg. 144
 — A.B., Wirthin, Mtzg. 102
 Michle Spez., Aarl>g. 18
-Mieg L., Äahnhof-Jnspekt., im neuen Bahnhof
+Mieg L., Bahnhof-Inspekt., im neuen Bahnhof
 Mieville L., Lehrer, Grchtg. 100
 — Ed., Commiss., Längg.212
 Migy P., Reg.-Rath, Kreuzg. 162 s
 Milliet J.F.,Kanzl., Mrktg.51
 Minder R., Holzschuhm., Junkerng. 158
-— J.,Schr., Zeughg.13
+— J.,Schr., Zeughg. 13
 — Schirmsab., Schpltzg. 195
 — gb.Hvrrisberger, Grempl., Schauplg. 219
-Mining, Lehrer, Rcuenq. 86
-Mischler Ul., Kamins., Schauplatzg. 225
+Mining, Lehrer, Neueng. 86
+Mischler Ul., Kaminf., Schauplatzg. 225
 Mohni I., Schneid., Schg. 21S
 Moll A., Conditor, Neuengasse 111
 Mollet L.,Fruchthl.,Brg. 28
@@ -2488,27 +2489,27 @@ Mori, Rentier, Schauplg. 234
 Mori S., Condit., Sptlg. 140
 Mörker J., Wagner, Anatg.14
 v. Morlot-Kern C. A. N., Sekretär der burgl. Feld- und Forstcomm., Junkg. 150
-— Asä. vr., Jkq.150
-— Karl Ad., Pros., Jkg.150
-— -Crousaz, Ww.,Kirchg.265
+— Asä. vr., Jkq. 150
+— Karl Ad., Pros., Jkg. 150
+— -Crousaz, Ww., Kirchg.265
 — Fräul., Junkerng. 184
 Moser L. M., Landw., Weißenstein 51
 — Oberrichter, Keßlerg. 278
 — geb. Scheurer, Sptlg. 132
 — Frau, Schneid., Brg. 21
 — H., Bücksenm., Aarbg. 73
-— C. F., Müllerin., Sulgenbach 106
+— C. F., Müllerm., Sulgenbach 106
 - J. F., Schr., G-rbg.143
 — F. R., Schn., Marktg. 52
 — H. U., Metzger, Gerbt. 112
 — geb. Lüthi, Anna, Weißnäherin, Keßlerg. 238
 — R. L., Bäcker, Neueng. 101
-— F.,Rechenin., Schoßh.49
-— J.,Eisendrcber,Aarz. 70
-- N., M-d., Marktg. 40
+— F., Rechenm., Schoßh.49
+— J., Eisendreber,Aarz. 70
+- N., Mod., Marktg. 40
 — Chr., Metzger, Aarz. 22
 — I., Leinweber, Schoßh. 74
-— Wtw., Cigarrenm.,Stld. 8
+— Wtw., Cigarrenm., Stld. 8
 — I., Schuhm., Brünng.15
 — N., Käshdl., Neueng.202
 — A., Gypser, Zwiebelng.58
@@ -2520,22 +2521,22 @@ Mosimann, Schuhm., Lgg. 243
 — Frau, Spez., Gerechtg.116
 Mosmer J., Schirmfabr., Gerechtg. 77
 Mottaz C., Lingsre, Grchtg. 73
-Mottet, Jnstr.-Offiz., Arbg. 35
+Mottet, Instr.-Offiz., Arbg. 35
 Mouille geb. Depping, Kräm., Keßlerg. 334
 Mouillet, Jgf., Malerin, Kipchgasse 275
 Mühle U.,Mech., Aarbg. 18
 Mühlethaler I., Kondukt., Aarbergergasse 21
 — Joh., Steinh., Badl. 86
 — v. Mülinen-v. Mutach E. F>, Reut., Gercchtg.95
-— Gurowsky, Rcnt., Gcrechtigkcitsg. 96
-Müller F. E., gew. Ingenieur, Längg. 215 A
-— Pfarrer, Spitalgasse!32
-— Substitut auf d. ^tadtpol., Längg. 215 A
+— Gurowsky, Rent., Gerechtigkcitsg. 96
+Müller F. E., gew. Ingenieur, Längg. 215 g
+— Pfarrer, Spitalgasse 132
+— Substitut auf d. Stadtpol., Längg. 215 g
 — Antiquar, Marktg. 73
-— I., Vater, Müllerin., Sulgenbach 79
-— I., Sohn, Müllerin., Sulgenbach 79
-— Ä., Sprach!., Herrcng. 312
-— G., Obergerichtspräsident, Kramg.152
+— I., Vater, Müllerm., Sulgenbach 79
+— I., Sohn, Müllerm., Sulgenbach 79
+— A., Sprachl., Herreng. 312
+— G., Obergerichtspräsident, Kramg. 152
 — -Häberli, Spez., Krmg. 191
 — Chr., Apoth., Kramg. 181
 — J. H., Schuhm., Postg. 26
@@ -2566,7 +2567,7 @@ Müller A. M., Gärtnerin, Aarziehle 85
 — I., Schnd., Spitalg. 156
 — S. V., Amtsnot., Subst. d. Staatskanzlei, Jdg.112
 — G.R., Schr.,Narz. 85
-— I., Schubm., Käfichg. 99
+— I., Schuhm., Käfichg. 99
 — Casp., Schnd., Hollg. 143
 — M., Schnd., ZwLlng. 40
 — J., Gppser, Schoßh. 53
@@ -2586,13 +2587,13 @@ Müller A. M., Gärtnerin, Aarziehle 85
 — R., Buchbinder u. Papierhändler, Spitalg. 134
 Mumprecht I. I., Spengler, Aarz. 39 b
 Münger A., Fuhrm., Lag. 222
-— Z.,Oberst, Aarz. öö
-— Saagcr im Dalinazi
-— I-/ Flachmaler, Aarz. 135
+— Z., Oberst, Aarz. öö
+— Saager, im Dalmazi
+— I., Flachmaler, Aarz. 135
 — N., Dachd., Aarba. 76
 — Jb., Gppser,Sptlg. 136
 — F.N., Schuhm., Äarbg.30
-— C., WeiHmüll., Spitlg. 148
+— C., Weihmüll., Spitlg. 148
 — A. F., Regt., Käfichg.28
 Munzinqer, Dr., Nydeckg. 198
 Mürset A. A., Postabw., Spitalg. 176
@@ -2630,7 +2631,7 @@ Neukomm J. G., Kürsch., Kramgasse 170
 — J. Jb. Zuchthd., Bllw. 265
 — Schnd., Speichg. 6
 — A. M., Milchhll, Gcktg.112
-Ney L., Bedient., Hcrreng. 304
+Ney L., Bedient., Herreng. 304
 — geb. Dürüsscl, Schneider., Herreng. 304
 Neynens A., Schndm.,Jkg.162
 — H.A., Schndm., Krmg. 218
@@ -2661,22 +2662,22 @@ Noth I., Gypser, Zeughg. 9
 Nötbinger E., Kommiss., Spitalg. 160
 Nothegcn L., Rent., Nng. 1166
 Nüesck C. A., Drechsler, Keßlerg. 29!)
-— S.J., Kamins., Stalb. 15
+— S.J., Kaminf., Stalb. 15
 — I. Chr., jgr., Kaminfeger, Marktg. 35
 Nußbaum I. A., Brunng. 28
-— I., Bäcker, Müllcrl. 26
-— M.,Trödlerin, Marktg. 31
-— geb. Ftiedli, Spitalg. 142
+— I., Bäcker, Müllerl. 26
+— M., Trödlerin, Marktg. 31
+— geb. Friedli, Spitalg. 142
 Nydegger I., Oeler, Mit. 102
-— I. R-, Amtsnot., Läng. 201
+— I. R., Amtsnot., Läng. 201
 — I., Steinbrech., Matte121
 Nyffeler C. S., Schrb., Ilcuengasse 121
 — geb.Mori,Lumpcnsamml., Äarbg. 37
 — E., Schneid., Müller!. 26
 Nyffenegger, Schnd., Arbg. 38
 Oblaser I. A, Spcisewirth, Tiefenau
-Oberbolzcr C., Schuhmacher, Metzg. 134
-d'Ochando, russ. Leg.-Rath, Gcrechtigkeitsg. 162
+Oberbolzer C., Schuhmacher, Metzg. 134
+d’Ochando, russ. Leg.-Rath, Gerechtigkeitsg. 162
 Ochs I. P., Schnd , Bnbenb.-Rain 61
 — H. L., Kanzl., Herreng. 305
 — Jgfr., Schätzerin, Brg.,28
@@ -2690,7 +2691,7 @@ Oesterle C.H., Neg.,Mrktg. 41
 Offenhäuser, I., Schuhmach., Enge 108
 O’Gorman, gb.Brunner, Rnt., Gerechtg. 130
 Ohnstein J. L., Kürschn., Kirchgasse 266
-Olivier, Schubm., Schplg. 191
+Olivier, Schuhm., Schplg. 191
 Oppermann Cbr., Schneiderin, Marktg. 33
 — Jgfr. S., Ncg., Krmg. 147
 Oppliger I. Chr., Buchb., Arziebie 35
@@ -2721,7 +2722,7 @@ Ougspurger Ph. F., Bürgerschreiber, Marktg. 91
 — Ji. F. L., Friedensrichter, Schoßh. 47 u. Grchtg. 64
 Pabst C., Pros., Brückfeld 232
 Pärli Chr., Schr. u. Küchliw., Bärenplatz 101
-Pages A. S., Schnhm-, Neuengasse 108
+Pages A. S., Schnhm., Neuengasse 108
 Pagenstecher Jgfrn., Insg. 136
 Paroz I., Dir. d. neuen Mädchenschule, Stadtbach 178
 Pascboud, Crbschft., Gypshdl., Matte 101
@@ -2747,7 +2748,7 @@ Peyer Jb., Zahnarzt, Metzgergasse 106
 Petzold H., Lehrer, Schifft. 47
 Pfeffli A., Schhm., Vrunnq. 3
 — Chr., Schrn., Neueng.104
-Pfander I., Gcrechtg. 128
+Pfander I., Gerechtg. 128
 Pfenniger J., Sekr., Muesmtt.
 Pfister Chr., Vürstbd., Schauplatzg. 233
 — gb. Sommer, Frau, Schröpferin, Keßlg. 249
@@ -2841,7 +2842,7 @@ Reist L., Lebküchler, Speichg. 4
 Rellstab I. A., Getreidchdl., zwisch. d. Thor. 280
 — I., Schuhm., Längg. 215s
 Remke F. P., Schreiner, Metzgerg. 81
-Rcmnnd Ä-, Krm., Sptlg. 163
+Rcmnnd Ä., Krm., Sptlg. 163
 Renaud, Fürspr.^ Kramg. 162
 — Bankkassier, Herreng. 307
 Renfer N., Sattls, Schplg. 200
@@ -2852,7 +2853,7 @@ Reußer F., Lehrer, Längg. 202
 Reust C., Spez.,Mktg.90
 Reynolds C., Sprachlehrerin, Kramg. 202
 Rhin C., Buchbd., Brunng. 23
-Rhincr F., Lumphdl., Kßg. 276
+Rhiner F., Lumphdl., Kßg. 276
 — -Witschi, Schneid., Schulgasse 305
 Ribi V., Kostgeberin, Aarbergergasse 14
 — Ä. M., Hcbam., Aarbg. 41
@@ -2874,14 +2875,14 @@ Riedwnl R., Buchbd., Kß^g. 244
 Riesen I., Schhm., Sptlg. 126
 — I., Schneider, Sptlg. 177
 — F., Gärtner, Hollig. 142
-— E., Ärämcrin, Schg. 233
+— E., Ärämerin, Schg. 233
 — N., Speisewirth, ^rtald.1
-Rieter H., Seidcn-Negt., Holligen 149
+Rieter H., Seiden-Negt., Holligen 149
 Rindlisbacher, Müller, Müllerlaube 107
 — Bäcker, Metzg. 121
-— P. Milchhdl.,Metzg.92
+— P. Milchhdl.,Metzg. 92
 — Sattl., Schauplg. 204
-Ringgenburger I., Schuhm., Postg.40
+Ringgenburger I., Schuhm., Postg. 40
 Ris A. S., Kaminfeg., Mit. 10
 — C. L., Tffizial, Junkg. 173
 — G. F., gw. Bäck., Altb.162
@@ -2899,14 +2900,14 @@ v. Rodt-Couvreux C. A. S., Prediger, Herreng. 329
 — -Brunner K. E., Rentier, Junkg. 166
 Rodt G. S., Wagnermeister u. Lekenmann, Engemeistergut 247
 — G., gw. Sckirrmst., Marktgasse 32
-Roggcnmoscr A., Schuhmacher u. Musikus, Matte 91
+Roggenmoser A., Schuhmacher u. Musikus, Matte 91
 Rohiner L. Th., Strohhutfabr., Aarz. 22 und Kramg. 165
-Rohncr E. Chr., Schnd., Kßlergasse 255
+Rohner E. Chr., Schnd., Kßlergasse 255
 — Chr., Rent.,Junkg. 185
 — I., Bachknecht, Hollig. 152
 Rohr C. I., Dr. Heck., Junkerim. 153
 — S., Schreiber, Neueng. 92
-— Jgsr-, Bettmach., Spitalgasse 150
+— Jgfr., Bettmach., Spitalgasse 150
 — Alb., Wettmacht., Kßlg. 236
 Rohrbach I., Kutscher u. Gastwirth, Metzg. 118
 — F.Jb., Schneider, Bubenbergrain 61
@@ -2970,7 +2971,7 @@ Rudolf J.,Pächter, Längg. 254
 Rudrauff F. L., Central-Stadtkassier, Bollw. 266
 Rüedi R., Weibel, Grchtg. 112
 — I., Kübler, Matte 36
-— I., Gipser u. Flachmaler, Müllcrl. 33
+— I., Gipser u. Flachmaler, Müllerl. 33
 Ruef S., Pferdehdl., Aarbg. 76
 — F., Speisew., Sptlg. 167
 Rüegger J. Jb., Zimmerm.
@@ -2995,12 +2996,12 @@ Rufener I. B., Schuhmacher, Metzg. 136
 Rufer, Schuhn., Jkg. 182 b
 — I. S. F., Spengl., Altenberg 143
 — Chr., Krämer, Gerbl. 112
-Ruff R., Bäcker, Mctzg. 81
+Ruff R., Bäcker, Metzg. 81
 Rumpf D., Briefträg., Ng. 94
 Rupp, Speisew., Metzg. 137
 Ruprecht A. B. Feinwascherin, Aarbergg. 52
 Rüthi, Frau, Kaubenmacherin, Spitalg. 150
-Rütishauser, Schrein., Mt.119
+Rütishauser, Schrein., Mt. 119
 — Ph., Schlosfer, Sptlg. 151
 v. Rütte, gw. Lehrer., Postg. 45
 — -Henzi, Frau, Bollw. 264
@@ -3010,7 +3011,7 @@ Rychener, Standeswbl., Zeughausg. 14 u. Marktg. 47
 Ryf J. Jb., Speisew., Zghg. 6
 Ryffel Jb., Schneid., Sg. 11
 Ryser I., Schuhn,., Matte 34
-— I., Schuhm., Altcnbg.146
+— I., Schuhm., Altenbg. 146
 — S., Messerschmied, Aarbergerg. 34
 — Wittwe, Käfichg. 22
 — G., Tabakfabr., Stald. 8
@@ -3024,11 +3025,11 @@ Salvisberg S., Amtsnotar, Schauplg. 199
 Salzmann I., Kostpferdhalter, Junkerng. 149
 — F., Schreiner, Neueng. 81
 — Frau, Wäscherin, Matte 79
-Sanvmcier C-, Schrein., Kefilcrg. 289
-Sauser J.,Jnstr.-Adj.,Zqhg.5
+Sanvmcier C., Schrein., Kefilcrg. 289
+Sauser J., Instr.-Adj., Zqhg.5
 Sauter K., Porträtmaler, L>otellb.233, Ablg. Krmg.140
 Saxer F. E., Rothsärb., Altenberg 165
-Schädel I. U., Schuhm., Keßlcrg. 294
+Schädel I. U., Schuhm., Keßlerg. 294
 Schädeli J. A., Sattler, beim Casino 131
 Schädelin, geb. König, Wwe., Metzgerg. 130
 Schäfer F., Buchdrucker, äuß. Bollw. 263
@@ -3063,15 +3064,15 @@ Schaffer J.A., Bandfabrikant, Schoßhalde 206
 Schaffter A., franz. Pfarrer, Herrcng. 324
 — Schwest., Keßlg. 257
 — R., Lehrerin, Judeng. 113e
-— I. I., Jnstruktor, Brg. 3
+— I. I., Instruktor, Brg. 3
 Schaller F., Schriftsetzer, Falkenpl. 217 e
 — I. Chr., Fürsp., Schpg.199
 Schatzmann, Frau, Pfarrer, Spitalg. 149
 — Jul., gb.Fluri, Lohnwasch. Sckistlaube 49
 Schaub I., Wwe., Bollw.81
-Schaufelberger I-, Buchbind., Kreuzg. 105
+Schaufelberger I., Buchbind., Kreuzg. 105
 Scheqg u. Bohlen, Spediteure, Schauplg. hint. d. Bären.
-Scheideggcr I. U., Leinweber, Aarz. 24
+Scheidegger I. U., Leinweber, Aarz. 24
 — Schwest., Schneiderinnen u. Blmnenhandl., Marktgasse 63
 — Chr., Mühlcm., Matte 54
 — Chr., Spsw., Krnhpl.153
@@ -3083,7 +3084,7 @@ Scheidcgger gb. Fehlmann, M., Kleiderputzerin, Stld. 206
 — Frau, Krämer., Aarbg. 67
 Schenk C., Reg.-Rath, Maulbeerbaum, Ablage Spitalgasse 171
 — Ww., Schneid., Aarbg. 27
-— S., Zimmcrm., Auß. Bollwerk 122
+— S., Zimmerm., Auß. Bollwerk 122
 — J.U., Wagner, Sptlq. 173
 — C. F. A., Goldarb., Stalden 216
 — Holzhdl., Spitalg. 173
@@ -3098,9 +3099,9 @@ Scherler A. B., Schneiderin, Keßlg. 237
 Scherrer I. B., Lohnkutscher, Zeughg. 10
 Schertenleib J. Jb.,Schuhm., Aar. 22
 Scherz B., Schneid., Matte 48
-— I., Regicrungsrath, Spitalg. 165
+— I., Regierungsrath, Spitalg. 165
 — Wittwe u. Sohn Theod., Gercchtigk. 141
-Scheuch, Lhnbcd-, Judeng. 127
+Scheuch, Lhnbed., Judeng. 127
 Scheuermerster I. L., Uhrenm., Schauplg. 196
 Scheurer I. G. R., Zuckerbäck, Zwiebg. 39
 — I., Gypser, Marktg. 77
@@ -3120,8 +3121,8 @@ Schiffmann M., Kondukteur, Brunng. 17
 Schick P., Rechtsagt., Sohn, Kornhauspl. 152
 — Fr., Brunng. 7
 Schild J.D., vr. Pros., Kramgasse 183
-Schilt P., Cviff-, Siptalg. 123
-SchindlcrChr., Büchsenschmd., Schauplg. 221
+Schilt P., Coiff., Siptalg. 123
+Schindler Chr., Büchsenschmd., Schauplg. 221
 — L. N., Müller, Schutzmühle 20
 -I. II., Metzger, Junkg.195
 — A., Schlosser, Aarbg. 21
@@ -3145,7 +3146,7 @@ Schlapbach I. Lr., Ziinmerm., Länggaß 215
 — J., Sohn, Schweinmetzg., Neucng. 100
 Schläppi L., Schnd., Mtzg. 127
 Schlatter D., Kaminfcg., Keßlerg. 285
-— I- G., Flachmalcr, Langmauer 227
+— I- G., Flachmaler, Langmauer 227
 — geb. Rohr, Feinwascherin, Keßlg. 257
 Schlee Casp., Bildhauer, im Hochschulgebäude
 Schlub D. W., Gypser, Länggaß 220
@@ -3174,7 +3175,7 @@ Schmid-Flohr, Claviermacher, Monbijou 94
 — Musiklehrer, Kramg. 456
 — I. Jb., Matratzenmacher, Bärenpl. gegcnüb. d. Bärencafs
 — I., Bäcker, Matte 22
-— geb. Stettler, Frau, Jndeng. 122
+— geb. Stettler, Frau, Judeng. 122
 — Maler u. Gypser, Mtzg. 122
 — -Sprüngli, Wttwe, Kranigasie213
 Schmitz A., Sümeid., Bg. 24
@@ -3196,9 +3197,9 @@ Schneider P., erst. Sekretär d. Finanzdep., Spitalg. 160
 — F., Schlosser, Bollw. 80
 — F. J.,Buchdr.,Mktg.46
 — C. A., Barbier, Käfg. 107
-— A. M.. Lehrerin, Aarz.83
-— P-, Schuhm., Aarbg. 41
-— G-, Gärtner, Aarz. 86
+— A. M., Lehrerin, Aarz.83
+— P., Schuhm., Aarbg. 41
+— G., Gärtner, Aarz. 86
 — Wit wc, Neueng. 91
 — Wr.,Nudlen»i., Stald.10
 — O., Privatlehrer, Mktg. 71
@@ -3226,7 +3227,7 @@ Schönt A.E., Kram., Lngg. 227
 — Buchbd., Scharfrichtg. 115
 Schonhcr F., Schuhm., Stalden 212
 Schorer S., Mnzbeamt., Postgasse 43u
-— geb. Glcthcr, Tapetcnhdl., Kramg. 172
+— geb. Glcther, Tapetcnhdl., Kramg. 172
 Schort R., Bäcker, Marktg. 52
 — Bäcker, alt. Schwnmkt.251
 Schrämli I. Jb., Schuhmach., Brunng. 15
@@ -3263,7 +3264,7 @@ Schütz P., Silberarbeiter, Gerberngrb. 140
 Schwab I., Pferdehändler, Aarbergg. 77
 — Frau, Kostgeberin, Spitalgasse 142
 Schwager J. A., Kappenmach., Gerechtg. 67
-Schwäglcr N., Ausrufer, Müllerlaube 35
+Schwägler N., Ausrufer, Müllerlaube 35
 Schwalm, Wirth, Metzg. 115
 Schwarz U., Schrn., Schg. 219
 — I., Asphltarb., Brunng. 21
@@ -3289,8 +3290,8 @@ Schweizer, Karl, Amtsnotar, Kramg. 185
 — F., Hafner, Brung. 2
 — I., Quincailleriehndlung, Marktg. 94
 — F., Schreiner u. Speisew., äuß. Bollw. 268
-Schwitz B., Roßhaarfabrikant, Altcnbg. 120
-Schwpzcr Jb., Ngt., Altbg.274
+Schwitz B., Roßhaarfabrikant, Altenbg. 120
+Schwpzer Jb., Ngt., Altbg.274
 Seeger I., Modiste, Käfg. 23
 Segessenmann, Einnehmer im Bahnhof
 Seewer Jgfr., Schnd., Ag. 61
@@ -3304,7 +3305,7 @@ Senn N., Lehrer, Inselg. 136
 — F. N., Postofftz., Schg. 235
 — F.. Fechtmstr., Schg. 215
 Sesti A., Regt., Kramg. 185
-Shuttleworth, Rcnt., Bierhübeli 227
+Shuttleworth, Rent., Bierhübeli 227
 — R.I., Dr., Bierhübeli 227'
 Sidlert A., Dr., Lehr., Aarz. 2
 Sieber F. Jb., Ngt., Schg.216
@@ -3337,7 +3338,7 @@ Simon, Notar u. Rechtsagent., Marktg. 68
 Sing I., Küfer, Speichere,. 1
 Singeisen, Chef d. Cent.-Po«"Bureau, Casinoplatz 131
 v. Sinner-v. Kirchberger I.. Rent., Spitalg. 155
-— «Sinner A. F. R., Rent., gew. Obcramtmann von Seftigen, Junkg. 178
+— «Sinner A. F. R., Rent., gew. Oberamtmann von Seftigen, Junkg. 178
 — -v. Wattenwyl C. F., Renk., Marktg. 72
 — -v. Fischer R. C. F., Rent., Kramg. 166
 — B. R., Archit., Grchtg. 86
@@ -3350,7 +3351,7 @@ v. Sinner-v. Kirchberger I.. Rent., Spitalg. 155
 — geb. v. Stürler, Junkerng. 174 u. 175
 Sohner I. R., Zimmermann, Spitalg. 147
 Sollberger I., Gram, Schauplatz«. 196
-— M-, Schneid., Aarbg. 58
+— M., Schneid., Aarbg. 58
 Sommer u. Comp., Mineralwasserhdl., Kehlg. 237
 — I., Geschäftsm., Aarbg. 32
 — L., Pferdbdl., Aarbg. 46
@@ -3359,7 +3360,7 @@ Sommer u. Comp., Mineralwasserhdl., Kehlg. 237
 # Date: 1861-04-15 Page: 1395970/116
 Spahr H.J., Küf., Junkg. 119
 Spalinger F., Bäcker, Gerechtigkeitsg. 133
-Spätig F., Jnstrukt., Zghg. 13
+Spätig F., Instrukt., Zghg. 13
 Spengler I. H., Schuhmacher, Marktg. 90
 Spicher R., Postcom., Mit. 127
 — J., Butterhdl., Brunng.19
@@ -3377,8 +3378,8 @@ Spring R., Schneider, Salzmagazin 236
 Sprüngli, Jgfr. (von Belp), Kramg. 162
 — Jgfr., Musikl., Zwiebg., 10
 Sprünglin N., Stubenschreib., Hotell. 231
-— Louise, des Apoth. Wittwe, Jnselg. 136 k
-Spuhler Frau, Bcttwaarenhdl., Marktz. 88
+— Louise, des Apoth. Wittwe, Inselg. 136 k
+Spuhler Frau, Bettwaarenhdl., Marktz. 88
 Stadelmann P.,Neg., Mhg.89
 Städter S., Schneid., Mit. 115
 Stadlin C. M., Zinngießer, Altenbg. 161
@@ -3388,7 +3389,7 @@ Stahel J.U., Feilenh., 2tbg.71
 Stäheli, Regt., Marktg. 38
 — Frau, Ellenwaarenhandl., Kramg. 221
 Stähli, Zimmerm., Enge 117
-— I-, Knopfmacher, Kafg. 25
+— I., Knopfmacher, Kafg. 25
 Stäbli-Groß, Revisor, Altenb. 160 k
 — --c., Krämer, Sptlg. 161
 — A., Postcom., Kornhpl. 5V
@@ -3396,7 +3397,7 @@ Stäbli-Groß, Revisor, Altenb. 160 k
 — Jb., Bäcker, Matte 53
 Stalder F., Glaser, Sptlg.117
 Stämpfli Jb. , Bunvesrath, Böhlenhaus 128
-— I. F. R., gcw. Küfcrmstr., Neueng. 90
+— I. F. R., gcw. Küfermstr., Neueng. 90
 — S. G. R., Eiscnnegotiant
 — C. G., Architekt, Metzg. 126
 — B.A., Spcz., Metzg. 126
@@ -3430,9 +3431,9 @@ Stauffer, Tuchhdl., Mktg. 57
 — I. S. B., Schreiblehrer, Kramgasse 220
 — J. C. G. ZNot., Brunng.36
 — D., Schuhm., Schg. 2245
-— I. C-, Sekr., Spitlg. 165
+— I. C., Sekr., Spitlg. 165
 — A., Schuhm., Aarbg-39
-— M.,Kostgeb., Gerechtg.144
+— M., Kostgeb., Gerechtg.144
 — Frau, Dekatier., Mktg. 90
 — geb. Meyer, Bettmacherin, Spitalg. 150
 — L., Kanzlist, Aarberg. 67
@@ -3441,18 +3442,18 @@ Steiler I., Schrein., Stald. 3
 — N., Amtsnot., Zeughausplatz 251 u. 252
 Steck L. F. I., Spitalbcrwalt., zwisch. d. Thor. 274
 — C.F. R.,Amtsnot., Inselgasse 136 e
-— Ä., Fürspr., Aarbcrg. 55
+— Ä., Fürspr., Aarberg. 55
 Steffen Schwest., Schneider., Storcheng.
 — Wirtb z. Storch., Sptg.157
 — S., Bäcker, Schutzmüüle20
 Stegmann J.F., Hafn., Äg.41
 — F., Modiste, Aarbergg. 41
 — I., im Bahnhof
-Stehli, Frau,Schnd-, Mktg.44
-Steiger Jb., Sattl-, Mtzg-109
+Stehli, Frau, Schnd., Mktg. 44
+Steiger Jb., Sattl., Mtzg-109
 — R., Bäcker, Spitalg. 175
 — G., Buchbinder, Frick 74
-— H., Schneid., Aarbcrg. 65
+— H., Schneid., Aarberg. 65
 — Elise, Glätt., Brunng.25
 — ^Cöleste, Ling., Brunng.25
 v. Steiger F. A., Feldkassäverwalter, Neueng. 122 u. 117
@@ -3460,7 +3461,7 @@ v. Steiger R. L. A., Banquier, Spitalgasse 127
 — F.A., gew. Offizier in Holland, Spitalg. 131
 — Frau, Rathsh., Sptlg. 127
 — K., Oberst, Spitalg. 130
-v. Sinncr C. L. I., Oberbibliothekar, Sulgenb. 64
+v. Sinner C. L. I., Oberbibliothekar, Sulgenb. 64
 — F. R. F., Sekretär, Brunnadern 16
 — Frln., Rent., Junkg. 177
 - -v. May, Junkg. 177
@@ -3535,7 +3536,7 @@ Stell, Jb., Küfer, Speichg. 6
 — A., Kanzlist, Neueng.113 d
 Stooß, S. C., gew. Reg.-Rath, Äetzgerg. 101
 — Schwestern, Grchtg. 102
-— I. F., Mctzgerm., Kramg. 164
+— I. F., Metzgerm., Kramg. 164
 — S. A., Spez., Kramg. 164
 — Frau Doktor, Neueng. 113
 Stößel, B. E., Notar, Grchtg. 146
@@ -3566,7 +3567,7 @@ Stuber, I. R., gcw. Brodbäck., Spitalg. 149
 — S., Dachdecker, Aarbg. 77
 — R., Regt., b. Casino 131 a
 — Karl, Schlosser, Metzg. 80
-Stübner, Ch. W., Schreiner, Gcrberngr. 138
+Stübner, Ch. W., Schreiner, Gerberngr. 138
 Studer, B.F., Apoth., Spitalgasse 178
 — G. L., Pros. d. Theologie, Spitalg. 178
 — G. S., Reg.-Statth., Spitalg. 134
@@ -3582,7 +3583,7 @@ Studer-Lanterburg, Pelik. 230
 — Mechaniker, Käfichg. 25
 Stucki J.B., Küfer, Längg. 193
 — Chr., Schuhmach., Brunngasse 26
-— R., Mehlhändlcr, Schauplatzg. 208
+— R., Mehlhändler, Schauplatzg. 208
 — Gbr. L., Steinh., Längg. 193
 — Ar., Bäcker, Längg. 215 d
 — S., Mehlhändl., Metzg. 74
@@ -3619,21 +3620,21 @@ Tännler I., Kondkt., Aarbg. 21
 v.TavelA., Redakt.,Sptlg. 123
 — C. L., gewes. Oberst, Blumenrain 13 u. Kramg. 173
 — -v. Werdt L. N., Rentier, Spitalg. 126
-— -v. Stüicler Ä. V., Rent., Keßlcrg. 258
+— -v. Stüicler Ä. V., Rent., Keßlerg. 258
 — geb. Wägnerhv. Frutigen), Spitalg. 123
 Tellenbach F., Schm. Stld. 11
 Terrano, Gypser, Aarbg. 77
 Thaler Ww., Regt., Krmg. 196
 Theurer C. G.L., Tapez., Keßlerg. 248
-Teuschcr W., Fürsprecher, Gerechtigkeitsg. 89
+Teuscher W., Fürsprecher, Gerechtigkeitsg. 89
 Thiele, Müsiklehrer, Muesmatt
 Thierstein J., Postcom., Ag. 38
 — Wtw., Mehlhl., Aarbg. 28
 Thomann Sl., Comm., Bubenbergsrain
 ThomaßA., Apoth., Grchtg. 118
-Themen, Hasncr, Aarbg. 66
+Themen, Hasner, Aarbg. 66
 Thormann-v. Wyttenbach F., W., (v. Gerzensee), Rent., Spitalg. 155
-— -v. Bären A. V. L., Rcnt., Gerechtg. 100
+— -v. Bären A. V. L., Rent., Gerechtg. 100
 — -Grüner C. E. F., Junkerng. 185
 — N. F. E., Gutsbes., Muristalden 13
 — -o. Erlack F. R., Rentier, Muristalden 13
@@ -3643,8 +3644,8 @@ Thürner S., Darbd., Sptg. 139
 Tobler I. Jb., Schr., Bstbcnbergsrain 58
 — Frau, Wasch., Matte 14
 — I., Registrator, Stald. 267
-Trabold B-, Glaser, Nng. 111
-— Zgfr., Oberlchr.,Postg.45
+Trabold B., Glaser, Nng. 111
+— Zgfr., Oberlehr., Postg. 45
 Trackisel Ckr., Speisew., Aarberg. 70
 — R., Pferdh., Zeughg.15
 Trächsel G., Doz., Grbgr. 144
@@ -3657,9 +3658,9 @@ TribolctZ. A., Pros., Dr. Llsä. Lorraine (Abl. b. Fürspr. Lutz, Gerbernl. 62)
 — Jbl, Speisew., Bollw. 78
 Tritschler I., Neg., Krmg. 217
 Tritten E., Schr., Keßlg. 283
-Trolltet R-,Hufschm.,Arbg. 35
+Trolltet R., Hufschm., Arbg. 35
 # Date: 1861-04-15 Page: 1395975/121
-Trüb I., Kamt. u. Spezicrer, Müllerl. 107
+Trüb I., Kamt. u. Spezierer, Müllerl. 107
 Trümpler I., Barb., Arbg. 63
 Trümpy A., Commission., Inselgasse 133
 Trüßel Joh., Kettelim., Speicher^. 9
@@ -3668,7 +3669,7 @@ v.TschannV., Bang., Krg. 145
 Tschanen Chr. , Steinhauer, Spitalg. 158
 — Wtw., Bäcker, Aarbg. 60
 Tschantre I., Schn., Nng. 89
-Tschanz N., Jnstrukt., Abg. 70
+Tschanz N., Instrukt., Abg. 70
 — A. Chr., Schuhmach., Gerbern«. 141
 — geb. Fues, Hebam., Brunngasse 6 u. 7
 — Jb., Bäcker, Stald. 206
@@ -3689,13 +3690,13 @@ v. Tscharner, geb. v. Fischer, Frau, Junkerng. 154
 — Frl. Amalie, Kramg. 177
 Tscharner I. C., Redakt., äuß. Bollw. 267
 Tschiffeli F., Archit., Chef des Brandkorps, Stadtb. 177
-— R. S.,Umbictcr, Mtzg. 127
+— R. S., Umbicter, Mtzg. 127
 — gb. Christen, Frau, Photograph., Postg. 33
 Tüscher Jb., Klösterliw., Stld.
 — Abwart, Brunng. 29
 — Jb., Kondukt., Gerechtg. 76 u.
 Uebersax J.,Tanzlhr.,Bllw.11
-Ulemann A., Buttcrh., Schifflaube 52
+Ulemann A., Butterh., Schifflaube 52
 Uli F., Revisor u. Not., Kramgasse 174
 — Gebr., Leinwandhandlung, Kramg. 174
 Ulrich M., Schn., Neueng. 110
@@ -3711,7 +3712,7 @@ Valentin G., Pros., Juda. 112
 Valentini, D., Chocoladefabr., Gerechtg. 86
 Vafsaur A. D., Schn.,Herrengasse 298
 # Date: 1861-04-15 Page: 1395976/122
-Vasserot P. A. F., Hutmachcr, Kramg. 135
+Vasserot P. A. F., Hutmacher, Kramg. 135
 Verdat, Arzt, Inselg. 135
 Verrey M. I., Kram., Neuengasse 119
 Vetterli N., Cemnnssion., Aarbergerg. 33
@@ -3773,17 +3774,17 @@ Walch A., Maler, Marktg. 40
 Wälchli I., Schuhm., Spitalgasse 160
 — Al., Bäcker, Aarbg. 64
 — Frau u. Tochter, Spchg. 6b
-Wald I. A.,Schnitzlcr, Marktgasse 50
+Wald I. A., Schnitzler, Marktgasse 50
 Wälder Chr. G., Schuhmach., Schauplatzg. 194
-Walker I-, Maurer, Brunng. 22
+Walker I., Maurer, Brunng. 22
 — N., Buchb., Kramg. 150
-v. Wallier geb. v. Lentulus, Rcnt., Kramg. 148
+v. Wallier geb. v. Lentulus, Rent., Kramg. 148
 Walter J.D.,Steinh.,Mt. 67
 — Fr., Spez., Marktg. 33
-Walthard N. G., Handelsin., Langmauer 254
+Walthard N. G., Handelsm., Langmauer 254
 — F. R.,Buchhl., Krmg.219
 - J.J.F., Kunstmal., Postgasse 40
-Walther L. D., Kupfcrschm., Metzg. 123
+Walther L. D., Kupferschm., Metzg. 123
 - R. F., Brodb.,Metzg. 119
 — H., Spezier., Spitalg.141
 — F., Kamms., Aarbg. 63
@@ -3793,17 +3794,17 @@ Walther L. D., Kupfcrschm., Metzg. 123
 — E., Lohnwasch., Brng. 82
 Wälti F., Gcschäftsm., Stld. 3
 — R., Schuhm., Sptlg. 152
-— I. R-, Bäcker, Grchtg. 145
+— I. R., Bäcker, Grchtg. 145
 — R.,Mod., a.Bollw. 266
 — I., Tuchnegt., Marktg. 55
 — N., Seckelm., Sptlg. 152
-— E-, Schn.,Zeughg.12
-Wanner N., Speisew., Speichcrg. 5ck
+— E., Schn., Zeughg.12
+Wanner N., Speisew., Speicherg. 5ck
 — I., Sattler, b. obern Thor. 123
 Wanner F., Schn., Matte 96
 Wanzenricd N., Wagn., Arz. 89
 v. Wartburg I. U., Schreiner, Matte 76
-— gb. Nobs, Frau, Zuckerbck-, Aarbcrg. 31
+— gb. Nobs, Frau, Zuckerbck., Aarberg. 31
 Wasserfallen Frau, Hebamme, Keßlerg. 286
 v. Wattenwpl G. E., Rent. u. Gutsbes., zw. d. Th. 180
 — geb. Tscharner, Frau, Junkerng. 150
@@ -3857,24 +3858,24 @@ Weiler M., Neg., Marktg. 33
 — M., Speisew., Aarbg. 33
 Weiler Schwestern, Modist. u. Ling., Aarbg. 45
 — F.. Sohn, Reg., Aarbg. 52
-Weingart A., Buchdr-, a. Bollwerk 263
+Weingart A., Buchdr., a. Bollwerk 263
 Weiß Jb. F., Gefangenwärter, Käfichthurm
 — Gebr., Schirmh., Mktg.67
 — Fr., Bärenw., Spitlg.242
 - J.Jb.,Spengl., Kßg.280
-— C., Quincaillh.,Krma. 222
+— C., Quincaillh., Krma. 222
 Weißenbach, Vater und Sohn, Zeugschm., Matte Müllerlaube 107
 Weißkopf Jb., Schuhm., Zeughausg. 249
 Welti A., Reuengasse 91
-Wendel Jb., Dresckst-, Krg. 91
+Wendel Jb., Dresckst., Krg. 91
 — I. F., Kamm., Kramg.179
 Wenger G., Lehrer, Einwohn.polizei 337
-— Chr., Lehrer, Kcßg. 243
+— Chr., Lehrer, Keßg. 243
 — Chr., Regt., Aarbg. 29
 — Wtw., Cvnsts.,Kramg.194
 — N., Tap., Marktg. 55
 — Chr., Buchb., z. d. Th. 180
-— Chr., Polizeid^, Kcßg. 237
+— Chr., Polizeid., Keßg. 237
 — I., Kondukt., Brunng. 3
 — Chr., Mehlh.,Aarbg. 22
 — G., Schuhm., GerbI. 141
@@ -3953,7 +3954,7 @@ Wirtz I., Kunstm., Kramg. 185
 — J., Bürstenhl., Salzm. 238
 — Frau, Schneid., Marktg.39
 Witschi J., Regt., Marktg. 54
-— J., Müllerin., Aarz. 72
+— J., Müllerm., Aarz. 72
 — N. Flachm., Aarbg. 29
 — Jb., Bäcker, Spitalg. 169
 Wittmer Chr., Lithogr., Zwiebelng. 57
@@ -4040,7 +4041,7 @@ Wyß C. B., Prof., Bill. 167 c
 Wyßbach, Joh., Messerschmied, Altenberg 178
 Wyßmann, Sägenf., Bollw. 82
 — M., Schnd., Kramg. 140
-Wytten S., Schn-, Brunng.22
+Wytten S., Schn., Brunng.22
 Wyttenbach Rud., Gutsbesitzer, Weißenbühl 52
 Wyttenbach F. E., Ingenieur, Kramg. 205
 — S. A., gew. Amtsschreib., Kramg. 219

--- a/src/cleanup/charset_exceptions.txt
+++ b/src/cleanup/charset_exceptions.txt
@@ -3,6 +3,12 @@
 # Normally, the tool in src/cleanup/checkup_charset.py would report these,
 # but in some exceptional cases, they’re known to be good.
 
+# Date: 1861-04-15 Page: 1395918/64
+— Café français, Bollw. 267
+
+# Date: 1861-04-15 Page: 1395952/98
+Lüçon H., Lehrer, Kramg. 159
+
 # Date: 1935-12-15 Page: 26020341/38
 – W., Dr. med., Spezialarzt f. innere Krankheiten. Praxis: Bärenplatz 9, 13½ bis 15½ und nach Uebereinkunft [29.421]; Wohng.: Gotthelfstrasse 18 [25.328]
 


### PR DESCRIPTION
After this change, 168 of 4079 records (4.1%) in the 1861 volume are still failing the tests of `check_charset.py`