### PR TITLE
Clean up some OCR errors in 1861 scan

### DIFF
--- a/proofread/1861-04-15.txt
+++ b/proofread/1861-04-15.txt
@@ -24,7 +24,7 @@ Aebi A. B., Bettm., Hlzm. 243
 — I. S., Schr., Herreng. 300
 — R., Fürspr., Inselg. 136 b
 — M., Schneiderin, Aarbergerg. 69
-— J., Cigarrinhdl., Jkg. 183
+— J., Cigarrenhdl., Jkg. 183
 Aebischer A., Rent., Sptg. 161
 Aeschbach J., Schrein., Ag. 17a
 Aeschbacher E., Zeughausarb., Schifflaube 56
@@ -167,7 +167,7 @@ Beck Jb., Schnd., Kramg 152
 — Ed., Reliefkartenfabrikant, Spitalgasse 141
 — geb. Buß, Lehr., Postg. 43
 — E., Fürspr., Falkenpl. 218
-— I., Pros., Falkenpl. 218
+— I., Prof., Falkenpl. 218
 — I. N., Regt., zw. d. Thor.
 — U., Speisew., Grchtg. 120
 Becker J. S., Instrumentm., Kramgasse 195
@@ -467,7 +467,7 @@ Brunner L. F., Schreib., Kornhauspl. 50
 — I. S., Schr., Stalden 16
 — -Blau, D. R. L., Hdlsm., Hotcllaube 230
 — -Lüthard A.F., gew. Mas., Inselg. 136
-— C. E., Pros., Marktg. 50
+— C. E., Prof., Marktg. 50
 — -Sutter I. R., Handlsm., Gerechtg. 130
 — -Marcuard F.R., Handelsmann, Junkerngasse 178
 — Fz. Rd., Drechsl., Brg. 21
@@ -824,7 +824,7 @@ Einiger, vr., Journal., Lg. 247
 — L., Antiquar, Metzgerg. 97
 Ellenberger I., Schn., Schoßhalde 65
 — I., Schuhm., Metzg. 79
-Emmert C. vr., Pros., Htl. 229
+Emmert C. vr., Prof., Htl. 229
 — W. vr., äuß. Bollwerk 268
 — geb. Dann, Rt., Krma. 181
 Enchelmayer, Wwe., Silbergeschirrputz., Muesmatte
@@ -889,7 +889,7 @@ Fehlmann A. M., Schneiderin, Schauplatzg. 213
 — Schuhm.,Schauplatzg.217
 Fehr I. C., Tel.-Büreauchef, Gerecktg. 70
 — geb. Wäber, Linq., Kramgasse 203
-v. Fellenberg-Rivier, L. R., Pros., Roscnbühi 157 b
+v. Fellenberg-Rivier, L. R., Prof., Rosenbühl 157 b
 — E. L., gew. Kuchthauspred., Junkerng. 185
 — (v. Hofwyl) E., Jkg. 185
 — (v. d. Wegmühle) Gchg. 90
@@ -1037,7 +1037,7 @@ Fuchser Jb., Schr., Aarbg. 56
 Fues geb. Benteli, Leichenbitt., Drunng. 1
 — Fr., Schuhm., Brunng. 1
 Fueter E. F., Eisennegotiant, Falkenplätzlein 217 b und Marktgasse 58
-— geb. Bücher, Wtw. d. Pros., Marktg. 42
+— geb. Bücher, Wtw. d. Prof., Marktg. 42
 — Wtw. des Apothekers, Gerechtg. 119
 Furer I. F., Hutm., Rng. 103
 — C. F., Amtsn., Marktg. 64
@@ -1056,14 +1056,14 @@ Gander Chr., Wirth i. d. Enge
 Ganguillet A., Ncg., Mrktg. 39
 — E., Oberingen., Nng. 121
 Garnier, Oberricht., Zcughg.8
-Garraud, I. Cbr., Schreiner, Falkenplatzti 212
+Garraud, I. Chr., Schreiner, Falkenplatzti 212
 Garraux J., Echr., Gerechtigkeitsgasse 131
 — I. F., Schr., Flkenegg 223
 — gb. Gfeller, Bäurischichn., Gerbg. 131
 Gartenmann, Junkerng. 185
 Gaschen I. R., Lohnbedienter, Speicherg. 6
 — I., Graveur, Aarbg. 33
-Gasser Cbr., Kanzl., Aarbg. 28
+Gasser Chr., Kanzl., Aarbg. 28
 — F. N., Schuhm., Kramgasse 203
 — C., Autogr., Metzgerg. 92
 — F., Sattler, Marktg. 48
@@ -1100,7 +1100,7 @@ Gerber S., Kappenm., Zwieb.gäßchen 61
 — M., Modist., Speichg. 7
 — N., Krämer, Aarbg. 61
 — I., Steinst., Postg. 30
-— Cbr., Schnd., Zeughg. 9
+— Chr., Schnd., Zeughg. 9
 — Jb. Schmied, Speichg. 7
 — Z. Jb. E., Silberschmied, Schifflaube 51
 — S., Regt., v. Schlößli üb. die Muesmatte 179
@@ -1145,57 +1145,57 @@ Gfeller B., Küfer, Marktg. 33
 Gilgen J., Schuhm., Metzg. 88
 — Jb., Schneid., Spitg. 166
 — R., Schneid., Aarbg. 56
-Gillieron, D., Rt., Holiig. 1K>
+Gillieron, D., Rt., Holiig. 166
 Giobbe I., Taphdl., Schg. 217
-Girardet F. Uebers.,Krmg.111
+Girardet F., Uebers., Krmg.111
 Giordani, Gipser, Gerechtigkeitsg. 116
 Giraud-Faure M. F., Weinhdl., Spitalg. 1,1
-Giroud 9. C., Musiki. Pstg. 13
-— V., Musiki., Kraing. 110
+Giroud L. E., Musikl., Pstg. 13
+— V., Musikl., Kramg. 110
 Giudice, Part., Kramg. 202
 — M., Modiste, Krmg. 202
-Glan'pnann I., Strumpfwb., Matte 19
-Glaser, Schuhn,., Schg. 208
+Glanzmann I., Strumpfwb., Matte 19
+Glaser, Schuhm., Schg. 208
 Glättli H., Hafner, Holiig. 189
-Glauser, Pferdblt., Junkg. 117
+Glauser, Pferdhlt., Junkg. 117
 — G.F., Kaminf., Brunng. 3
 — I., Steinh., Matte 16
-— P., Hoizhdl., Postg. 85
-— S., Vehrer, Postg. 28
-— C., Schnd., Krauig. 221
+— P., Holzhdl., Postg. 85
+— S., Lehrer, Postg. 28
+— C., Schnd., Kramg. 221
 — Chr., Metzg., Brunng. 3
-Glai, Jb., Koblenhändl., Äüllerlaube 88
+Glatz, Jb., Kohlenhändl., Müllerlaube 88
 — Rnd., Speisew., Stld. 221
 Glinz I., Buchb., Sptlg. 177
 Gloor I. H., Kappenmacher, Spitalg. 113
 — geb. Götti, Krankenwärt., Aarbg. 10
 — Wtw., Spitalg. 167
-Glotz, Kubier, Schaupltzg. 2i!3
-Glur Jb., Schlosser, beiin unt. Thor 225
-— Iran, Hcbam., u. Th. 225
-— Iran, Galand., Mtzg. 123
-Gnautb, Frau, Blumcnfabrk., Marktg. 17
+Glotz, Kübler, Schaupltzg. 203
+Glur Jb., Schlosser, beim unt. Thor 225
+— Frau, Hebam., u. Th. 225
+— Frau, Galand., Mtzg. 123
+Gnauth, Frau, Blumenfabrk., Marktg. 17
 — Barbier, Aarbg. 77
 Gnägi, Uhrenm., Aarbg. 21
 v. Gonten I., Cent.-Pol.-Sekr., Käfichg. 22
 — I., Bäcker, Aarbg. 57
-— Jb., Aspbalti., Klappl. 19
-v. Gonchnbach, 11r., Großr., in Auri, lAblage b. Ponti)
-Gorge N., Revisor, Quästor V. Hochschule, Ilarbg. 52
+— Jb., Asphaltl., Klappl. 19
+v. Gonzenbach, Dr., Großr., in Muri, (Ablage b. Ponti)
+Gorgé N., Revisor, Quästor d. Hochschule, Aarbg. 52
 Gosteli Jb., Schnd., Matte 81
 # Date: 1861-04-15 Page: 1395936/82
 Gosteli, Kondukt., Käfichg. 98
 Gottier Chr., Färber, Hllg. 149
-Götz Chr., Kaffeew. Krmg.161
-v. Goumoens - v. Tavel, Wwe., Reut., Billette 168
+Götz Chr., Kaffeew., Krmg.161
+v. Goumoens - v. Tavel, Wwe., Rent., Billette 168
 — E. R., Verwl., Krmg. 142
-— -v.Stürlersv.Chcsaux)A., Rent., Kreuzg. 105
+— -v.Stürlers (v.Chesaux) A., Rent., Kreuzg. 105
 — A. C., Rent., Kramg. 152
 — Luise, Kramg. 167
-— - gb. o.Sinuer, Frau, Kramgasse 172
-Gräs G., Schreiner, Bubenbergrain 64
+— gb. v. Sinmer, Frau, Kramgasse 172
+Gräf G., Schreiner, Bubenbergrain 64
 — L. H., Schr., Metzg. 136
-Graf L. Th., gew. StandeSkas. Markta. 91
+Graf L. Th., gew. Standeskas., Marktg. 91
 — C., Messerschm., Krmg. 169
 — Jgfr., Inselg. 138
 — I. P. E., Schriftsetz., Altenb. 170
@@ -1207,16 +1207,16 @@ Graf L. Th., gew. StandeSkas. Markta. 91
 — (v. Burgistein) Judg. 124
 — Frau, Neueng. 90
 — Frln., Spitalg. 149
-— zeb. Morell, Wwe., Reut., Billette 167 >:
+— geb. Morell, Wwe., Rent., Billette 167 c
 — (v. Blonay) Frl., Hrng. 329
 — Wittwe, Junkerng. 181
 — -Marcuard, Gerechtg. 84
 — C. A., Arch., Junkg. 181
 — F., Rent., gew. Offizier in Frankreich, Kramg. 186
-— F. A. Hasnerm., Hrg. 306
+— F. A. Hafnerm., Hrg. 306
 Granicher G., Schweinmetzg., Schauplatzg. 207
 Granicher B., Sattl., Lgg. 267
-— F- G., Ing., Gerechtg. 102
+— F. G., Ing., Gerechtg. 102
 Grau S., Krämer, Bruung. 30
 v. Graviseth, Frl., Junkg. 176
 Graydon, Rent., z. d. Th. 183
@@ -1227,11 +1227,11 @@ Greter A., Schn., Brunng. 11
 Gribi L., Kondukt., Matte 31
 — I. F., Krankenw., Abg. 58
 — Wtw., Kramg. 169
-— Reallehrer, Sommerleist 171 1>
+— Reallehrer, Sommerleist 171 b
 Grieser I. M., Schuhmacher, Matte 24
-Grimm I. M., Milchhändler, Neu eng. 107
+Grimm I. M., Milchhändler, Neueng. 107
 — F. R., Wattcnfabr., Kramgasse 147
-— geb. Lutfiorf Rt. Mtzg. 130
+— geb. Lutstorf, Rt., Mtzg. 130
 — C., Kräm., Nydeckg. 234
 — S., Gärtner, Längg. 201
 Griesel M., Schmied, Spitalgasse 162
@@ -1240,14 +1240,14 @@ Großenbacher Jb., Weißmüller, Aarz. 77
 Großenbacher I. F., Schneid., Matte 83
 — N., Kondukt., Metzg 77
 — Jb., Bäcker, Herreng. 304
-— F. E., Aorbm., Matte 80
+— F. E., Korbm., Matte 80
 — A. B., Kräm., Mrktg. 31
-— Mehlhändl., Sptlg. 125 u
-Großglaufer N. G., Tabakfab., Längg.200
+— Mehlhändl., Sptlg. 125 a
+Großglaufer N. G., Tabakfab., Längg. 200
 — Zimmerm., Längg. 154
 Grosjean C., Kutsch., Mktg. 77
 — C.H.N., Regt., Aarb. 31
-Grüßn, C.L., Com., Aarbg.53
+Grüßy, C. L., Com., Aarbg.53
 Grütter Jb., Schn., Mrktg. 69
 # Date: 1861-04-15 Page: 1395937/83
 Grütter Frau, Spez., Mktg. 53
@@ -1256,21 +1256,21 @@ Grützner C. G., Buchdrucker, Aarbg. 44
 — Carl, Commis, im Pelikan
 Gruber-Meßmer, C. E., Rt., Kramg. 195
 — R., Schuhm., Gall. Rcb. 6
-Grüner I. F., Graveur, Bollwerk 267
+Gruner I. F., Graveur, Bollwerk 267
 — H. L. F., Schr., Lngg. 201
 — Frau, Käfichg. 25
 — (v. Worblaufen), Papierfabr., Ablage Keßlrg. 282
-— Rud., Sigrist am Münster u. Umbieter v. Ober-Gerwern, Kirche,. 281
-— -Haller F., Kassier, Kramgasse 21 l
-— W. R., Sattl., Keßlg.244
+— Rud., Sigrist am Münster u. Umbieter v. Ober-Gerwern, Kirchg. 281
+— -Haller F., Kassier, Kramgasse 211
+— W. R., Sattl., Keßlg. 244
 — R., Abwart der Stadtbibl., Kramg. 215
 Gründer, I., Neueng. 122 b
-Gschwind M., Gilctmacherin, Aarberg. 29
+Gschwind M., Giletmacherin, Aarberg. 29
 — W., Calandr., Aarbg. 29
-Gubler, Sämcidermst., Stld.6
+Gubler, Schneidermst., Stld. 6
 Güdel N., Büchsenmacher, Gerechtg. 90
-Güder C. I. M., Verw. d. Deposito-Cas. Falkpltz. 218 6 u. Zwiebelng. 40
-— I. I., Sigrist a. Münster, Kirchg. 2Ö9
+Güder C. J. M., Verw. d. Deposito-Cas. Falkpltz. 218 d u. Zwiebelng. 40
+— J. J., Sigrist a. Münster, Kirchg. 269
 — Rosina, Zeichnerin, Kirchgasse 269
 — Cd. D., Pfarrer auf der Nydeck, Junkerng. 187
 — R., Commis, Kramg. 175
@@ -1299,77 +1299,77 @@ Gyger F., Thierarzt u. Speisewirth, Aarbg. 46
 — Clise, Cravattenmacherin, Marktg. 64
 Gylam R., Abwart d. Baudir., Kirchg. 314
 Haag G., Ncg., Altenberg 180
-— geb. Fischer Frau, Rent., Kramg. 139
+— geb. Fischer, Frau, Rent., Kramg. 139
 — -Keller, Neueng. 113
-— S. R., Ing., Postg. 43 »
+— S. R., Ing., Postg. 43 a
 — C. G., Schreib., Stald. 17
 — A., Schuhm., Neueng. 108
 Haari, Wwe., Steinbrech., am Spiegel
 # Date: 1861-04-15 Page: 1395938/84
 Haas I., Notar, Altenb. 160
-— G., Zuckerbäck, Grchtg.135
-— I., Mnsika!icnh.,Keß'g.257
-— F. (5., Fürspr., Metzg. 101
-— Frau, Corsetm., Brng. -12
-Habegger I., Wcgkn. Hllg. 148
+— G., Zuckerbäck., Grchtg. 135
+— I., Musikalienh., Keßg. 257
+— F. C., Fürspr., Metzg. 101
+— Frau, Corsetm., Brng. 32
+Habegger I., Wegkn., Hllg. 148
 — Frau, Schneiderin, Aarbergerg. 82
-— N., Bnlterhdl.,Neueng. 90
+— N., Butterhdl., Neueng. 90
 — Ib., Metzg., Neubrücke
 Häberli Chr., Reg., Gercht.125
 — Chr., Sattler, Bollw. 81
 — Chr., Courtier, Metzg. 120
-— Ib., Ilhrenhdl., Sptg. 142
-— Cdr., Commis, Spt'g.142
-— I!., Zimmermeister, Schauplatzg. 238
-Hablützel D. 13 F., Kanzlist, RathhSp'tz. 52 !
-— C., Bierbr., Ratbhspltz.52
+— Ib., Uhrenhdl., Sptg. 142
+— Chr., Commis, Sptg. 142
+— N., Zimmermeister, Schauplatzg. 233
+Hablützel D. L. F., Kanzlist, Rathhspltz. 52
+— C., Bierbr., Rathhspltz. 52
 — I., Bierwirth, Matte 92
-Hadern Jb., Schreiner, Ätg. 91
-— geb. Fankhanser, Käshdl., Aarz. 15
-Häselen-Schenk, Blasinstrumentm., Marktg. 80 u. 40
-— Ferd., Sekretär d.Erz.-Direktion, Zeitglockenth. 228
+Hadorn Jb., Schreiner, Ng. 91
+— geb. Fankhauser, Käshdl., Aarz. 15
+Häfelen-Schenk, Blasinstrumentm., Marktg. 80 u. 40
+— Ferd., Sekretär d. Erz.-Direktion, Zeitglockenth. 228
 — geb. Zimmermann, Kostgb., Brunng. 28
 — C., Adjunkt, Aarbergg. 43
 Häfelin F., Kanzlist, Schg. 198
 — C., Adjunkt, Junkerng. 158
 Hagen C., Prof., Falkenpl. 217
 Hager L. G., Bäcker, Schifft. 47
-— Chr.,Schneid., Neueng.92
+— Chr., Schneid., Neueng.92
 — D., Zimmermann, Bollwerk 263 o
-Hahn-Lchnyder R. L., Amtsnotar, Kornhauspl. 48
+Hahn-Schnyder R. L., Amtsnotar, Kornhauspl. 48
 Hähni I., Amtsnotar, Käfg. 28
 Halber, Erbschaft, Zuckerbäcker, Marktgassc 65
 Haldi, Frau, Aarbergg. 52
 Haldimann A., Lith., Stald. 3
 — I., Flößer, Salzmag.238
 — I., Mechaniker, Matte 47
-Hakler I. E. F., Spitalprediger, Schwarzthor 10!, Ablage im Burgerspital
-— Bs F., Vater, Neck. Du., Buchdruckereibes., Marktgasse 39
+Haller J. E. F., Spitalprediger, Schwarzthor 101, Ablage im Burgerspital
+— B. F., Vater, Med. Dr., Buchdruckereibes., Marktgasse 39
 — R. F., Sohn, Buchdrucker, Aarbergg. 49
 — I., Mühlem., Stalden 13
 — Frau, Hebamme, Stald. 13
-v. Hallwyl-v. JmhosTH., Rentier, Kramg. 192
-Hambcrger I., Lehrer, Falkenplätzli 272
-— geb. König, Renk., Kreuzgasse 103
-Hämmert!, I., Briefträger, Brunng. 28
+v. Hallwyl-v. Imhof Th., Rentier, Kramg. 192
+Hamberger J., Lehrer, Falkenplätzli 272
+— geb. König, Rent., Kreuzgasse 103
+Hämmerli, J., Briefträger, Brunng. 28
 — E., Kanzlist, Zwiebg. 94
 Hanhart J. Jb., Kupferschmd., Stalden 2
-Hänni, Frau, Kostgcb., Metzgergasse 77
+Hänni, Frau, Kostgeb., Metzgergasse 77
 — J., Schuhm., Metzg. 77
-— geb. Josl, Rent., Schg. 227
-— J. Jb., Schrb.,HoLig.167
+— geb. Jost, Rent., Schg. 227
+— J. Jb., Schrb., Hollig. 167
 — B., Korber, Altenberg 173
 — A., Samenhdl., Schg. 230
-— N., Speisewirth u. Sattler, Speicherg. 6o
+— N., Speisewirth u. Sattler, Speicherg. 6c
 — I., Barbier, Käfichg. 103
 — G., Bannwart, Hollig. 156
-— A., Hebamme, Zeuqhg. 9
-— I., Rechtsagt., Aarberg. 47
-— I.H., Schreiber, Poitg. 32
-— A., Schncidr., Jdg. 113u
+— A., Hebamme, Zeughg. 9
+— J., Rechtsagt., Aarberg. 47
+— J. H., Schreiber, Poitg. 32
+— A., Schneidr., Jdg. 113u
 — S., Kondukt., Keßlerg. 292
 — I., Schuhm., Keßlerg. 235
-— Fr., Uhrinacb., Judg. 113
+— Fr., Uhrmach., Judg. 113
 Hanslin-Kurz, Wittwe, Glaser, Kirchgasse 272
 # Date: 1861-04-15 Page: 1395939/85
 Hanslin gb. Mühlemann, Kostgeber., Brunng. 19
@@ -1380,50 +1380,50 @@ Harrer, geb. Kablützel, Rent., Marktg. 94
 Harri, Spczierer, Stalden l
 Hartmann C. D. E., Privat.
 — F., Schneider, Altenb. 172
-— P.A., Schreinern. Speisewirth, Aarbergg. 17a
-— -Völliger, Kvstg., Mtzg.131
-Hasler A., Amtbnot. u. Rechtsagent, Marktg. 91
-— Chef derTelcg.-Werkstätte, Postg. 32
+— P. A., Schreiner u. Speisewirth, Aarbergg. 17a
+— -Bolliger, Kostg., Mtzg. 131
+Hasler A., Amtsnot. u. Rechtsagent, Marktg. 91
+— Chef der Teleg.-Werkstätte, Postg. 32
 — I. R., Schndr., Stald. 15
-Häsler, Pferdhlt., Schulg.332
+Häsler, Pferdhlt., Schulg. 332
 — Schreiner, Spitalg. 136
 Hässig, geb. König, Junkg. 182
 — L. G., gew. Buchhändler, Metzgerg. 102
-Haßlinger, Wittwe und Sohn, Schlosser, Käfichq. 102'
+Haßlinger, Wittwe und Sohn, Schlosser, Käfichg. 102
 Häubi Jb., Metzger, Stald. 17
 Haudenschild, Neueng. 86
 Hauert S., Daebd., Anatg. 11
-Haueter D., Sattl., Grcktg. 71
+Haueter D., Sattl., Grchtg. 71
 — Frau, Göllerkm., Frick 77
-— Poirvl, Brodericehändlerin, Kramg. 225
-Hang Wwe., Pflaster., Brg. 17
+— -Voirol, Broderiehändlerin, Kramg. 225
+Haug Wwe., Pfläster., Brg. 17
 Häuptli C., Schn., Brunng. 21
-Hauser, Spielwaarenhandlung, Gerbernlaube 115
-— Schlosser, Skalden 9
-Hausmann u. Lambelct, Drogueriehdl. am Bärenplatz
+Hauser, Spielwaarenhandlung, Gerbernlaube 145
+— Schlosser, Stalden 9
+Hausmann u. Lambelet, Drogueriehdl. am Bärenplatz
 — D., Negot., Neueng. 122 a
 — H. F., Maler, Herreng. 299
 — C. L., Schlosser, Metzg. 80
 Haußener S., Bäcker, Aarbg. 16
 Hauwert C. L., Klaviermacher, Spitalg. 163a
 Hebler C. L., Architekt, Schauplatzg. 202
-— 2 - C., gew. Oberlichter, Schauplg. 202
-— R. A. C. , Privatdozcnt, Npdeckg. 198
+— J. C., gew. Oberrichter, Schauplg. 202
+— R. A. C., Privatdozent, Nydeckg. 198
 — G., Architekt, Gerecht. 99
-— I., Neucng. 113
-— Heinr., bei'r Linde
-Heer J.A., Schuhm.,Aarbg.40
-— Frau, Schneid., Sptlg.167
+— I., Neueng. 113
+— Heinr., bei’r Linde
+Heer J.A., Schuhm., Aarbg.40
+— Frau, Schneid., Sptlg. 167
 — N. I., Wirth, Aarbergg. 51
 Heft Jgfr., Musiklehr., Zwiebelngäßchen 40
 Hefti I., Schlosser, Matte 26
 Hegel I., Regt., Bärenpl. 241
 Heger A., Schuhm., Matten 37
 Hegg Schwest., Strickwaarenhandlung, Kramg. 197
-— Joh. Eman., Commis der >Lalzhandi., Kramg. 197
-— F., Wcgknecht, Längg. 198
+— Joh. Eman., Commis der Salzhandl., Kramg. 197
+— F., Wegknecht, Längg. 198
 Heim R. A., Tap., Grchtg. 96
-— F. C.,Brieftrg.,Altbg.182
+— F. C., Brieftrg., Altbg.182
 — C. D., Brieftrg., Krzg. 103
 — Schwest., Schneiderinnen, Marktg. 57
 — Frau, Hebamme, Gerechtg.
@@ -1431,12 +1431,12 @@ Heim R. A., Tap., Grchtg. 96
 Heimel C., Amtsnotar, Kramg. 175
 Heiniger, geb. Brugger, Schuhmacher, Kramg. 175
 — Postcommis, Kramg. 175
-— 2. R.,Armenpstg., Mtt. 45
-— 2. F., Maler, Brunng. 6
+— J. R., Armenpflg., Mtt. 45
+— J. F., Maler, Brunng. 6
 Heinzelmann A. F. Bierbrauer, Matte 116
 Heinzmann I., Schn., Mtzg.72
 Heiß A., Bandagist, Grchtg. 99
-Held I., Konduft., Ng. 122 b
+Held I., Kondukt., Ng. 122 b
 # Date: 1861-04-15 Page: 1395940/86
 Heller, Broderiehdl., Krg. 206
 — J., Glaser, Aarbergg. 27
@@ -1444,39 +1444,39 @@ Heller, Broderiehdl., Krg. 206
 — Wwe., Glashandl., Kramgasse 177 und 176
 Hemmann F. E., Quartieraufseher, Brunng. 35
 — R. E., Schreiber, Kßg. 244
-— Marie, Spitalg. 14«»
+— Marie, Spitalg. 140
 — Fl.,Modiste, Schauplg.211
 — I. I., Büchscnschmicd, Schauplg. 220
 Hemmerling M., Broderie- und Wollwaarenhdl., Mktg. 57
 Hendrich C. F., Schreiner, Schauplg. 204
 Henzi I. F., Gutsbes., gew. Ammann, Stadtbach 181, Ablage Marktg. 63
-— R.,Or.lH6c1., Inselg.1361>
+— R., Dr. med., Inselg. 136b
 — B., eidg. Pulververwalt., Rabbenthal 155
-— Ww.d. Pros., Insg. 136e
-— F. S.,Ktsbuchh.,Mtzg.130
+— Ww. d. Prof., Insg. 136c
+— F. S., Ktsbuchh., Mtzg.130
 — S., Schuhhdl., Krmg. 159
-— R.F.,Amtsnt.,BUw.263n
-— Schwest., Modiste, Kßg.279
+— R. F., Amtsnt., Bllw. 263a
+— Schwest., Modiste, Kßg. 279
 — Karl, Wwe., Speicherg. 6a
-— Sopyie, Lehr., Metzg. 130
+— Sophie, Lehr., Metzg. 130
 Herbert, Frln., Spitalg. 131
 Hermann C. F. A., Maler, Marktg. 92
-— I. J.,i)r.Ue<1., Professor, Brunng. 29
-— Th., Ür. Lloä., Brunngasse 29
+— J. J., Dr. Med., Professor, Brunng. 29
+— Th., Dr. Med., Brunngasse 29
 — W. R., Generalprokurat., Judeng. 129
 — I. A., Zuckerb., Krmg. 195
-—-Cgger, Junkerng. 199
-— G., Fürsp., Sekr.d.Einw.-Polizei, Holligen 167a
-— Jb., Büchsenschm.,i. Bollwerk 262
+— -Egger, Junkerng. 199
+— G., Fürsp., Sekr. d. Einw.-Polizei, Holligen 167a
+— Jb., Büchsenschm., i. Bollwerk 262
 Hermann-Genton, Bäcker, Spitalgasse 163
-— Cmilie, Modiste, Kßlg. 281
+— Emilie, Modiste, Kßlg. 281
 — Mechaniker, Kästchg.25
 — I. F., Krämer, Keßlg. 291
 Herrmann A. N., Unterweibel, Matte 38
 — A., Advokat, Speicherg. 8
 Hermingard, Elisc, Sptlg. 139
-Herrenschwand, Frau u. Tocht., Bollw. 263o
-— v. — geb. Ma», Frau, Insg. 136
+Herrenschwand, Frau u. Tocht., Bollw. 263c
+v. Herrenschwand geb. May, Frau, Insg. 136
 Herndl M., Schuhm., Bg. 3
 Herter, geb. Roth, Gastwirthin zum Affen, Kramg. 184
 — I., Metzger, Zwiebg. 59
@@ -1500,15 +1500,15 @@ Heubi S., Kleiderhdl., Bubenbergrain 60
 Heumann B., Kräm., Zghg. 12
 Heuser, Klavierstimmer, Keßlergasse 255
 Heyniger N., Schnd., Mktg. 52
-Hidbcr B., vr. Lehrer, Junkerng. 177
+Hidber B., Dr. Lehrer, Junkerng. 177
 # Date: 1861-04-15 Page: 1395941/87
-Hiltiold I., Auswandergsagt., — Aarbergg. 43
+Hiltbold I., Auswandergsagt., Aarbergg. 43
 Hiltbrunner-Oppliger, Hbam., Aarbergg. 28
 — S., Hufschmied, Bllw. 83s
 — I., Fetthändler, Aarbg. 33
-Hirs C., Ghpser, Marktg. 31
-Hirsbrunner Ehr., Flachmaler, bei'r Linde
-— F., Stcinhauer, Aarz. 46
+Hirs C., Gypser, Marktg. 31
+Hirsbrunner Chr., Flachmaler, bei’r Linde
+— F., Steinhauer, Aarz. 46
 — C., Drechsler, Altenbg. 74
 — Metzger, Schifflaube 43
 Hirschgartner H., Bildhauer, Monbijou 94
@@ -1517,17 +1517,17 @@ Hirschi H., Instrukt., Zghg. 5
 Hirstger J. S., Grtn., Läng 114
 — Träg. d. Intelligenzblattes, Inselgasse 131
 Hirt C., Mühlem., Matte 57
-— N., Lehrer, Länag. 201
-— S., Schuhm., <Ltald. 215
-— B., Speisen'., Stald.221
+— N., Lehrer, Längg. 201
+— S., Schuhm., Stald. 215
+— B., Speisew, Stald. 221
 Hirter I., Schiffmstr., Mit. 42
 Hirtuni u. Neyncns, Kleidhdl., Junkerng. 162
-Hochstcttler C., Gasanzünder, Schauplg. 203
-Hockstraßer Jb., Schrn., Junkerng. 193
-— J. Ä., Schneider, Kßg. 277
+Hochstettler C., Gasanzünder, Schauplg. 203
+Hochstraßer Jb., Schrn., Junkerng. 193
+— J. J., Schneider, Kßg. 277
 Holoch, Messerschm., Krmg.211
 Hodel L., Buchbinder, Neueng. 104 6
-Hodler I., Schuhni., Metzg. 84
+Hodler I., Schuhm., Metzg. 84
 — Oberrcht., Breitenrain 120
 — Z., Schrn., Schauplg. 228
 Höhn I. H., Vater, Sekretär, Ochsenscheuer
@@ -1558,14 +1558,14 @@ Hoffmann G., Barbier, Bärenplatz 109 u. Storcheng. 160
 — I., Gärtner, Frick 67
 — Ww., Spez., Gerechtg. 127
 — F., Säuvcinm., Marktg. 31
-— F., Scbneider, Aarbg?23
-— J., Ouincaillh., Sptg. 150
-— I. S., Sattler u. Tapez., Gerberikssrb. 140
+— F., Scbneider, Aarbg. 23
+— J., Quincaillh., Sptg. 150
+— I. S., Sattler u. Tapez., Gerberngrb. 140
 — R., Bettmacherin, Khg.257
-— Gescbwister, Ellenwaarenhandlung, Aarbergg. 59
+— Geschwister, Ellenwaarenhandlung, Aarbergg. 59
 — I. G., Schuhm., Matte 18
-— Sebwest., Wirthsch., Kfg. 98
-Hofniann I., Speisen., Nwuengasse 100
+— Schwest., Wirthsch., Kfg. 98
+Hofmann J., Speisew., Nwuengasse 100
 Hofstetter, D., Buchb., Metzg. 135
 — Abwart, Stift.
 — I., Kramg. 169
@@ -1576,25 +1576,25 @@ Hofstetter Anna, Schneiderin, Metzgerg. 74
 Hofstettler, Kondurtch Hrg. 302
 Hohlenweger P., Bergführer, Postg. 34
 Höllenstein Frau, Iuponsstcpp. Aarziele, b. innern Bad
-Hölzer Ib., Speisew., 2lg. 21
-— Ehr., Gürtler, Lwg. 225
+Hölzer Jb., Speisew., 2lg. 21
+— Chr., Gürtler, Lwg. 225
 — geb. Flückiger, Kostgeber., Spitalg. 162
-Honegger E., Sekr. n. llkcgistr. d?Telegr.-Dir.,Krmg.212
-Hops-Steiger, Kramg. 179
+Honegger E., Sekr. n. Registr. d. Telegr.-Dir., Krmg. 212
+Hopf-Steiger, Kramg. 179
 Horisberger, Frau, Brodeuse, Aarbergerg. 52
 Hößli, Lohnkutscher, Krmg. 169
-Hoßscld Ei Ä., Lehrn., Aarz. 34
-Hostettler E., Hebamme, Metzgergasse 8i>
-Hotz E., Schuhm., tzirrtztg. 113
+Hoßfeld C. A., Schrn., Aarz. 34
+Hostettler E., Hebamme, Metzgergasse 86
+Hotz E., Schuhm., Grchtg. 113
 — -König, Brunng. 29
 Howald, Frau, Haft,., Sulgb.
-— K., 'Rvtar, Herreng. 321
-Howard, getv. Klaviermacher, Bollw. 264
+— K., Notar, Herreng. 321
+Howard, gew. Klaviermacher, Bollw. 264
 Hubacher R., Spez., Mktg. 68
-— E., Wcinbdl., Nng. 116 u
-— Frau, Ncnensi. 116 n
+— E., Weinhdl., Nng. 116 u
+— Frau, Neueng. 116 a
 Huber I. R., Färber, Mtt. 118
-— H. D., Lhnktskh., Fghsg. 13
+— H. D., Lhnktsch., Zghsg. 13
 — Peter, Buchdrucker
 — u. Cie., Bchhdl., Grchtg. 94
 — F., Hafner, Matte 127
@@ -1608,21 +1608,21 @@ Huber I. R., Färber, Mtt. 118
 Hubler-Käsermann, Ellenwaarenhandlung, Marktg. 72
 Hünerwadel G., Buchdruckereibesitzer, Spitalg. 178
 — -Frikart, Frau, Kramg. 148
-Hug F. D., Srganistn. Dintenfabrikant, Renen,; 91
+Hug F. D., Organist u. Dintenfabrikant, Renen,; 91
 — W., Kanzlist, Marktg. 89
 — E. L., Vt., Kaminf., Bg. 16
-— Tobn, Kaniinf., Mtzg. 125
+— Tobn, Kaminf., Mtzg. 125
 — Wittwe, Pensionshälterin, Aarbergerthor
 — L., Bettmach., Schg. 213
 — Emma, Feinwaschch Bg. 7
 — I., Kommis, Postg. 44
 — R., Kommis, Kornhpl. 148
 — Wittwe d. Messerschmieds, Metzg. 71
-HugcndubelEhr. H., Direkt, d. Realschule, Falkenpl. 217b
+Hugcndubel Chr. H., Direkt, d. Realschule, Falkenpl. 217b
 Hügi S. M., Modiste, in. Bollwerk 83
 — I. D., Kanzl., Herrg. 365
-— Ehr., Brngrb.. Hollig. 161
-— «., Schneiderin, Aarbg. 72
+— Chr., Brngrb.. Hollig. 161
+— S., Schneiderin, Aarbg. 72
 Hügli G., Amtsnt., Sptlg.128
 — Vcr., spez., Spitalg. 128
 — Kth., Eorsetm., L-Ptlg. 136
@@ -1634,15 +1634,15 @@ Hummel G., Metzg., Keß lg. 182
 Hunsperger Jb., Schuhmacher, Keßlg. 246
 — Dachdecker, Postg. 23
 Hunzigker Abraham, Otegot., Junkerng. 186
-Hunziker I- Ä., Rnt., Läng. 214
-— Rot. u. Anrspr., Mrktg. 88
+Hunziker J. A., Rnt., Läng. 214
+— Not. u. Fürspr., Mrktg. 88
 — R., Schreiner, Brunng. 19
-— C., Lohnbcd., Zwiebg. 56
-—-Lchmid, Spielwaarnhdl., Kramg. 210
+— C., Lohnbed., Zwiebg. 56
+— -Schmid, Spielwaarnhdl., Kramg. 210
 # Date: 1861-04-15 Page: 1395943/89
 Hunziker M., Lehrerin, Zwiebelng. 56
 Hurni Jb., Zimmerm., Schindermätteli
-— P.,Zimmerm., Aarbg. 19
+— P., Zimmerm., Aarbg. 19
 — P., Schweinm., Aarbg. 20
 — Jb., Sckwcinm., Grchtg.87
 — Jb., Spcisew., Aarbg. 58
@@ -1653,59 +1653,59 @@ Hutmacher I., Lehrer, Postg. 16
 — geb. Weniger, Krämerin, Keßlg. 241
 Huttcnlochergb.Wäber, Pfläst., Aarz. 21
 Hutter L., Zckngslhr., Mktg. 44
-Hyseli, F., Sprach!., Zghg. 10
-Jacot des Combes L., Ncnt., Inselg. 136a
-Jacquct G., Hutm., Krmg. 155
+Hyseli, F., Sprachl., Zghg. 10
+Jacot des Combes L., Rent., Inselg. 136a
+Jacquet G., Hutm., Krmg. 155
 Jäger I., Rent.,Längg.202
-— F.,Tapez., Neucng.1l>6
-Jäggi Cman. Fried., Amtsnot., Pelikan 230 u. Kirchg. 268
-—-I. E. A., Amtsnot., Kirchgasse 268
-— I. F. E., Ncgot., Schönbnrg.
-— M., Waisenoater, Waisenhaus.
+— F., Tapez., Neueng. 106
+Jäggi Eman. Fried., Amtsnot., Pelikan 230 u. Kirchg. 268
+— J. E. A., Amtsnot., Kirchgasse 268
+— I. F. E., Negot., Schönbnrg.
+— M., Waisenvater, Waisenhaus
 — R., Postangest., Käfg. 102
 — -Chariatte, Schnd., Marktgasse 44
 — -Lauterburg, Kramg. 189
-— -Grüner, Hotell. 229
+— -Gruner, Hotell. 229
 Jaggi I., Milchhdl., Grchtg.69
-— Inftrkt.-Major, Zeughausplatz 251 u.252
-Jaggi Cbr., Hutm., Postg. 35
+— Instrkt.-Major, Zeughausplatz 251 u.252
+Jaggi Chr., Hutm., Postg. 35
 — Frau, Feinwasch., Bg. 25
 Jahn A., eidg. Archtvargehülfe u. Doz. an d. Hochschule, Altenb. 172
 Jakob I., Strumpfwb., Bg.22
 — A. C., Schneid., Aarbg. 35
-— Ww., Schrn. u. Möbclhdl., Neueng.122
-Jakobi P. I., Eiscngiesi., Sulgenbach 88
+— Ww., Schrn. u. Möbelhdl., Neueng.122
+Jakobi P. I., Eisengieß., Sulgenbach 88
 Janitsch, geb. Marti, Antiquarin, Keßlg. 277
 Janz B., Schneid., Aarbg. 33
 Jährmann P., Schuhmacher, Spitalg. 152
-Jaumann, Wirtb, Aarbg. 53
-Jausn Chr., Trödler, Aarbergerg. 27
-JavetR., Buchb., Keßlg. 261
-Jeance! I. L., Gärtn., Mir. 35
+Jaumann, Wirth, Aarbg. 53
+Jaußi Chr., Trödler, Aarbergerg. 27
+Javet R., Buchb., Keßlg. 261
+Jeancel J. L., Gärtn., Mtt. 35
 Jeandrevin F., Tuchngt., Krmgasse 209
 Jeanneret C. F., Weinhändler, Nathhspl. 51
 Jeanmaire, Knckl., Aarbg. 47
 Jecker-Stähli, Posamentirer, Marktg. 44
 Jenni Chr., Buchdruck., Metzgerg. 96
-— Bäcker, Junkerng. 146ct
-— R., Bäcker, Rhdeckbrck.234
-— R., Buchdrucker u. Schriftgießer, Gercchtg. 115
+— Bäcker, Junkerng. 146d
+— R., Bäcker, Nydeckbrck. 234
+— R., Buchdrucker u. Schriftgießer, Gerechtg. 115
 — F., Buchb., Brunng. 31
 — Glaser, Metzg. 133
 — A., Drechsler, Metzg. 87
-— G., Metzger, Metzg?120
+— G., Metzger, Metzg. 120
 — I., Schrn. u. Glas., Bg. 24
 — I., Weber, Heilig. 115
-— S., Wirth zur Waldcck
+— S., Wirth zur Waldeck
 — I.. Zimmerm., Längg. 218
-— E.,Speziererin,Hotell.238
+— E., Speziererin, Hotell.238
 — M., Schneiderin, Frick 70
 # Date: 1861-04-15 Page: 1395944/90
-v. Jenner G.N. (oonPruntrut), Oberstlieut., Rnt., Gerechtigkeitsg. 85
+v. Jenner G. N. (von Pruntrut), Oberstlieut., Rnt., Gerechtigkeitsg. 85
 — I. E. F., Papierhändler u. Buchb., Gerechtg. 111
 — B. L. N., gew. Polizei-Inspektor, Gerechtg. 100
 — F. G. H., Schnd., Mtzg. 72
-— -Marcuard C. D. F., Bnq>, Marktg. 49
+— -Marcuard C. D. F., Bnq., Marktg. 49
 — I. E. R., Schreiber, Zeughauspl. 250u
 — N. G. E., Zuckerb., Brunngasse 30
 — -v. Herrenschwand, Frau, Junkerng. 184
@@ -1714,14 +1714,14 @@ Jent L., Buchhändler, Spitalgasse 138
 Jenzer G. F.G., Schuhmacher, Monbijou 93
 — G. F. R., Schreibr., Monbijou 93
 — S.E.R., Schiff., Kßg. 245
-— R., Metzg.96
+— R., Metzg. 96
 — Car., Modiste, Neueng. 102
-— Ludw., Sckreib., Mtzg. 97
+— Ludw., Schreib., Mtzg. 97
 Jester J. A., Schnd., Mtza.121
-Illig Gpps. u. Flachmal. Bg. 24
+Illig, Gyps. u. Flachmal., Bg. 24
 Imboden I., Casinowirth 131
-Imhoof F. Ch., Kleidertrödler, Längg.201
-— C., Ghpser,Keßlg. 291
+Imhoof F. Ch., Kleidertrödler, Längg. 201
+— C., Gypser, Keßlg. 291
 — I., Schreiner, Stald. 10
 — F.H., Regt., Hotell. 233
 — I. S., Schuhm.,Metzg. 76
@@ -1733,8 +1733,8 @@ Immer A. H., Professor, Gerechtigkeitsg. 133
 Imobersteg G., Bundesweibel, Aarz.26
 — Oberrichter, Käfichg. 28
 — Ohmgeldverw., Junkg.187
-Indermüs>lc I., Strohhutfabr., bei der kl. Schanze 186
-— -v. Wyttenbach,F.B., Rnt., Kramg. 215
+Indermühle J., Strohhutfabr., bei der kl. Schanze 186
+— -v. Wyttenbach, F. B., Rnt., Kramg. 215
 Ineichen A. A., Lehrer u. Literat, Aarbergg. 45
 Ingold H., Zimmrinst., Stadtbach 178
 — A., Schuhm., Metzg. 80
@@ -1745,8 +1745,8 @@ Jöhr A., Gärtnerin, Aarz. 83
 — Frau,Nudlcmacherin, Spitalg. 143
 — Frau, Hebamme, Zghpl.205
 Joneli J., Lehrer, Marktg. 80
-JonquiereD.J.G., gw.Eisenneqt., Zwiebg. 55
--J.'D., Or. Lleci., Pros., Herreng. 312
+Jonquière D. J. G., gw. Eisennegt., Zwiebg. 55
+- J. D., Dr. Med., Prof., Herreng. 312
 — Eman., Speicherg. 7
 Jordan D., Messerschm., Gerberngr. 140
 Jordi J., Schuhm., Mktg. 82
@@ -1764,32 +1764,32 @@ Jost Chr.,Buchhdl., Junkg. 168
 — Chr., Müller, Aarz. 84
 # Date: 1861-04-15 Page: 1395945/91
 Jost F., Spez., Spitalg. 161
-— S., Regt., Gerbern!. 145
-— I., Photogr.,Kornhpl. 46
--— I. U., Schreiner, Zghg. 9
+— S., Regt., Gerberng. 145
+— I., Photogr., Kornhpl. 46
+- I. U., Schreiner, Zghg. 9
 — F., Pächt., Altb. 122 u. 123
 Jourdat, Jgfr., M. Grchtg. 105
 Ischi M., Schneid., Kßg. 280
-Iseli Jb., Müller, Müller!. 36
+Iseli Jb., Müller, Müllerl. 36
 — I., Hlzschuhm., Gerbl. 116
-— -Gygax, Ellenwaarcnhdl., Spitalg. 137
-- -Schmutz, Spez.,Krmg.163
+— -Gygax, Ellenwaarenhdl., Spitalg. 137
+- -Schmutz, Spez., Krmg. 163
 — G., Krämer, Käfichg. 100
-— I., Trödler, Käfiche,. 103
+— I., Trödler, Käfichg. 103
 Iselin-Bernoulli, zw.d.TH. 186
 Isenschmid D. F., Rnt., Kramtzasse 160
-— 1)r., Kramgasse 175
-— aeb.Daler, Frau, Jdg.113
+— Dr., Kramgasse 175
+— geb. Daler, Frau, Jdg. 113
 — Julie, Junkerng. 183
-— G.R.,Schhm., Junkg.152
-Isler J.H., Schnd., Spchg.6b
+— G. R., Schhm., Junkg. 152
+Isler J. H., Schnd., Spchg. 6b
 — Kanzl., Speicherg. 6b
 — I., Wirth, Käfichg. 109
-Juni M., Schneid., Sptlg. 140
+Jüni M., Schneid., Sptlg. 140
 — S., Körber, Längg. 215 b
-Jucker I., LohnkutschJ', Zghg. 15
+Jucker I., Lohnkutsch., Zghg. 15
 — -Huber, Standesweibel, Aarbergg. 37
-Julius R. S.,Knzl., Mtt.117F
+Julius R. S., Knzl., Mtt. 117g
 Jung, Frau, Blumenhändler., Neueng. 93
 Jungi R., Bäcker, Grchtg. 126
 Junker I., Schwnm., Mtzg. 84
@@ -1811,42 +1811,42 @@ v. Käncl Chr., Wirth, Kornhauspl. 152
 — I., Graveur, Metzg. 122
 Käser C.E., Spengl., Mtzg.76
 — -Steinmann, Gemeinderath, Gerechtigkg.-IOI
-— Cbr., Weinbl., Gerecht.101
+— Chr., Weinbl., Gerecht.101
 — Jb., Weinhdl., Sptlg.174
 - I. I., Schneid., Abg. 72
 — I., Gypser, Aarbergg. 37
 — E., Splwrnhdl., Krmg. 200
 — geb. Scheidegger, Glätter., Aarbergg. 5ö
 Käsermann U., Kanzlist, Langmauer 227
-Kamm I., Gypser, Aarbg. 50
-Kappeler I., Bildh., Mkta. 47
-Karlen I. Jb. , Reg.-Rath, Thierspital
+Kamm J., Gypser, Aarbg. 50
+Kappeler J., Bildh., Mkta. 47
+Karlen J. Jb., Reg.-Rath, Thierspital
 — gb. Zaugg, Ww., Bärenpl.
 Kastenhofer J. I., Trödler, Aarbergg. 40
 Kasthofer-Jonguisre, A., Rnt., Länggasse 215 p
 Kästli, Schneider, StaldenIO
 Katz S., Zahnarzt, Sptlg. 172
-Kauert Nikl., Müller u. Mehlhändler, Zeughausq. 9
-Kaufmann I., Lehrer, Äg. 113
+Kauert Nikl., Müller u. Mehlhändler, Zeughausg. 9
+Kaufmann I., Lehrer, Ng. 113
 — F. A., Schrb., Grchtg. 145
 — C., Spez., Mktg. 66 u. 71
-— C.H., Mehlhdl., Metzg. 67
+— C. H., Mehlhdl., Metzg. 67
 — C. H., Spez., Zwiebg. 62
 # Date: 1861-04-15 Page: 1395946/92
 Kaufmann, Notar, a. d. Amtsaerichtsschreiberei
-— Schwestern, Gerechtg.127
-Kehr, Schuhm., Poftg. 24
+— Schwestern, Gerechtg. 127
+Kehr, Schuhm., Postg. 24
 — Wwe., Spez., Sptlg. 171
-Kehrer Jb., Schrn., Schg.197
-— I. I., Glashdl., Krchg.270
-Kellenberger W. , Schreiner, Statd. 6
+Kehrer Jb., Schrn., Schg. 197
+— I. I., Glashdl., Krchg. 270
+Kellenberger W., Schreiner, Statd. 6
 Keller A., Maler, Altenb. 169
 — G., Spez., Neueng 118
 — R., Wagner, Poftg. 56b
 — A., Metzger, Metzg.137
-— Jb., Schwemm., Aarbg. 67
-— N.,Schweinm.,Zwiebg.56
-— M.,Lingdre, Gerbern!. 144
+— Jb., Schweinm., Aarbg. 67
+— N., Schweinm.,Zwiebg.56
+— M., Lingère, Gerbernl. 144
 — F., Schmiedm., Käfg. 110
 Kern-Germann, eidg. Staatsschrb., Bundesrathhaus
 Kernen G., Buchdr., Metzg. 96
@@ -1854,20 +1854,19 @@ Kernen G., Buchdr., Metzg. 96
 — Joh., Speisew.,Grcht.139
 Keser E., Regt., Längg. 267
 Keßler Ph., Musikl., Brunng. 9
-Kiener I., Stcinh., Längg. 193
+Kiener I., Steinh., Längg. 193
 — I., Silberarbeiter u. Graveur, Müllerl. 107
-Kienast I., Regt., Hotell.235
-Kilchenmann, Frau, Sptlg.153
-Kilian, Reg.-Rath,Kreuzg.161
+Kienast I., Regt., Hotell. 235
+Kilchenmann, Frau, Sptlg. 153
+Kilian, Reg.-Rath, Kreuzg. 161
 Kinkelin C., Gschrrhdl., Marktgasse 38
 Kipfer A., Schreiner, Stald. 13
 Kistler P., Körber, Brunng. 1
 — Staatskassier, Aarbgg. 55
 — Sekr. d. Forsten- u. Dom.-Direkt., Sulgenbach 89
-Kißling A.F., Küs., Brunng.2
+Kißling A. F., Küs., Brunng.2
 — I., Spengler, Marktg. 37
-— Schwest., Schneiderinnen,
-Keßlerg 246
+— Schwest., Schneiderinnen, Keßlerg 246
 Kirchhof, Musikalh., Zwgß. 54
 Klaus A., Schreiner, Anatg. 14
 Klah Frau, Marktg. 33
@@ -1884,25 +1883,25 @@ Kneubühler Jgfr., Schneider., Aarbergg. 44
 — I. Chr., Spez. u. Briefträger, Gerechtg.124
 Knöri I. I., Brunnengräber, Hollig. 119
 — C. F., Schreiber, Schg. 235
-— Frau, Speisew., MattelOZ
+— Frau, Speisew., Matte 108
 — Töcht., Sclmd., Sptlg. 150
-— Chr.,Brnngrb., Hol!ig.143
-Knuchel Jb., Kondkt., Hg.310
+— Chr.,Brnngrb., Hollig. 143
+Knuchel Jb., Kondkt., Hg. 310
 — M., Broderiehdlg., Kramgasse 222
 — Gypsreiber, Matte 101
 Knüsel M., Bundesrath, Billette 167 c
 Koch J.J., Lederhdl., Jdg. 123 u. Metzg. 93
 — I. R., Lehrer d. Mathem., Judeng. 123
 — -Hoffmann R. C.,Hdlsm., Junkerng. 175
-— J.J., Schwnm.,Mtzg.133
+— J. J., Schwnm.,Mtzg.133
 Kocher F., gew. Eisennegt., Marktg. 70
-— C. L., Cisennegt., Idg.118
+— C. L., Eisennegt., Idg.118
 — R. F., Apoth., Zeitgl. 228
 — Ingenieur, Bollw. 268
 Kochli, Schuhm., Reueng. 119
 — Chr., Müller, Junkg. 164u
 # Date: 1861-04-15 Page: 1395947/93
-Köchli Cbr., Küchliw., Abg. 47
+Köchli Chr., Küchliw., Abg. 47
 Köhler I., gew. Büchsenschm., Löchligut 140 u
 — Fr., Schneider., Aarbg.27
 — I., Schneider, Reu eng. 95
@@ -1914,7 +1913,7 @@ Köhler I., gew. Büchsenschm., Löchligut 140 u
 — I., Schreiber, Keßlg. 249
 — Lehrer, inneres Bollw. 81
 — I., Revisor, Zeughspl.249
-— Cm., Tpeisew., Schauplg.
+— Em., Tpeisew., Schauplg.
 Kohli F., Zeughausbuchhalter, Brunng. 20
 Köhli P., Kutscher, Junkg.147
 Kohlrusch G. U., Literat, Gerechtg. 97
@@ -1922,33 +1921,33 @@ Köhniein H., Schnd., Mktg.82
 Kolb S., Schnd., Brunng. 21
 — F., Zuckerbäck, Aarbg. 61
 — Ohmgeldbeamt. b. ob. Th.
-Koller, Pros. Vet., Schg. 97
+Koller, Prof. Vet., Schg. 97
 König A., Amtsnotar u. Sachwalter, Kramg. 203
-— A., Sohn, 2!ot., Krmg. 203
+— A., Sohn, Not., Krmg. 203
 — S. W., Mal., Bärenwärt., Speicherg. 4
-— W., Sohn, Mlr., cpchg. 4
+— W., Sohn, Mlr., Spchg. 4
 — A. C., Architekt, schw. Thor
-— Fr. R., Gypssr u. Maler, Aarz. 18
-— W., Dr.gnr., Fürsprecher, Gerechtg. 81 u. 82
-— -Ba» E. R., Apotheker, Pg. 43 u
+— Fr. R., Gypser u. Maler, Aarz. 18
+— W., Dr. jur., Fürsprecher, Gerechtg. 81 u. 82
+— -Bay E. R., Apotheker, Pg. 43 a
 — S. K., Regt., Zwiebg. 58
-- C. L.R., Wcmnegt., Judeng. 113 s.
-König I. R. F., Dr. ölml., Gerechtigkcitsgasse 130
-— I. R. M., Ührenm., Kornhauspl. 147
-— geb.Hirtin, Frau, Kßg.237
-— Cd., Regst., Keßlerg. 246
+- C. L.R., Weinnegt., Judeng. 113 a
+König I. R. F., Dr. Med., Gerechtigkeitsgasse 130
+— I. R. M., Uhrenm., Kornhauspl. 147
+— geb. Hirtin, Frau, Kßg.237
+— Ed., Negot., Keßlerg. 246
 — N., Küfer, Schauplg. 230
 — C. G., Fürspr., Krmg. 205
-— C.L., gew. Missionär, Junkerng'. 182
+— C.L., gew. Missionär, Junkerng. 182
 — II., Lohnkutscher, Zghg. 15
 — B., Schneider, Metzg.95
-— Hptm., Gemdr , Krmg.221
-— J.R., Archit.,Haspeln,.92o
-— Anna, Hebamme, Mktg.82
+— Hptm., Gemdr., Krmg.221
+— J.R., Archit., Haspelm. 92c
+— Anna, Hebamme, Mktg. 82
 — Barb., Wittwe, Krämerin, Schauplg. 207
 Kopp I. J., Rent., gew. Vergolder, Kramg. 159
 — I., Schneider, Kramg. 175
-— S., Regt., Spitalg. 153
+— S., Negt., Spitalg. 153
 Körber Ioh., Buchhbl., Laugmauer 230
 — H., Sobn, Buchhändl.,Altenb. 173 b
 Kraft I., Kroncnwirth, Gerechtg. 9<1
@@ -1957,19 +1956,19 @@ Kraft I., Kroncnwirth, Gerechtg. 9<1
 Krähenbühl G., Schrein., Holligen 155
 — I. P., Gärtner, Bubenbergrain 64
 — S. P., Kanzlist, Matte 76
-— Ouiul. rnocl., Junkg. 191
-— Schuhn,., Bubenbg'rain 61
+— Cand. med., Junkg. 191
+— Schuhm., Bubenbgrain 61
 — Jb., Schn., Sckauplg. 226
 Krämer I., Schuhmacher, Sckg. 215
-Kräuchi Jb., Metzger, Aarbergergasse 29 u.'67
-— R., biecktsag., Nng. 102
-Kraut G., Metzger, Mstzg. 134
+Kräuchi Jb., Metzger, Aarbergergasse 29 u. 67
+— R., Rechtssag., Nng. 102
+Kraut G., Metzger, Metzg. 134
 # Date: 1861-04-15 Page: 1395948/94
 Krebs A., Rechtsag., Schg. 217
 — A., Wirth, Postg. 43
-— Chr., TröLl., Reueng.116
-— Chr., Dcichd., Reueng. 116
-— I., Scknd., Gerbg. 143
+— Chr., Trödl., Neueng.116
+— Chr., Dachd., Neueng. 116
+— I., Schnd., Gerbg. 143
 — I., Polizeidiener-Corpor., Spitalg. 144
 — I. U., Wirth z. Linde 138
 — -Berger S., Hutmacher, Storcheng. 206
@@ -2037,7 +2036,7 @@ Kulm C. F., Ebenist, Aar;. 8
 — F. G.,Nent., Marktg. 37
 — Frau, Mod., Gerechtg. 145
 Kuhnen F.,Major, Aarbg. 38
-Kuhni K'., Küfer, Metzq. 102
+Kuhni K., Küfer, Metzq. 102
 Kummer, Eh., Sesselst., Postgasse 26
 — <L. F., Fürspr. u Amtsnot., Spitalg. 143
 - J., Negt., Aarz. 92 b
@@ -2079,35 +2078,35 @@ Landolt geb. Gaspard, Rent., Marktg. 46
 Lang A., Schneid., Metzg. 65
 — A. G., Spez., Grchtg. 85
 — D., Kammm., Grchtg. 144
-— I., Speisen,., Schplg. 199
+— I., Speisew., Schplg. 199
 — K. M., Wattenfb., Mtzg. 94
-— gb.>Ltauffer, Kräm., Mt. 86
-Läng gb.Montet, Schneiderin, Brunnad. 4
-Langet Wtw., Rent., Gchg. 122
+— gb. Stauffer, Kräm., Mt. 86
+Läng gb. Montet, Schneiderin, Brunnad. 4
+Langel Wtw., Rent., Gchg. 122
 Langenegger, Kaminf., Mtzg. 78
 Langhans G., Landsaßen-Almosner, Schauplatzg. 202
-— C. L., Ncg.ui Buchsührer, Kramg. 149
-— -Stählt, Mod., Krmg. 149
-— Wtw., Kramg.139
-— Elise, Wasch., Postg. 21»
-Lanz-Wyß F., Regt., Gemdr., Fclsenau 257
+— C. L., Neg. u. Buchführer, Kramg. 149
+— -Stähli, Mod., Krmg. 149
+— Wtw., Kramg. 139
+— Elise, Wasch., Postg. 21a
+Lanz-Wyß F., Regt., Gemdr., Felsenau 257
 — -Moser, Negot. im Altenb.
 — Gebrüder, Lederhdl., Gerberngr. 142
 — J.H., Bäcker, Spitz. 168
 — I. S., Notar, Kramg. 209
 — A., Kanzlist, Gerechtg. 121
 # Date: 1861-04-15 Page: 1395950/96
-Largin I. I., VuMalt. Brück' seid 230
+Largin J. J., Buchhalt., Brückfeld 230
 Lasche, Lehrer, Falkenpl. 217
 Lauber S. L., Haarflch., Mt. 91
 — C., Haarflechterin, Mtt. 31
-Lauster Äl., Metzg., Aarbg. 67
-— Jgfr., Spcz., Metzg. 122
-— Catch., Kräm., Metzg. 90
-Lauster J.C.,Lchlosters Schauplatzgasse 198
-Lauper N., Mehlhl., Kng. 92
+Läuffer R., Metzg., Aarbg. 67
+— Jgfr., Spez., Metzg. 122
+— Cath., Kräm., Metzg. 90
+Lauffer J. C., Schlosser, Schauplatzgasse 198
+Lauper N., Mehlhl., Nng. 92
 Lauterburg E. F., Flachmaler, Weyermannshaus 133
-— F.G.,Eisenneg.,Zghg. 18
+— F. G., Eisenneg.,Zghg. 18
 — C. G. R., Ingen., schwarz Thor 101
 — C. A., Posam., Kramg. 171
 — C. L. S., Buchb., Kßg. 281
@@ -2115,7 +2114,7 @@ Lauterburg E. F., Flachmaler, Weyermannshaus 133
 — -Wäber, Strickwhandlung, Marktg. 80
 — -Fleury, Hdlsm., Krmg.172
 Leder Gärtner, Billette
-Ledermann Frau, Dekatierer»«, Spitalg. 175
+Ledermann Frau, Dekatiererin, Spitalg. 175
 — Ros., Schneid., Aarbg. 52
 Lehman« Chr., L. C., Inselprediger, Casinopl. 131
 — S.J.G., Lekrer, Mrktg. 59
@@ -2139,15 +2138,15 @@ Lebmann R., Postwagenni., Postg. 31
 — S. R., Gypser, Matte53
 — geb. Lörtscher, Krämerin, Matte 11
 Lehner U., Schnd., Aarbg. 16
-Leibundgut, Wirtb, Keßlg. 236
+Leibundgut, Wirth, Keßlg. 236
 — Oberrichter, Marktg. 92
 — F., Steindruck., Sptg. 135
 Leibzig P. H., Weinhl., Marktgasse 52
 Leimbacher J. C., Kalligraph, Brunng. 17
 Leitner, Frau, Sprachlehrerin, Kramg. 225
-Leizmann I., Dr., Pros., alt. Viehmarkt 185
-Lemp geb. Mühlemann, Lehr., Spitalg. 16 >
-— H., a. d. Mii.-Dir., Spitalg. 160
+Leizmann I., Dr., Prof., alt. Viehmarkt 185
+Lemp geb. Mühlemann, Lehr., Spitalg. 160
+— H., a. d. Mil.-Dir., Spitalg. 160
 — V., Hebam., Brunng. 27
 — I., Wagner, Bollwerk83
 Längenhager geb. Hochstraßer, Rent., zw. d. Th. 180
@@ -2162,26 +2161,26 @@ Leonhard F., Glätterin , Aarberaerg. 37
 Lequin F. Ä., Gärtner, Billette 166 u
 Lerch I., Metzger, Marktg. 3S
 # Date: 1861-04-15 Page: 1395951/97
-v. Lerber - Grüner, F. Theod., Prioatlh., Sulgenrain 74
+v. Lerber-Grüner, F. Theod., Privatlh., Sulgenrain 74
 - -v. Werdt F.G., Zeughaus-Verwalt., Waisenhspl. 48
 — L. C., Archit., Jkg. 165u
 Leroy L. E., Kanzlist, Nng. 94
 Lesers F., Kräm., Brunng. 21
-LeuF., Kanzlist, Brunng. 18
-— J.U., Schuhn,. Grbg. 141
--V., Wirthin, Inseli'
-— I., Speisew., «peichg. 61
+Leu F., Kanzlist, Brunng. 18
+— J. U., Schuhm., Grbg. 141
+- V., Wirthin, Inseli
+— J., Speisew., Speichg. 61
 Leuch R. L. F., Apoth., Kramgasse 193
 — N. G. R., Arzt u. gewes. Quart.-Aufs., Junkg. 158
 Leuenberger R. L. F., Schrb., Kirchg. 272
 — G., Papierhl., Krma. 166
 — I. I. U., Rentier, Hotellaube 234
-— I., Pros., Rabbenthal 155
-— I., Telcgr., a. Boüw. 264
+— I., Prof., Rabbenthal 155
+— I., Telegr., a. Boüw. 264
 — J., Postadj., Zeughg. 5
-— S., Echuhm., Zghg. 16 u
+— S., Schuhm., Zghg. 16 u
 — I., Schuhm., Metzg. 134 u. Kramg. 143
-— I. U., Schuhn,., Matte 39
+— I. U., Schuhm., Matte 39
 — E. Seifenhl., Herrcna.331
 — Metzger, Metzg. 100
 — Frau, BLurisrh-Schneid., Metzg. 101
@@ -2268,7 +2267,7 @@ Lüthard Em. u. Comp., Sachwalter, Kramg. 175
 — M., Kapellmstr., Falkcnpl. 222
 — P., Müsiklehrer, Aarz. 84
 Lüthi Wtw., Rent., Matte 106
-— A., Notar, Stcmpelverw., Ncueng. 87
+— A., Notar, Stempelverw., Ncueng. 87
 — P., Schneid., Metzg. 80
 — Jb., Arzt, Krmg. 175 (Gallrrie Rebold)
 — D., Krämer, Aarz. 46
@@ -2426,21 +2425,21 @@ Mey G., Amtsnot., Hvtell. 232
 — Gärtn., zw. d. Th. 182
 — C., Möbelschr., Spchg. 13 u. Anatomg. 257
 Meyer S. Chr., Privatlehrer, Marktg. 51
-— I., Oberzollsekret., Kramgasse 208
-— u. Tritschler, Eisenhänbler, Kramgasse 217
-— I., Photogr., Keßlerq. 254
-— F.,Ghps. ».Mal., Nq.121
+— J., Oberzollsekret., Kramgasse 208
+— u. Tritschler, Eisenhändler, Kramgasse 217
+— I., Photogr., Keßlerg. 254
+— F., Gyps. u. Mal., Ng. 121
 — -Rohrer Frau, Sptlg. 151
-— Frau, Bettfedernh. Schauplatzg. 200
-— I., Photograph, Sptq.142
-— I. I ., Archiv., b. schw,'TH vr
-— Alb., Sckr.,b.schw. Thor
-— Fr.,Schr.,Brunng. 3
+— Frau, Bettfedernh., Schauplatzg. 200
+— J., Photograph, Sptg.142
+— J. J., Archiv., b. schw. Thor
+— Alb., Sekr., b. schw. Thor
+— Fr., Schr.,Brunng. 3
 — I., Schneid., Kramg.104
 — I., Wirth, Salzmag.l90u
-— J.,Schnd.,Postg.38
-— J.,Kräm.,Keßlg. 254
-— I., N c g t., Kramg. 220
+— J., Schnd.,Postg.38
+— J., Kräm.,Keßlg. 254
+— J., Negt., Kramg. 220
 — Bäcker, Metzg. 131
 — -Liebi I. I., Eisennegot., Bierhübeli 266 u. 267
 — L., Negt., Metzg. 117
@@ -2481,8 +2480,8 @@ Mvnteil I. E., Schirmfabrikant, Marktg. 91
 Morell B. L., gew. Spitaleinz., Billette 167 o
 — xErnst, Rent., Judeng. 129
 — -v. Wattenwyl, gew. Major in Neapel, Gerechtigkg. 89
-Mors Buchhalt.,Kramg.'192
-— Frau, Haubenm., Stld.18
+Mors Buchhalt., Kramg. 192
+— Frau, Haubenm., Stld. 18
 Morhard G., Schreiner, Aarbergergasse 71
 Mori, Rentier, Schauplg. 234
 # Date: 1861-04-15 Page: 1395956/102
@@ -2490,7 +2489,7 @@ Mori S., Condit., Sptlg. 140
 Mörker J., Wagner, Anatg.14
 v. Morlot-Kern C. A. N., Sekretär der burgl. Feld- und Forstcomm., Junkg. 150
 — Asä. vr., Jkq. 150
-— Karl Ad., Pros., Jkg. 150
+— Karl Ad., Prof., Jkg. 150
 — -Crousaz, Ww., Kirchg.265
 — Fräul., Junkerng. 184
 Moser L. M., Landw., Weißenstein 51
@@ -2618,12 +2617,12 @@ Nast J. B., Musikl.Kramg.158
 Naumann C. G.,Käfichg. 107
 Neidhard Pelzhdl., Kramg.124
 # Date: 1861-04-15 Page: 1395958/104
-NenningerJ., Feilcnh.,Arz.87
+Nenninger J., Feilenh., Arz. 87
 — M., Leinwandh., Keßg. 244
-Neuenschwander J.Jb., Goldarbeiter, Frick 69
+Neuenschwander J. Jb., Goldarbeiter, Frick 69
 — Buchb., Junkg. 146
 Neuhaus G., Schlss., Metzg. 85
-— Chr., Schuhm.,Brunnq.5
+— Chr., Schuhm., Brunnq.5
 - Ch. N., Schuhm., Salzmagazin 236
 — S.L., Uhrenm., Svtlg. 115
 — A., Postcommis, Metzg. 123
@@ -2632,19 +2631,19 @@ Neukomm J. G., Kürsch., Kramgasse 170
 — Schnd., Speichg. 6
 — A. M., Milchhll, Gcktg.112
 Ney L., Bedient., Herreng. 304
-— geb. Dürüsscl, Schneider., Herreng. 304
+— geb. Dürüssel, Schneider., Herreng. 304
 Neynens A., Schndm.,Jkg.162
 — H.A., Schndm., Krmg. 218
 Niederhäuser J. Pacht., Schoßhalde 89
 — Chr., Schnd., Marktg. 49d
 Niehans J.E., Or.LIsci., Enge 256
 — G.E., Notar u. Sachwalt., Junkg. 189
-— Ww. d.Bäckers, Grchtg.103
-—Joh., Geschäftsag., Schauhlahg. 234
-Niggeler, Fürspr., GrL'tg. 116
+— Ww. d. Bäckers, Grchtg.103
+— Joh., Geschäftsag., Schauhlahg. 234
+Niggeler, Fürspr., Grchtg. 116
 Niggli T., Schuhm., Brnng. 15
-— Chr., Barbier, Spitlg. 138 u.Käfichg. 27
-Nigst F. Schr., Altenb. 160 e
+— Chr., Barbier, Spitlg. 138 u. Käfichg. 27
+Nigst F. Schr., Altenb. 160 c
 — E., Schnd., Sptalg. 141
 Niklaus, Geschwister, Aarbg.22
 Nobs A.,Negt., Spitalg. 149
@@ -2692,7 +2691,7 @@ Offenhäuser, I., Schuhmach., Enge 108
 O’Gorman, gb.Brunner, Rnt., Gerechtg. 130
 Ohnstein J. L., Kürschn., Kirchgasse 266
 Olivier, Schuhm., Schplg. 191
-Oppermann Cbr., Schneiderin, Marktg. 33
+Oppermann Chr., Schneiderin, Marktg. 33
 — Jgfr. S., Ncg., Krmg. 147
 Oppliger I. Chr., Buchb., Arziebie 35
 — I. G. M.,Buchb.,Stld.6
@@ -2720,7 +2719,7 @@ Otz R. S.,Schr., Aarbg. 31
 Otzcnberger J. F.,Tap., Junkerng. 166
 Ougspurger Ph. F., Bürgerschreiber, Marktg. 91
 — Ji. F. L., Friedensrichter, Schoßh. 47 u. Grchtg. 64
-Pabst C., Pros., Brückfeld 232
+Pabst C., Prof., Brückfeld 232
 Pärli Chr., Schr. u. Küchliw., Bärenplatz 101
 Pages A. S., Schnhm., Neuengasse 108
 Pagenstecher Jgfrn., Insg. 136
@@ -2756,10 +2755,10 @@ Pfister Chr., Vürstbd., Schauplatzg. 233
 — J. Jb., Lhr., Schauplg. 205
 — I., Schreiber, Posig. 30
 — R., Schuhm.,unt.Thor223
-— I., Stcinh., Aarbg. 66
+— I., Steinh., Aarbg. 66
 Pflick W. B., Buchb., Junkerngasse 155
 Pflugshaupt P. H., Lvhnbed., Gerechtg. 120
-Pfotenhauer, Pros., Hrg. 327
+Pfotenhauer, Prof., Hrg. 327
 Phsne, geb. Meißner, Privatlehrerin, Kramg. 173
 Piana I. A., Barometersabr., Metzg. 98
 Piat Wittwe, Färb., Grchtg.89
@@ -2847,7 +2846,7 @@ Renaud, Fürspr.^ Kramg. 162
 — Bankkassier, Herreng. 307
 Renfer N., Sattls, Schplg. 200
 Renz Jb., Schnd., Grchtg. 121
-Rettlg G., Pros., Postg. 87
+Rettlg G., Prof., Postg. 87
 Reußer F., Lehrer, Längg. 202
 — Frau, Ellenwaarenhandl., Schauplg.207
 Reust C., Spez.,Mktg.90
@@ -2887,8 +2886,8 @@ Ris A. S., Kaminfeg., Mit. 10
 — C. L., Tffizial, Junkg. 173
 — G. F., gw. Bäck., Altb.162
 — R. L., Ingen., Altenb. 162
-— Pros., Böhlenhaus, Aargauerstalden
-— L. V., gew. Pros. in Calcutta, Brunnadern 18
+— Prof., Böhlenhaus, Aargauerstalden
+— L. V., gew. Prof. in Calcutta, Brunnadern 18
 — R. M., Krämer.,Zwg. 39
 Risold J. F., Schrn., Kbg. 292
 Ritschard F. L., Schuhm., Müllerlaube 36
@@ -2923,22 +2922,22 @@ Römer I., Bdswbl., Bundesrathhaus
 # Date: 1861-04-15 Page: 1395963/109
 Rooschütz A. L., Mineralwasserfabrikant, Postg. 46
 Roseng Kath., Lehr., Kßg. 295
-Rösch, Unters.-Nlicht., Grchtg.94
-— I. Jb., Schnd., Käfg?101
-Rosen Jb.,Drcclw'ler, Bg.12
+Rösch, Unters.-Richt., Grchtg.94
+— I. Jb., Schnd., Käfg. 101
+Rosen Jb., Drechsler, Bg.12
 Rosselet-Veillon F., gew. Spitaleinzieher, Kramg. 186
 Roß A., Commis, Aarberg. 68
 Roth P. R., Schleifer, Matte 4
-— F. F., Schreiber, Ltald.,14
-— R., Wirth, Schanplg. 201 u
+— F. F., Schreiber, Stald. 14
+— R., Wirth, Schauplg. 201 a
 — C., Krämerin, Matte 111
 — M. Chr., Schnd., Mktg.63
 — S., Hufschmied, Schg. 212
-— A.B., Gärtner.. Aarbg. 36
-— A., Dr., Redaktor, Lillette 166 d
+— A. B., Gärtner., Aarbg. 36
+— A., Dr., Redaktor, Billette 166 d
 — W. F., Buchbd., Krmg. 168
 — gb. Frey, Kostgb., Mtzg. 100
-— F,, Schriftsetzer, Aarbg. 39
+— F., Schriftsetzer, Aarbg. 39
 — F., Schhm., Schauplg.228
 — Jb., Steinh., Marktg. 73
 — Frid., Postfaktor, Zwbg.60
@@ -2993,7 +2992,7 @@ Rühl C.B., Coiff., Krnhpl. 146
 Rufener I. B., Schuhmacher, Metzg. 136
 — Küher, Gerechtg. 139
 # Date: 1861-04-15 Page: 1395964/110
-Rufer, Schuhn., Jkg. 182 b
+Rufer, Schuhm., Jkg. 182 b
 — I. S. F., Spengl., Altenberg 143
 — Chr., Krämer, Gerbl. 112
 Ruff R., Bäcker, Metzg. 81
@@ -3010,7 +3009,7 @@ Ruutz-Haller, H., Regt., Marktgasse 93
 Rychener, Standeswbl., Zeughausg. 14 u. Marktg. 47
 Ryf J. Jb., Speisew., Zghg. 6
 Ryffel Jb., Schneid., Sg. 11
-Ryser I., Schuhn,., Matte 34
+Ryser I., Schuhm,., Matte 34
 — I., Schuhm., Altenbg. 146
 — S., Messerschmied, Aarbergerg. 34
 — Wittwe, Käfichg. 22
@@ -3045,7 +3044,7 @@ SchärJb., Sattl., Altnbg. 177
 — Chr. R., Drechsl.,Aarz. 22
 — Chr., Schuhm., Schg. 225
 — R. H., Regt., Längg. 201
-— A., Schuhn,., Postg. 23
+— A., Schuhm., Postg. 23
 — Tabak- und Cigarrenhdl., Spitalg. 153
 Schärer A. L. G., Tabaknegotiant, Kramg. 162
 — G. C., Schloss., Pelik. 230
@@ -3092,7 +3091,7 @@ Schenk C., Reg.-Rath, Maulbeerbaum, Ablage Spitalgasse 171
 — R., Krämerin, Metzg. 89
 — I., Sattler, Frick 72
 — Jb., Steinbr., Schoßh. 65
-— Jb. R., Schuhn., Kramgasse 169
+— Jb. R., Schuhm., Kramgasse 169
 Schenkel Wwe., Schweinmetzg. u. Speisew., Gerechtg. 123
 — I., Schuhm., Matteil
 Scherler A. B., Schneiderin, Keßlg. 237
@@ -3113,14 +3112,14 @@ Scheurer I. G. R., Zuckerbäck, Zwiebg. 39
 Schieß I. 11., Bundeskanzler, Bundesrathhaus
 — Schieferdecker, Altbg.173n
 v. Schiserli C. M., Vr. Asä., Junkerng. 169
-Schiff M., Pros., Brückfeld 232
+Schiff M., Prof., Brückfeld 232
 — >6., Dozent, Brückfeld 232
 Schiffmann M., Kondukteur, Brunng. 17
 — R., Pdstcomm.,Zghpl.253
 — geb. Pfäffli, Spez., Neuengasse 122 0
 Schick P., Rechtsagt., Sohn, Kornhauspl. 152
 — Fr., Brunng. 7
-Schild J.D., vr. Pros., Kramgasse 183
+Schild J. D., vr. Prof., Kramgasse 183
 Schilt P., Coiff., Siptalg. 123
 Schindler Chr., Büchsenschmd., Schauplg. 221
 — L. N., Müller, Schutzmühle 20
@@ -3133,7 +3132,7 @@ Schindler Chr., Büchsenschmd., Schauplg. 221
 Schinz Emil, Dr., Lehrer, Altenberg 160
 Schläfli F. I., Brunneninstr., Aarz. 57
 — Chr., Kondukt., Grchg. 76
-— L., Pros., Altenbg. 130
+— L., Prof., Altenbg. 130
 — I. F., Lehrer, Kramg. 201
 — I. F., Schreib., Grchtg. 76
 — B., Schneider, Gerbl. 19
@@ -3239,7 +3238,7 @@ Schubert I. C., Barbier, Gerechtg. 86
 - B., Lehrerin, Grchtq. 127
 Schuhmacher F. E. H., Metzgermstr. u. Wirth in Hllg.
 — V., Buchbinder, Krmg. 169
-— I., Schuhn,., Stald. 5
+— I., Schuhm., Stald. 5
 — Jb. H., Briefträgerchef, Brunng. 17
 — I., Zahnarzt, Junkg. 176
 — F. I., Instrukt.-Adjutant, Brunng. 3
@@ -3270,19 +3269,19 @@ Schwarz U., Schrn., Schg. 219
 — I., Asphltarb., Brunng. 21
 — Jb., Schrn., Gerechtg. 116
 — S., Knopfmach., Aarz. 22
-— Jb., Schuhn,., Marktg. 48
+— Jb., Schuhm., Marktg. 48
 — I. C., Spez., Zghpl. 246
 — Z., Krämer, Aarz. 22
 — Schreiner u. Pintenwirth, Bollw. 268
 — U., zwisch. d. Thor. 185
 — Quincailleriehdl., Mktg. 84
 Schwarzentrub E., Schneider, Metzg. 77
-Schwärzler C., Ghps., Schützgäßlein 11
-Schwarzmann F. I., Ghpser, Postg. 28
+Schwärzler C., Gyps., Schützgäßlein 11
+Schwarzmann F. I., Gypser, Postg. 28
 — Frau, Neueng. 106
 Schweck, Schuhmacher, Frick 70
 Schweighauser F., Buchbinder, Keßlg. 267
-Schwcinfurth J.IH., Schnhm., Kramg. 141
+Schweinfurth J.IH., Schnhm., Kramg. 141
 Schweizer, Karl, Amtsnotar, Kramg. 185
 — I. H., Unterwbl., Arbg. 40
 — H., Fhrm., Schifflände 42s
@@ -3302,12 +3301,12 @@ Selhofer, Wwe., Steindruck., Neueng. 113
 — I., Steindruck., Mtzg. 105
 — Ww., Mehlhdl., Grchtg.140
 Senn N., Lehrer, Inselg. 136
-— F. N., Postofftz., Schg. 235
+— F. N., Postoffiz., Schg. 235
 — F.. Fechtmstr., Schg. 215
-Sesti A., Regt., Kramg. 185
+Sesti A., Negt., Kramg. 185
 Shuttleworth, Rent., Bierhübeli 227
-— R.I., Dr., Bierhübeli 227'
-Sidlert A., Dr., Lehr., Aarz. 2
+— R. J., Dr., Bierhübeli 227
+Sidler G., Dr., Lehr., Aarz. 2
 Sieber F. Jb., Ngt., Schg.216
 — I., Müller, Gerechtg. 93
 — I., Schuhm., Herreng. 301
@@ -3321,7 +3320,7 @@ Siegfried C. F., Angest. a. d. eidg. Kursbureau, Speicherg. 8
 — gb. Frey, Marg., Hebamme, Kramg. 221
 — I. Jb., Papierngt., Marktgasse 81 u. Aarz. 26
 — I., Schuhm., Hollig. 141
-— L.M ., Schneid., Mtzg. 127
+— L. M., Schneid., Mtzg. 127
 Siegler, Bäcker, Gerecktg. 145
 Siegrist B., Spengl., Krg. 151
 Sigrist, geb. Kubli, Wittwe, Kornhausplatz 118
@@ -3330,27 +3329,27 @@ Simeon, Vicomte, Gesandtschaftssekretar, Sptlg. 124
 Simmen A., Wirth im Altenbergbad
 — I. F., Fürspr., Sptlg. 160
 Simon, Notar u. Rechtsagent., Marktg. 68
-— Frau, z. Affen, Kramg. 1° t
-— F., Buchhalter, Krmg. 2'.t3
+— Frau, z. Affen, Kramg. 184
+— F., Buchhalter, Krmg. 223
 — E. A.,Handelsmann, Junkerngasse 174
 — B., 1>r.gnr., Fürsprecher., Neuengasse 88
 — F., Kunstmaler, Jdg. 118
-Sing I., Küfer, Speichere,. 1
-Singeisen, Chef d. Cent.-Po«"Bureau, Casinoplatz 131
+Sing I., Küfer, Speicherg. 1
+Singeisen, Chef d. Cent.-Pol.-Bureau, Casinoplatz 131
 v. Sinner-v. Kirchberger I.. Rent., Spitalg. 155
-— «Sinner A. F. R., Rent., gew. Oberamtmann von Seftigen, Junkg. 178
-— -v. Wattenwyl C. F., Renk., Marktg. 72
+— -Sinner A. F. R., Rent., gew. Oberamtmann von Seftigen, Junkg. 178
+— -v. Wattenwyl C. F., Rent., Marktg. 72
 — -v. Fischer R. C. F., Rent., Kramg. 166
 — B. R., Archit., Grchtg. 86
 — v. May K. L., Frau, Spitalg. 130
-— N.Ä., Major, Jkg. 176
-— -v. Effinger R. C.F., Dr. iur., Junkg. 150
+— R. A., Major, Jkg. 176
+— -v. Effinger R. C. F., Dr. jur., Junkg. 150
 — Jgfr., Kramg. 219
-— Rud., gw. Hptm. in Ocftr., Spitalg. 155
-— - Mutach, Gerechtg. 95
+— Rud., gw. Hptm. in Oestr., Spitalg. 155
+— -Mutach, Gerechtg. 95
 — geb. v. Stürler, Junkerng. 174 u. 175
 Sohner I. R., Zimmermann, Spitalg. 147
-Sollberger I., Gram, Schauplatz«. 196
+Sollberger I., Grav., Schauplatzg. 196
 — M., Schneid., Aarbg. 58
 Sommer u. Comp., Mineralwasserhdl., Kehlg. 237
 — I., Geschäftsm., Aarbg. 32
@@ -3444,7 +3443,7 @@ Steck L. F. I., Spitalbcrwalt., zwisch. d. Thor. 274
 — C.F. R.,Amtsnot., Inselgasse 136 e
 — Ä., Fürspr., Aarberg. 55
 Steffen Schwest., Schneider., Storcheng.
-— Wirtb z. Storch., Sptg.157
+— Wirth z. Storch., Sptg.157
 — S., Bäcker, Schutzmüüle20
 Stegmann J.F., Hafn., Äg.41
 — F., Modiste, Aarbergg. 41
@@ -3487,7 +3486,6 @@ Steiner S. J. N., Vater, Müller, Matte 32
 — D. F., Klaviermach., Aarziele 29
 — D. L., Schuhmach., Zeughausgasse 12
 # Date: 1861-04-15 Page: 1395972/118
-118
 Steiner-Gruber S., Uhrenm., Zeughspl. 26
 — L., Bäcker, Matte 30
 Steinhauer M., Brvdeuse, Marktgasse 33
@@ -3514,19 +3512,19 @@ Stettler F. R. C., Fürsprech, Ntzdcckg. 195 u. Krmg.175
 — C.G., Reut., Obstberg 51
 — I., Gypser, Postg. 24
 — S., Gärtner, Längg. 210
-Stettler so. Trachselwald) Frl., Junkerng. 188
+Stettler (v. Trachselwald) Frl., Junkerng. 188
 — Jb., Sattler, Matte 28
 — Christ., Steinhauer, Aarbergerg. 51
-— I. Jb., Regt., Längg. 213
+— I. Jb., Negt., Längg. 213
 — Frau, Nudelmacherin, Aarbergerg. 51
-— N., So!;bauer,Schaupltzg. 231^ '
+— N., Holzhauer, Schaupltzg. 231
 — Karl, Buchdr., Neueng. 118
-— Frau, Krämerin, „ 118
+— Frau, Krämerin, Neueng. 118
 — Kath., Schneiderin, Zeughausg. 9
 — Ros., Schneid., Mktg. 63
 — I., Steinbrecher, Staiden 221
-— I. Chr., Schuhm.,Brunngasse 15
-— B., Staiden 3
+— I. Chr., Schuhm., Brunngasse 15
+— B., Stalden 3
 — I., Steinh., Längg. 215
 Stierlin, R. C., Pfarrer am Münster, Herreng. 325
 — Rob., Direkt. d. Sekundar-Mädchenschule, Hrng. 325
@@ -3569,7 +3567,7 @@ Stuber, I. R., gcw. Brodbäck., Spitalg. 149
 — Karl, Schlosser, Metzg. 80
 Stübner, Ch. W., Schreiner, Gerberngr. 138
 Studer, B.F., Apoth., Spitalgasse 178
-— G. L., Pros. d. Theologie, Spitalg. 178
+— G. L., Prof. d. Theologie, Spitalg. 178
 — G. S., Reg.-Statth., Spitalg. 134
 — I. F., älter, Architekt, Judeng. 122
 — B. R., Prof. d.Mathem., Inselg. 132
@@ -3632,7 +3630,7 @@ Thierstein J., Postcom., Ag. 38
 — Wtw., Mehlhl., Aarbg. 28
 Thomann Sl., Comm., Bubenbergsrain
 ThomaßA., Apoth., Grchtg. 118
-Themen, Hasner, Aarbg. 66
+Themen, Hafner, Aarbg. 66
 Thormann-v. Wyttenbach F., W., (v. Gerzensee), Rent., Spitalg. 155
 — -v. Bären A. V. L., Rent., Gerechtg. 100
 — -Grüner C. E. F., Junkerng. 185
@@ -3654,7 +3652,7 @@ Traffelet J. A., Spe;., Keßlergasse 240
 Trechsel, Pfarrer am Münster, Herreng. 320
 Trechslin S., Sattler, Kramgasse 190
 Tribelhorn N.,Lederhl., Kirchgasse 265
-TribolctZ. A., Pros., Dr. Llsä. Lorraine (Abl. b. Fürspr. Lutz, Gerbernl. 62)
+TribolctZ. A., Prof., Dr. Llsä. Lorraine (Abl. b. Fürspr. Lutz, Gerbernl. 62)
 — Jbl, Speisew., Bollw. 78
 Tritschler I., Neg., Krmg. 217
 Tritten E., Schr., Keßlg. 283
@@ -3682,7 +3680,7 @@ v. Tscharner (v. Amsoldingen), Gutsbesitz., Spitalg. 152 n
 — -v.Bonstetten, gw. Rittmstr. in Oesterr., Junkg. 194
 — -v. Wyttenbach C. B. N., gewes. Oberrichter, Junkerng. 166
 — (v. Signau) Fräul., Junkerng. 182
-- geb. Stettler, Wittwe des Pros., Junkg. 182
+- geb. Stettler, Wittwe des Prof., Junkg. 182
 — -Fellenberg Frau, Jkg.185
 — so. Bcllerive), Junkg. 194
 - -Frau so. Bümplitz), Marktgasse 45
@@ -3702,13 +3700,13 @@ Uli F., Revisor u. Not., Kramgasse 174
 Ulrich M., Schn., Neueng. 110
 Ungericht Chr., Kostpferdhalt., Zeughausg. 16 l>
 Urban Fr., Gärtner, Falkenegg
-Urcch, Frau Barb., Käfichg. 104
+Urech, Frau Barb., Käfichg. 104
 — I. C., Schr., Käfichg. 104
 Urfer A., Modewhl., Kßlg. 283
 Urscheler B., Schiff., Nng.101
 Utz E., Schn., Aarbg. 353
 — B., Schuhm., Schiffl. 56
-Valentin G., Pros., Juda. 112
+Valentin G., Prof., Juda. 112
 Valentini, D., Chocoladefabr., Gerechtg. 86
 Vafsaur A. D., Schn.,Herrengasse 298
 # Date: 1861-04-15 Page: 1395976/122
@@ -3735,7 +3733,7 @@ Vogt F., Gärtner, Frick 69
 — I. I., Berichterstatter im Armenwesen, Grchtg. 128
 — Klaviermacher, Brunng. 30
 Vollenweider, Photograph, Gerechtg. 96
-VolmarÜr. Pros., Sptlg. 159
+Volmar, Dr. Prof., Sptlg. 159
 — P., Literat, Spitalg. 159
 Volz L.F., Hdlsm., Zghg. 16 u
 — C. R. ,Buchhlt. d. Cmwh.-Ersparnißk., Judeng. 114
@@ -3768,7 +3766,7 @@ Wahli B., Lohnk., Postg. 58
 — geb. König, Küchluv., Gerechtg. 146
 # Date: 1861-04-15 Page: 1395977/123
 Waiblinger F., Schrifts., Kornhauspl. 149
-Wakker Cbr., Schuhm., Stld. 12
+Wakker Chr., Schuhm., Stld. 12
 — Jb., Bäcker, Spitalq. 163
 Walch A., Maler, Marktg. 40
 Wälchli I., Schuhm., Spitalgasse 160
@@ -4014,7 +4012,7 @@ Wyß C. B., Prof., Bill. 167 c
 — Jgfr., Inselg. 138
 — N. F. A., gew. Hauptm., Neueng. 113 b
 — Rent., Zwiebelng. 69
-— C., Kellerhlt. u.'Weinneg., Kirchg. 274 u. Matte 108
+— C., Kellerhlt. u. Weinneg., Kirchg. 274 u. Matte 108
 — Frau Oberst., z. d. Th. 186
 — Fr., Gutsb., Felsen. 257 a
 — A. C. E., Papiernegotiant, Kramg. 187


### PR DESCRIPTION
After this change, 86 of 4077 records (2.1%) in the 1861 volume are still failing the tests of `check_charset.py`