### PR TITLE
Clean up some OCR errors in 1861 scan

### DIFF
--- a/proofread/1861-04-15.txt
+++ b/proofread/1861-04-15.txt
@@ -9,7 +9,7 @@ Abys Obrstkrgsc., Spitlg. 144
 — Frau, Modehdl., Grchg. 135
 Adam Milchhdl., Schpltzg. 210
 — gb. Kubli I. Lederhändler, Kramgasse 177
-— Igfr. Adele, Schneiderin, Marktgasse 38
+— Jgfr. Adele, Schneiderin, Marktgasse 38
 — Hufschmid, Käfichgäßl. 22
 Aebersold G. Pacht., Schßh. 92
 — Mgdl., Kräm., Aarzhle 28
@@ -48,7 +48,7 @@ Allemann R., Lederhändl., Bärenplatz
 — F., Sekr., 5lramgasse 179
 — Anna, Rent., Herreng. 203
 Althaus Ulrich, Schuhsticker, Schifflaube 42
-— Frau, Mchlhndl. u. Spez., Schauplatzgasse 212
+— Frau, Mehlhndl. u. Spez., Schauplatzgasse 212
 — Wtw. und Sohn, Metzger, Altenb. 164
 Altherr H. I., Spgl., Stld. 14
 Altmüller geb. Hauri, Rent., Schauplatzgassc 203
@@ -68,7 +68,7 @@ Anneler J. C., Mül., Matte II
 — gb. Steiner M., Bettmach., Matte 7
 Antenen I., Schulinspektor, Brunngasse 27
 — Hebamme, Brunngasse 27
-App M., Schuhm.., Metzgerg. 67
+App M., Schuhm., Metzgerg. 67
 Appenzeller, Pfarrer a. d. heil. Geist-Kirche, Bollwerk 81
 Appoloni H., Schnd., Speichg. 2
 Arm H. U., Feilenh., Stald. 4
@@ -250,7 +250,7 @@ Beyeler B., Knochens., Mit. 91
 — M., Schneid., Aarbg. 37
 — M., Kostgeb., Neueng. 94
 Bichsel I., Gesch.-Ag., Speichergassc 3
-— F. I. S., Wollcnhändler, Gerechtg. 129
+— F. I. S., Wollenhändler, Gerechtg. 129
 Bichsel J.C., Spanner, Schauplatzg. 230
 — Chr., Lumpens., Stalden 217
 — Hebamme, Gerbgr. 141
@@ -260,7 +260,7 @@ Biedermann, A., Condukteur, Gerechtg. 83
 — A. Spezierer, Gerechg. 83
 — R., Badewirth Aarz. 33
 Bieger F., Schuhm., Brng. 9
-Bienz I., Buchb., Neucng-102
+Bienz I., Buchb., Neueng. 102
 Bieri A., Gypser, Altb. 157
 — Chr., Kond., Kästchg. 100
 — P., Lumpens., Matte 6
@@ -316,7 +316,7 @@ Blaser B., Schuhm., Matte 11
 — I., Wirth, Stalden 15
 — I., Baumstr., Postg. 32
 — F., Privatleh., Aarberg. 45
-— I., Eiscntröd., Sptlg. 177
+— I., Eisentröd., Sptlg. 177
 — I., Schlosser, Stalden 18
 — N., Schmied, Altbg. 184
 — J-E., Ing., Postg. 32
@@ -440,7 +440,7 @@ Broglie I. P., Gärtn. Brunnadern 19
 Broßard, D., Sprachlehrer, Marktgasse 46
 Brötie J., Amtsn, Junkg.183
 Brouillet A., Negt., Krmg. 158
-Bruder I. Schwemm., Metzgergasse 95
+Bruder I. Schweinm., Metzgergasse 95
 Bruderer, Metzger, Metzg. 124
 — Jgfr., Schnd., Metzg. 124
 Brüderlin J.M., Lebt., Ag.46
@@ -494,7 +494,7 @@ Büchler Frau, Neueng. 98
 — I., Schnd., Brunng. 14
 # Date: 1861-04-15 Page: 1395925/71
 Buchmüller Jb., Buchdrucker, Matte 130
-— S. Essigfabr., Grchtg. 71
+— S., Essigfabr., Grchtg. 71
 — B., Gypser u. Maler, Bg. 9
 Buchschacher I., Mehlhändler, Zwiebelng. 40
 Büeler C., Fürspr., Journalist, Zeughausg. 6
@@ -566,7 +566,7 @@ Bürki A. F., Großrath, Judeng. 128
 Bürki Fr., Spengl., Altbg. 175
 — R., Gypshdl., Gerchtg. 78
 Bürky Jb., Instr.-Hauptmann, Zeughg. 11
-— S., Sägenf., Gerbq. 143
+— S., Sägenf., Gerbg. 143
 — Ros. Cath., Kräm., Arz. 28
 — Anna, Schnd., Sptlg. 161
 — Jgfr., Mod., Schützengßl.
@@ -645,13 +645,13 @@ Courant S., Regt., Mrktg. 45
 Cramer ge. Mettler, Hebam., Metzg. 70
 Crinsoz G., Kanzl., Krmg. 209
 Cueni A. I., Schrb., Bill. 166
-Cürchod L., Telegr.-Direktor, Gercchtg. 85
+Cürchod L., Telegr.-Direktor, Gerechtg. 85
 Dachs F. W., Regt., Grchtg. 65
 Dähler C. R., Gürtl., Bg. 30
 — Frau, Strohhutsabrikant, Kramg. 185
 — J. C., Archit., Rabbenthal
 — I. B., Trödl., Junkg. 195
-— Jb., Speiscw., Spitg. 158
+— Jb., Speisew., Spitg. 158
 Dällenbach I., Schr., Jkg. 157
 — Chr., Schr., Aarbg. 27
 — E. H. R., Wagner, Mit. 27
@@ -704,7 +704,7 @@ Dick R., Postdir., Marktg. 68
 — F., Sattler, Aarbg. 19
 — Conditor, Spitalg. 144
 — F., Lumpens., Spchg. 9
-Diebold P. D., Weinhändler, Gerechtq. 100
+Diebold P. D., Weinhändler, Gerechtg. 100
 Diefenbach G. H. Schrn., Arz. 6
 Diegelmann R., Schnd., Länggasse 215b
 v. Dießbach, Fräul. Emma, Marktgasse 41
@@ -740,8 +740,8 @@ Dubach G., Schr., Sptlg. 176
 — J. A., Literat, Metzg. 88
 Dübi J.C., Uhrm., Hotelg.235
 — geb. Wcltin, Mod., Hotelgasse 235
-— R., Hcbam., Grechtg., 146
-— I., Ncgot., Marktg. 55
+— R., Hebam., Grechtg., 146
+— I., Negot., Marktg. 55
 Dücommün A. L., Sesselmach., Bogenschtzh. b. ob. Thor
 Duffert A., Schn., Mrktg. 92
 Düfresne E. C. S., gw. Brodbäck, Besenscheuer 111
@@ -818,7 +818,7 @@ Eichenberger I. I., Schneider, Schauplatzg. 220
 — L., Krämerin, Zeughg. 15
 Eicher I., Sekr., Herreng. 307
 — B., Kram., Neueng. 99
-— E., Kappcnmacherin, Spitalgasse 152
+— E., Kappenmacherin, Spitalgasse 152
 Eidam, G. P., Kanzlist, Altenberg 148
 Einiger, vr., Journal., Lg. 247
 — L., Antiquar, Metzgerg. 97
@@ -888,7 +888,7 @@ Fehlbaum, I., Kammmacher, Metzgerg. 76
 Fehlmann A. M., Schneiderin, Schauplatzg. 213
 — Schuhm.,Schauplatzg.217
 Fehr I. C., Tel.-Büreauchef, Gerecktg. 70
-— geb. Wäber, Linq., Kramgasse 203
+— geb. Wäber, Ling., Kramgasse 203
 v. Fellenberg-Rivier, L. R., Prof., Rosenbühl 157 b
 — E. L., gew. Kuchthauspred., Junkerng. 185
 — (v. Hofwyl) E., Jkg. 185
@@ -902,8 +902,8 @@ Feller, D., Lieh., Metzgerg. 94
 — I. D., Kübl., Neueng.103
 — S., Postg. 28
 — Chr., Mechan., Hollig.152
-— I. F., Lederhdl.. Matte 38
-— Chr., Spengl.,Längg.215
+— I. F., Lederhdl., Matte 38
+— Chr., Spengl., Längg.215
 — I., Schneider, Matte 95
 — F., Holzhdl., Matte 73
 — L., Kohlenhdl., Bubenbg.-Rain 58
@@ -914,14 +914,14 @@ Ferrier A.R., Rt. Kornhpl.121
 Fetscherin A. A. Vater u. Sohn, Hafnerm., Aarbg. 68
 — C., Schlosserm.,Bllw. 262
 — E.,Buchbd., Reueng. 107
-— -Ris Heinr., Kandelsm., Markst,. 41
+— -Ris Heinr., Kandelsm., Markst. 41
 — C. L., Rotar, Kästchg. 96
 — -Lichtenhahn G. W., Lehr., Salzbüchsli
-— F. R. A., Schlossermcister, Kästchg. 20
+— F. R. A., Schlossermeister, Kästchg. 20
 — C. C. P., Quincailleriehändl., Marktg. 34
 - J. F., VDM, Bibliothek., Altenb. 115
 Fey P., Train-Insp., Bllw. 263
-— L.. Spiegelhdl., Grchtg. 98
+— L., Spiegelhdl., Grchtg. 98
 Fiala Max., Buchhl.-Commis, Marktg. 51
 — F., Modistin, Spitalg.153
 Fiechter P., gew. Kondukteur, Postg. 33
@@ -937,7 +937,7 @@ v. Fischer-Ooster A. F. R.,Hotell. 292
 — E. F. L., Dr., Professor, Bvllw. 264
 — (v. Reichenbach), I. M., Rent., Junkerng. 180
 — -Brunner C. Fl, Ingen., Marktg. 50
-— -v. Mülincn A. R., Rt. u. Weinnegt., Gerechtg. 95
+— -v. Mülinen A. R., Rt. u. Weinnegt., Gerechtg. 95
 — -v. Wattenwyl R. F., Fürsprecher, Nydeckg. 201
 — -May, Frau, Spitalg. 133
 — E. F., Alt-Schulth., Schoßhalde 103 (Baumgarten)
@@ -1007,7 +1007,7 @@ Freiburghaus Chr., Leinewb., Stalden 203
 Freidig I. I., Adjunkt, Arz. 26
 Freudenberger Frau, Kßlg. 238
 Freudenreich-Falconnet A., Rt. Spitalg. 154
-— Fräul., Ncnt., Junk. 177
+— Fräul., Rent., Junk. 177
 Freudiger Jb., Schuhmacher, Müllerl. 133 u. 134
 Frey-Hubacher R. A., Jdg. 130
 — C., Sekr. d. Tel.-Direkt., Altenb. 164 u
@@ -1015,7 +1015,7 @@ Frey-Hubacher R. A., Jdg. 130
 — A., Tel.-Insp., Grchtg.65
 — 2-, Zugführ., Altb. 142 n
 — Wtw. d. Lohnt., Judg. 127
-Freytag I. I., Quincaill.- u. Spielzeughrndlg., Marktgasse 86 u. 72
+Freytag I. I., Quincaill.- u. Spielzeughndlg., Marktgasse 86 u. 72
 Frieden Jb., Krämer, Mit. 75
 — gb. Thurni, Rt., Altb. 186
 Friedli S., jgr., Ngt., Spitalgasse 145
@@ -1096,7 +1096,7 @@ Gempeler, R., Dachd., Schauplatzg. 216
 Gerber S., Kappenm., Zwieb.gäßchen 61
 — A. L., Strohhutfabrikant, Inselg. 134
 — Dr. Prof., Bollw. 265
-— Frau, Hebam., Neucng. 95
+— Frau, Hebam., Neueng. 95
 — M., Modist., Speichg. 7
 — N., Krämer, Aarbg. 61
 — I., Steinst., Postg. 30
@@ -1119,7 +1119,7 @@ Gerber gb. Dennler, Ww., Rt., Spitalg. 168
 — U., Milchhdl., Enge 10
 — H., Butterhdl., Grchtg. 75
 — U., Weißmül., Keßlg. 291
-— U., Pächter, Slltcnb. 181
+— U., Pächter, Slltenb. 181
 — M., Kram., Scbauplg. 811
 Gerig Ww., Fournier f. Matte
 Gerster C. B., Architekt, Speichergasse l
@@ -1137,7 +1137,7 @@ Gfeller B., Küfer, Marktg. 33
 — I. Jb., Lithogr., Mktg. 80
 — I., Schuhm., Stald. 217
 — I. F., Schuhm., Arbg. 58
-— I., Pächter, Holiig. Illl
+— I., Pächter, Hollig. Illl
 — I., Bäcker, Schpltzg. 219
 — I. L., Schneid., Arz. 218
 — Wittwe u. Söhne, Steinh., Schaupltzg. 283
@@ -1145,7 +1145,7 @@ Gfeller B., Küfer, Marktg. 33
 Gilgen J., Schuhm., Metzg. 88
 — Jb., Schneid., Spitg. 166
 — R., Schneid., Aarbg. 56
-Gillieron, D., Rt., Holiig. 166
+Gillieron, D., Rt., Hollig. 166
 Giobbe I., Taphdl., Schg. 217
 Girardet F., Uebers., Krmg.111
 Giordani, Gipser, Gerechtigkeitsg. 116
@@ -1156,7 +1156,7 @@ Giudice, Part., Kramg. 202
 — M., Modiste, Krmg. 202
 Glanzmann I., Strumpfwb., Matte 19
 Glaser, Schuhm., Schg. 208
-Glättli H., Hafner, Holiig. 189
+Glättli H., Hafner, Hollig. 189
 Glauser, Pferdhlt., Junkg. 117
 — G.F., Kaminf., Brunng. 3
 — I., Steinh., Matte 16
@@ -1230,7 +1230,7 @@ Gribi L., Kondukt., Matte 31
 — Reallehrer, Sommerleist 171 b
 Grieser I. M., Schuhmacher, Matte 24
 Grimm I. M., Milchhändler, Neueng. 107
-— F. R., Wattcnfabr., Kramgasse 147
+— F. R., Wattenfabr., Kramgasse 147
 — geb. Lutstorf, Rt., Mtzg. 130
 — C., Kräm., Nydeckg. 234
 — S., Gärtner, Längg. 201
@@ -1375,7 +1375,7 @@ Hanslin-Kurz, Wittwe, Glaser, Kirchgasse 272
 Hanslin gb. Mühlemann, Kostgeber., Brunng. 19
 Hänzi N,, Salzwaagmeister, Billette
 Harder, geb. Bücher, Sptlg.161
-— geb. Wcnger, Schg. 201
+— geb. Wenger, Schg. 201
 Harrer, geb. Kablützel, Rent., Marktg. 94
 Harri, Spczierer, Stalden l
 Hartmann C. D. E., Privat.
@@ -1446,7 +1446,7 @@ Hemmann F. E., Quartieraufseher, Brunng. 35
 — R. E., Schreiber, Kßg. 244
 — Marie, Spitalg. 140
 — Fl.,Modiste, Schauplg.211
-— I. I., Büchscnschmicd, Schauplg. 220
+— I. I., Büchsenschmicd, Schauplg. 220
 Hemmerling M., Broderie- und Wollwaarenhdl., Mktg. 57
 Hendrich C. F., Schreiner, Schauplg. 204
 Henzi I. F., Gutsbes., gew. Ammann, Stadtbach 181, Ablage Marktg. 63
@@ -1521,14 +1521,14 @@ Hirt C., Mühlem., Matte 57
 — S., Schuhm., Stald. 215
 — B., Speisew, Stald. 221
 Hirter I., Schiffmstr., Mit. 42
-Hirtuni u. Neyncns, Kleidhdl., Junkerng. 162
+Hirtuni u. Neynens, Kleidhdl., Junkerng. 162
 Hochstettler C., Gasanzünder, Schauplg. 203
 Hochstraßer Jb., Schrn., Junkerng. 193
 — J. J., Schneider, Kßg. 277
 Holoch, Messerschm., Krmg.211
 Hodel L., Buchbinder, Neueng. 104 6
 Hodler I., Schuhm., Metzg. 84
-— Oberrcht., Breitenrain 120
+— Oberricht., Breitenrain 120
 — Z., Schrn., Schauplg. 228
 Höhn I. H., Vater, Sekretär, Ochsenscheuer
 — E., Sohn,Kanzl., Ochsenscheuer
@@ -1536,7 +1536,7 @@ Hörning L. S., Handelsmann, Kramg. 245
 — Hauptmann, Kramg. 221
 Hofer M., geb. Brand, Speisewirthin, Judeng. 113
 — E., Kanzlist, Schauplg.250
-— I., Schwemm., Schg. 223
+— I., Schweinm., Schg. 223
 — Caselli G., Spez. u. Auswandgsagt., Sptlg. 159
 — G., Regt., Stald. 4
 — Schwest., Schneiderinnen, Zeughspl. 250
@@ -1571,13 +1571,13 @@ Hofstetter, D., Buchb., Metzg. 135
 — I., Kramg. 169
 # Date: 1861-04-15 Page: 1395942/88
 Hofstetter Anna, Schneiderin, Metzgerg. 74
-— P., Weißmüller, Aar;. 83
-— Müller, Aarbergg. 35n
-Hofstettler, Kondurtch Hrg. 302
+— P., Weißmüller, Aarz. 83
+— Müller, Aarbergg. 35a
+Hofstettler, Kondukt., Hrg. 302
 Hohlenweger P., Bergführer, Postg. 34
-Höllenstein Frau, Iuponsstcpp. Aarziele, b. innern Bad
-Hölzer Jb., Speisew., 2lg. 21
-— Chr., Gürtler, Lwg. 225
+Höllenstein Frau, Juponsstepp., Aarziele, b. innern Bad
+Holzer Jb., Speisew., Ag. 21
+— Chr., Gürtler, Schg. 225
 — geb. Flückiger, Kostgeber., Spitalg. 162
 Honegger E., Sekr. n. Registr. d. Telegr.-Dir., Krmg. 212
 Hopf-Steiger, Kramg. 179
@@ -1587,11 +1587,11 @@ Hoßfeld C. A., Schrn., Aarz. 34
 Hostettler E., Hebamme, Metzgergasse 86
 Hotz E., Schuhm., Grchtg. 113
 — -König, Brunng. 29
-Howald, Frau, Haft,., Sulgb.
+Howald, Frau, Hafn., Sulgb.
 — K., Notar, Herreng. 321
 Howard, gew. Klaviermacher, Bollw. 264
 Hubacher R., Spez., Mktg. 68
-— E., Weinhdl., Nng. 116 u
+— E., Weinhdl., Nng. 116 a
 — Frau, Neueng. 116 a
 Huber I. R., Färber, Mtt. 118
 — H. D., Lhnktsch., Zghsg. 13
@@ -1618,10 +1618,10 @@ Hug F. D., Organist u. Dintenfabrikant, Renen,; 91
 — I., Kommis, Postg. 44
 — R., Kommis, Kornhpl. 148
 — Wittwe d. Messerschmieds, Metzg. 71
-Hugcndubel Chr. H., Direkt, d. Realschule, Falkenpl. 217b
+Hugendubel Chr. H., Direkt, d. Realschule, Falkenpl. 217b
 Hügi S. M., Modiste, in. Bollwerk 83
 — I. D., Kanzl., Herrg. 365
-— Chr., Brngrb.. Hollig. 161
+— Chr., Brngrb., Hollig. 161
 — S., Schneiderin, Aarbg. 72
 Hügli G., Amtsnt., Sptlg.128
 — Vcr., spez., Spitalg. 128
@@ -1629,8 +1629,8 @@ Hügli G., Amtsnt., Sptlg.128
 Hüguenin, Wirth, Sandrain
 Hummel G., Metzg., Keß lg. 182
 — E., Bnchb., Marktg. 33
-— Fb., Bäcker, Reucng. 122b
-— Jgsr., Kostgeb., Metzg.123
+— Fb., Bäcker, Neueng. 122b
+— Jgfr., Kostgeb., Metzg.123
 Hunsperger Jb., Schuhmacher, Keßlg. 246
 — Dachdecker, Postg. 23
 Hunzigker Abraham, Otegot., Junkerng. 186
@@ -1651,7 +1651,7 @@ Hürst P., Bäcker, Brunng. 6
 Hüser, Oberstlt., Kramg. 221
 Hutmacher I., Lehrer, Postg. 16
 — geb. Weniger, Krämerin, Keßlg. 241
-Huttcnlochergb.Wäber, Pfläst., Aarz. 21
+Huttenlocher gb. Wäber, Pfläst., Aarz. 21
 Hutter L., Zckngslhr., Mktg. 44
 Hyseli, F., Sprachl., Zghg. 10
 Jacot des Combes L., Rent., Inselg. 136a
@@ -1697,7 +1697,7 @@ Jenni Chr., Buchdruck., Metzgerg. 96
 — I., Schrn. u. Glas., Bg. 24
 — I., Weber, Heilig. 115
 — S., Wirth zur Waldeck
-— I.. Zimmerm., Längg. 218
+— I., Zimmerm., Längg. 218
 — E., Speziererin, Hotell.238
 — M., Schneiderin, Frick 70
 # Date: 1861-04-15 Page: 1395944/90
@@ -1902,9 +1902,9 @@ Kochli, Schuhm., Reueng. 119
 — Chr., Müller, Junkg. 164u
 # Date: 1861-04-15 Page: 1395947/93
 Köchli Chr., Küchliw., Abg. 47
-Köhler I., gew. Büchsenschm., Löchligut 140 u
-— Fr., Schneider., Aarbg.27
-— I., Schneider, Reu eng. 95
+Köhler I., gew. Büchsenschm., Löchligut 110 a
+— Fr., Schneider., Aarbg. 27
+— I., Schneider, Neueng. 95
 — Frau, Geschirrhändlerin, Spitalg. 130
 — Chr., Sägenfeiler, Schauplatzg. 224
 — F., Schnitzler, Matte 111
@@ -1913,11 +1913,11 @@ Köhler I., gew. Büchsenschm., Löchligut 140 u
 — I., Schreiber, Keßlg. 249
 — Lehrer, inneres Bollw. 81
 — I., Revisor, Zeughspl.249
-— Em., Tpeisew., Schauplg.
+— Em., Speisew., Schauplg.
 Kohli F., Zeughausbuchhalter, Brunng. 20
 Köhli P., Kutscher, Junkg.147
 Kohlrusch G. U., Literat, Gerechtg. 97
-Köhniein H., Schnd., Mktg.82
+Köhnlein H., Schnd., Mktg. 82
 Kolb S., Schnd., Brunng. 21
 — F., Zuckerbäck, Aarbg. 61
 — Ohmgeldbeamt. b. ob. Th.
@@ -1949,9 +1949,9 @@ Kopp I. J., Rent., gew. Vergolder, Kramg. 159
 — I., Schneider, Kramg. 175
 — S., Negt., Spitalg. 153
 Körber Ioh., Buchhbl., Laugmauer 230
-— H., Sobn, Buchhändl.,Altenb. 173 b
-Kraft I., Kroncnwirth, Gerechtg. 9<1
-— Cnsr., Pfisternwirth, Kornhauspl. 51
+— H., Sobn, Buchhändl., Altenb. 173 b
+Kraft I., Kronenwirth, Gerechtg. 96
+— Cnst., Pfisternwirth, Kornhauspl. 51
 — C., Wirth, Bernerhof
 Krähenbühl G., Schrein., Holligen 155
 — I. P., Gärtner, Bubenbergrain 64
@@ -1959,7 +1959,7 @@ Krähenbühl G., Schrein., Holligen 155
 — Cand. med., Junkg. 191
 — Schuhm., Bubenbgrain 61
 — Jb., Schn., Sckauplg. 226
-Krämer I., Schuhmacher, Sckg. 215
+Krämer I., Schuhmacher, Schg. 215
 Kräuchi Jb., Metzger, Aarbergergasse 29 u. 67
 — R., Rechtssag., Nng. 102
 Kraut G., Metzger, Metzg. 134
@@ -1993,7 +1993,7 @@ Kuckenburg, Rent., Gerbgr. 138
 Küchler G. W., Gürtler, Zwiebelng. 62
 Küenzi I. F, Cond. Krmg. 215
 — I- R., Zeugsch., Matte 50
-— A. B., Weitznäh.,Jkg 192
+— A. B., Weißnäh.,Jkg 192
 — I. S., Rent., Matte 120
 - J.L., Zeugschm., Frick 72
 — I. F., Gärtner, Aarz. 15
@@ -2004,7 +2004,7 @@ Küenzi M. A., Wasch., Matte 105 a
 — Chr., Schiffer, Aarz. 52
 — g. Funk, Krämerin, Mt.114
 — Rosa, Baumw.-Handlung, Marktg. 88
-Küfer, Frau, Ouincaill.-Hdlq., Marktg. 88
+Küfer, Frau, Quincaill.-Hdlg., Marktg. 88
 Kümmerly G., Lithogr., Marktgasse 82
 Küng N., Schr., Aarbg. 63
 — geb. Bigler, Geschirrhdlg., Altenb. 173 a
@@ -2012,9 +2012,9 @@ Künkelen F.,Lehrer, Billette
 Künsch J. C.,Mühlem.,Mt.12
 Küpfer I. F., Rittm., Ng. 101
 — L. A., gewesen. Kantonsbaumeister, Junkerng. 151
-— C. E. A., gew.Angest. b.d. Kantonalb., Keßlg. 239
-— C. R.F.,Hutm.,Mrkg.93
-— F.G.,Dr. ineä., Nng. 88
+— C. E. A., gew. Angest. b.d. Kantonalb., Keßlg. 239
+— C. R.F., Hutm., Mrkg. 93
+— F. G., Dr. med., Nng. 88
 — Wwe. d. Tuchneg., Mktg.57
 — A. E., Schwellenmeister, Schwellenmätteli 6
 — Feilenhauer, Bärenpl. 109
@@ -2022,32 +2022,32 @@ Küpfer I. F., Rittm., Ng. 101
 — Spengler, Postg. 41
 — C., Amtsnot., Kramg. 165 u. Schütte 254
 — Charl., Schauplg. 134
-— P.A., Metzg., Krmg. 152
-— G., Matratzenur., Altb.173»
-Kützing Chr., Klaviermacher, Längg.207k
+— P. A., Metzg., Krmg. 152
+— G., Matratzenm., Altb. 173a
+Kützing Chr., Klaviermacher, Längg. 207b
 Kuentz F., Konditor, Mrktg. 75
 — -Freudig Carl, Marktg. 75
 — G., Kupferschm., Mrktg. 30
 Kucrt I. R., Fürspr., Kramgasse 189
 # Date: 1861-04-15 Page: 1395949/95
-Kulm C. F., Ebenist, Aar;. 8
-— F. R.,Klaßhl., Sptlg.134
-— G. D. F., gew. Broobäck, Schaupltzg. 232
-— F. G.,Nent., Marktg. 37
+Kulm C. F., Ebenist, Aarz. 8
+— F. R., Klaßhl., Sptlg. 134
+— G. D. F., gew. Brodbäck, Schaupltzg. 232
+— F. G., Rent., Marktg. 37
 — Frau, Mod., Gerechtg. 145
-Kuhnen F.,Major, Aarbg. 38
-Kuhni K., Küfer, Metzq. 102
-Kummer, Eh., Sesselst., Postgasse 26
-— <L. F., Fürspr. u Amtsnot., Spitalg. 143
+Kuhnen F., Major, Aarbg. 38
+Kuhni K., Küfer, Metzg. 102
+Kummer, Ch., Sesselfl., Postgasse 26
+— C. F., Fürspr. u Amtsnot., Spitalg. 143
 - J., Negt., Aarz. 92 b
-— N., Schlosser, Neucng. 116
+— N., Schlosser, Neueng. 116
 — E., Lehrerin, Brunng. 10
 Kunz L. G., Sattler, Matte 14
 — -Haller, Hotcll., 228
 — geb. Blaser, Butterhändl., Stalden 1
-— Schneider, Schaupltzg.220
-Kupferschm dtU. Stl.,Mt. 111
-— Baumat.-Hdlg.,Jdg.113n
+— Schneider, Schaupltzg. 220
+Kupferschmidt U. Stl. ,Mt. 111
+— Baumat.-Hdlg., Jdg. 113a
 Kurt Wtw., Trödl., Aarbg. 73
 Kurz, Reg.-Rath, Staatskanzl.
 — I. F., Kanzlist, Aarbg. 63
@@ -2063,7 +2063,7 @@ Kutzli, auf d. Intelligenzblatt-Büreau, Zeughauspl. 247
 — -Mürner, Schrifts., Brunngasse 10
 Kyburz, Schuhm., Anatg. 10 a
 Kyd M. A., Mod., Gerbg. 125
-Lahner U., Schn., Spcichg. 6 s
+Lahner U., Schn., Speichg. 6 s
 Lädermann F., Schmied, Spitalgasse 171
 — I., Schneid., Matte 114
 Läderach Chr., Gärtner, Heiligen 112
@@ -2092,7 +2092,7 @@ Langhans G., Landsaßen-Almosner, Schauplatzg. 202
 Lanz-Wyß F., Regt., Gemdr., Felsenau 257
 — -Moser, Negot. im Altenb.
 — Gebrüder, Lederhdl., Gerberngr. 142
-— J.H., Bäcker, Spitz. 168
+— J. H., Bäcker, Spitz. 168
 — I. S., Notar, Kramg. 209
 — A., Kanzlist, Gerechtg. 121
 # Date: 1861-04-15 Page: 1395950/96
@@ -2106,7 +2106,7 @@ Läuffer R., Metzg., Aarbg. 67
 Lauffer J. C., Schlosser, Schauplatzgasse 198
 Lauper N., Mehlhl., Nng. 92
 Lauterburg E. F., Flachmaler, Weyermannshaus 133
-— F. G., Eisenneg.,Zghg. 18
+— F. G., Eisenneg., Zghg. 18
 — C. G. R., Ingen., schwarz Thor 101
 — C. A., Posam., Kramg. 171
 — C. L. S., Buchb., Kßg. 281
@@ -2116,25 +2116,25 @@ Lauterburg E. F., Flachmaler, Weyermannshaus 133
 Leder Gärtner, Billette
 Ledermann Frau, Dekatiererin, Spitalg. 175
 — Ros., Schneid., Aarbg. 52
-Lehman« Chr., L. C., Inselprediger, Casinopl. 131
-— S.J.G., Lekrer, Mrktg. 59
+Lehmann Chr., L. C., Inselprediger, Casinopl. 131
+— S. J. G., Lehrer, Mrktg. 59
 — F., Bäcker, Längg. 252
 — F., Rent., Junkerng. 19
 — F., Schreiner, Kirchg. 261
 — F., Schuhm., Aarbg. 22
-— F., Äanzlist, Postg. 25
-— Chr., Reut., Aarbg. 67
+— F., Kanzlist, Postg. 25
+— Chr., Rent., Aarbg. 67
 — Jb., Kanzlist, Matte 13
-— Jb.,Kanzlist, Postg. 35
+— Jb., Kanzlist, Postg. 35
 — I., Müller, Matte 28
 — F., Journalist, Stld. 6
-— bhr., Uhrenm., Zghpl. 253
+— Chr., Uhrenm., Zghpl. 253
 — Geschwister, Metzg. 97
 — Frau, Kleiderhdl., Schauplatzg, 229
-Lebmann R., Postwagenni., Postg. 31
-— N., Goldarbelter, Mt. 254
+Lehmann R., Postwagenm., Postg. 31
+— N., Goldarbeiter, Mt. 254
 — S., Dr., Reg.-Rath, Rabenthal 155
-— S., Müller, Sulgcnb.101
+— S., Müller, Sulgenb. 101
 — S. R., Gypser, Matte53
 — geb. Lörtscher, Krämerin, Matte 11
 Lehner U., Schnd., Aarbg. 16
@@ -2150,15 +2150,15 @@ Lemp geb. Mühlemann, Lehr., Spitalg. 160
 — V., Hebam., Brunng. 27
 — I., Wagner, Bollwerk83
 Längenhager geb. Hochstraßer, Rent., zw. d. Th. 180
-Lengfelder I., Corsctmacherin, Zeughpl. 253
+Lengfelder I., Corsetmacherin, Zeughpl. 253
 Lenz I., Fimmerm.,Hollg.117
 — C. A., Sehn., Brung. 26
 — Zeitungstrg., Gerbgrb.111
 v. Lentulus-Pourtales, Wtw., Rent., Junkerng. 195
-Lenzinger, Strumpswb. u. Negot., Spitalg. 176
+Lenzinger, Strumpfwb. u. Negot., Spitalg. 176
 Leon, Schneid., Brunng. 19
 Leonhard F., Glätterin , Aarberaerg. 37
-Lequin F. Ä., Gärtner, Billette 166 u
+Lequin F. A., Gärtner, Billette 166 a
 Lerch I., Metzger, Marktg. 3S
 # Date: 1861-04-15 Page: 1395951/97
 v. Lerber-Grüner, F. Theod., Privatlh., Sulgenrain 74
@@ -2181,10 +2181,10 @@ Leuenberger R. L. F., Schrb., Kirchg. 272
 — S., Schuhm., Zghg. 16 u
 — I., Schuhm., Metzg. 134 u. Kramg. 143
 — I. U., Schuhm., Matte 39
-— E. Seifenhl., Herrcna.331
+— E. Seifenhl., Herrena.331
 — Metzger, Metzg. 100
 — Frau, BLurisrh-Schneid., Metzg. 101
-— geb.Hcminann, Frau Mar. Kathar., Kramg. 165
+— geb. Hcminann, Frau Mar. Kathar., Kramg. 165
 Leutenegger N., Siebmacher, Marktg. 78
 Leuthold U., Amtsnot., Kornhausplatz 152
 Leuw F. R., gew.Pfr.,Marktgasse 52
@@ -2214,7 +2214,7 @@ Lieäiti, A. S., O.uartieraufs., Matte 110
 — geb. Christen, Hebamme, Schaupltzg. 212
 Lienhard S., Kutsch., Jkg.150
 Lier B., Spcz., Spitalg. 136
-Lieutaud, Sprrchlehr., Neuengasse 92
+Lieutaud, Sprachlehr., Neuengasse 92
 v. Linden L., eidgen. Oberst, Neu eng. 122 u
 Linde,imann I., Schnd., Stalden 24
 Linder P., Oekonom, a. Krankenhaus
@@ -2226,7 +2226,7 @@ Linder P., Oekonom, a. Krankenhaus
 Linder geb. Mathey, Schneid., Herreng. 304
 Lindt I. R., Apoth., Mrktg. 94
 — W., Vr. Lleci., Hotell. 230
-— I. P., Äerichtspräs., Hotellaube 230
+— I. P., Gerichtspräs., Hotellaube 230
 Lindt F. A., Handelsmann, Marktgasse 72
 Link F., Ellenwhdlg., Mktg. 74
 — Schuhm., Metzg. 65
@@ -2235,14 +2235,14 @@ Loder C., Mech., Gerbg. 137
 — Frau, Lobnw., Matte 58
 Löffel J. F., Mehlh., Schg.226
 Löhrer J. J., Sattl., Pstg. 40
-— Kaffee- u. Küchliw., Gerbern!. 144
+— Kaffee- u. Küchliw., Gerbernl. 144
 — Wtw., Abwarts, Hochschule
-Lörtscher Chr., Gärtnl, Lg. 201
+Lörtscher Chr., Gärtn., Lg. 201
 — I. R., Gärtn., Längg. 201
 — M., Kram., Aarbg. 25
 Lösch P., Schuhmacher, Gerechtigkg. 130
 Löw I. F., Wirth, Speichg. 6
-Lombard P., Regcnsch.-Fabr., Kramg. 152
+Lombard P., Regensch.-Fabr., Kramg. 152
 Loosli I., Schnd., Mrktg. 37
 — P., Kanzlist, Stalden 214
 Losenegger-Bay, Kramg. 186
@@ -2264,10 +2264,10 @@ Lüthard Em. u. Comp., Sachwalter, Kramg. 175
 — Louise, Clavierlehr., Arz.8
 — F., Fürspr., Sekr. u. Kassier d. Mobil.-Assekur.-Gesellschaft, Marktg. 84
 — R., Koch, Zeitglockth. 228
-— M., Kapellmstr., Falkcnpl. 222
+— M., Kapellmstr., Falkenpl. 222
 — P., Müsiklehrer, Aarz. 84
 Lüthi Wtw., Rent., Matte 106
-— A., Notar, Stempelverw., Ncueng. 87
+— A., Notar, Stempelverw., Neueng. 87
 — P., Schneid., Metzg. 80
 — Jb., Arzt, Krmg. 175 (Gallrrie Rebold)
 — D., Krämer, Aarz. 46
@@ -2286,24 +2286,24 @@ Lüthi Wtw., Rent., Matte 106
 Lüthold-Rommel, Weinhandl., Kornhspl. 152
 Lütscher J., Sekr., Grchtg. 116
 Lustenberger, Musiker, Schauplatzg. 220
-Lutstorf Ä. R., Vat., Geschäftsmann, Stalden 7
-— E. L., Sohn, Geschäftsm., Ncueng. 87
+Lutstorf A. R., Vat., Geschäftsmann, Stalden 7
+— E. L., Sohn, Geschäftsm., Neueng. 87
 — -Richard, Maria, Corsetmacherin, Neueng. 87
 # Date: 1861-04-15 Page: 1395953/99
-Lutz A.,V. V.U.,gw.Waisenvater, Junkg. 183
+Lutz A., V. D. M., gw. Waisenvater, Junkg. 183
 — E. A., Amtsnt., Friedensrichter, Neueng. 101
-— Ed., Fürspr., Äcrbernl. 62, Gutsbes. in der Lorraine
-— F. W., Hafner, Lgg. 215 §
-— Th., Hafner, Bolkw. 83
+— Ed., Fürspr., Gerbernl. 62, Gutsbes. in der Lorraine
+— F. W., Hafner, Lgg. 215 g
+— Th., Hafner, Bollw. 83
 — C., Fürspr., Bollw.263 d
 — F. R., Glaserm., Ksig. 95
 — Wtw., Käfichg. 95
 — -Kühn Wtw., Aarbg. 63
-— S. R., Geom., Markt«. 81
-— F.B.G. Ueci.vr., Bq.33
-— G.,Hdlsm. Aargstld. 128ä
+— S. R., Geom., Marktg. 84
+— F. B. G., Med. Dr., Bg. 33
+— G., Hdlsm., Aargstld. 128d
 — geb. Steck, Wittwe, Marktgasse 84
-— gcw. Pfarrer, Altb. 1735
+— gew. Pfarrer, Altb. 1735
 Maag S., Schuhm., Sptg. 1733
 Mader, Sägenfeiler, Matte 77
 Mäder J.,Sekr., Aarz.26
@@ -2313,7 +2313,7 @@ Mäder J.,Sekr., Aarz.26
 Madöri J. J., Barbier, Kornhauspl. 47
 — Wtw., Zeughg. 9
 Mantel Wtw., Spengler, Aarberg. 24 u. 25
-Manthe F., Glaser, Keßlg. 295 !
+Manthe F., Glaser, Keßlg. 295
 Mann F., Commis, Stalden 5
 Manuel F. A. E., Rt., Ng. 113
 — -v. Wattenwyl L. G., Rt., Junkerng. 168
@@ -2343,11 +2343,11 @@ Marti C., Oberrich., Grchg. 115
 — A. M., Krämerin, a. Bollwerk 122 a
 — M., Schnd., Sptlg. 160
 — M., Lehrerin, Marktg. 88
-— geb. Dieffenbach, Schnd., ?chg. 261
-— ?, Spez., Aarbg. 61
+— geb. Dieffenbach, Schnd., Kirchg. 261
+— F., Spez., Aarbg. 61
 — Joh., Mechan., Sptg. 164 b
 — Frau, Bäurischschneiderin, Spitalg. 164 b
-Martin G., Schirmsb., Marktgasse 89
+Martin G., Schirmfb., Marktgasse 89
 — J. C. H., Schuhm., Ng. 109
 Martz J. D., Schr., Schg. 235
 Maser D. A., Sachw., Metzg. 133 u. Stalden 17
@@ -2362,47 +2362,47 @@ Mathys J., Kondkt., Hrg. 302
 Matti C., Antiquar, Keßlg. 242
 — -Müller, Frau, Bollw. 81
 Matz C. H,, Coiffeur, Kornh.platz 50 u. Marktg. 58
-Mauderli F., Lehn,, Mrktg.40
-— I., Gürtler, Neueng. 83
-Mauerhofer J.G.,Not., Obergerichtswbl., Nydeckg. 201
-— I., Schr., Neueng. 108
+Mauderli F., Schn., Mrktg. 40
+— J., Gürtler, Neueng. 83
+Mauerhofer J.G., Not., Obergerichtswbl., Nydeckg. 201
+— J., Schr., Neueng. 108
 Maure A., Schleif., Brng. 35
 Maurer A., Sesselm., Mtzg. 89
 — Gärtner, Längg. 154
-— I., Spengler, Kstlerg. 286
-— I. F. G., Neueng. 117
+— J., Spengler, Kßlerg. 286
+— J. F. G., Neueng. 117
 — Glaser, Junkerng. 158
 — Frau, Coiffeuse, Brng. 35
 — G., Postcom., Keßlg., 286
-— I., Drechsler, Lpcichg. 6e
-— I. L., Postcom., Nng. 94
-— I., Kutscher, Matte 53
+— J., Drechsler, Speichg. 6c
+— J. L., Postcom., Nng. 94
+— J., Kutscher, Matte 53
 — N., Kondukt., Aarbg. 22
 — A., Mehlhl., Aarbg. 70
-— Frau, Sehn., Aarbg. 29
-— A. M.,Mod., Ärmg. 152b
+— Frau, Schn., Aarbg. 29
+— A. M., Mod., Krmg. 152b
 Mäusli F., Steinh., Aarbg. 74
-v.Map-o.Tavcl G.G.A., Sachwalter, Spitalg. 130
-— Frtu., Spitalg. 137
-— -Wurstemberger (v. Urssllcn) A. R. B., Rent., Junkerng. 176
-— -v.Tschiffeli, d.Staatssckr. Wwe., Marktg. 34
+v. May-v. Tavel G.G.A., Sachwalter, Spitalg. 130
+— Frln., Spitalg. 137
+— -Wurstemberger (v. Ursellen) A. R. B., Rent., Junkerng. 176
+— -v.Tschiffeli, d. Staatsschr. Wwe., Marktg. 34
 — H., Ing., Junkg. 158
-- -V. Grastenried, debil.llr. Wwe., Marktgasse 40
+- -v. Graffenried, des M. Dr. Wwe., Marktgasse 40
 — v. May (von Hünigen), Fräul., Heiligen 151
 — (v. Rued), Bollw. 265
-— Wtw.(v.Belletrüche) Junkerng. 177
-Meckle Chr., Schuhm. Mrkg. 35
+— Wtw. (v. Belletrüche), Junkerng. 177
+Meckle Chr., Schuhm., Mrkg. 35
 Medina, Tapezier., Splg. 127
-Meister Frau, Leichenbitt.,Keßlerg. 283
-Melev-Werthmüller, F. A., Laudwirth, v. d. unt. Th. 4
+Meister Frau, Leichenbitt., Keßlerg. 283
+Meley-Werthmüller, F. A., Laudwirth, v. d. unt. Th. 4
 Mendel J. I., Musikl. (Organist), Bollw. 265
 Menn I., Kanzlist, Hrng. 362
-Menz Ör., Doz., Falkenplätzli 215 (Hugendubelhaus) "
-Menzi I. M., Küfer, Sptg. 167
-Mertz Chr., Dackd., Brg. 8
+Menz Dr., Doz., Falkenplätzli 215 (Hugendubelhaus)
+Menzi J. M., Küfer, Sptg. 167
+Mertz Chr., Dachd., Brg. 8
 Merz D. R., gew. Oberlehrer, Marktg. 76
 — C., Lehrer d. engl. Sprache, Marktg. 76
-— I. A. R., Ouartieraufseh., Maulbeerbaum 95
+— I. A. R., Quartieraufseh., Maulbeerbaum 95
 — J.,Zimmerm., Gerbg. 13g
 — Frd., Schlosser, Kfg. 105
 Messer R. G., Polizeid., Spitalg. 136
@@ -2416,12 +2416,12 @@ Meßmer R. A., Postcassier, Gerechtg. 78
 — G., alt-Landam., Mrkg.59
 de Mestral- o. Wurstemberger, G. A., gw. Oberförst., Gerechtg. 64
 — -Goumoens, Psr. Grcht. 84
-Mctkfessel G.A., Musikdirekt., Gerechtg. 93^
-— Ad., Kunstgärt., Grchg.93
+Methfessel G. A., Musikdirekt., Gerechtg. 93
+— Ad., Kunstgärt., Grchg. 93
 # Date: 1861-04-15 Page: 1395955/101
 Mittler Wtw., Herreng. 307
-— Söhne, Kanzlist., Hrq. 307
-Mey G., Amtsnot., Hvtell. 232
+— Söhne, Kanzlist., Hrg. 307
+Mey G., Amtsnot., Hotell. 232
 — Gärtn., zw. d. Th. 182
 — C., Möbelschr., Spchg. 13 u. Anatomg. 257
 Meyer S. Chr., Privatlehrer, Marktg. 51
@@ -2434,7 +2434,7 @@ Meyer S. Chr., Privatlehrer, Marktg. 51
 — J., Photograph, Sptg.142
 — J. J., Archiv., b. schw. Thor
 — Alb., Sekr., b. schw. Thor
-— Fr., Schr.,Brunng. 3
+— Fr., Schr., Brunng. 3
 — I., Schneid., Kramg.104
 — I., Wirth, Salzmag.l90u
 — J., Schnd.,Postg.38
@@ -2444,19 +2444,19 @@ Meyer S. Chr., Privatlehrer, Marktg. 51
 — -Liebi I. I., Eisennegot., Bierhübeli 266 u. 267
 — L., Negt., Metzg. 117
 — B., Trödl., Stald. 4
-— P., Kammmach., Brunnq. 6
-Meyerhoser F. P., Schr., Salzmagazin 236
-— G.C.,Kanzlist,Stald.3
+— P., Kammmach., Brunng. 6
+Meyerhofer F. P., Schr., Salzmagazin 236
+— G.C., Kanzlist, Stald.3
 — S., Theaterkass., Metzg.72
 — M., Schneiderin, Jkg.149
 Meyhöfer R., Kanzlist, Länggasse 215
-Metzcner, Tabakfabr., Spchg. 3
-Metzger A. S., Sprachleh., Gercchtg. 136
+Metzener, Tabakfabr., Spchg. 3
+Metzger A. S., Sprachleh., Gerechtg. 136
 — Ww., Speisewirth., Zeughausplatz 253
-Mickaud 8. G., Weinh., Marktgasse 43
-MichelJ.M., Schuhmach.,Gerechtg. 144
+Mickaud L. G., Weinh., Marktgasse 43
+Michel J.M., Schuhmach.,Gerechtg. 144
 — A.B., Wirthin, Mtzg. 102
-Michle Spez., Aarl>g. 18
+Michle, Spez., Aarbg. 18
 Mieg L., Bahnhof-Inspekt., im neuen Bahnhof
 Mieville L., Lehrer, Grchtg. 100
 — Ed., Commiss., Längg.212
@@ -2464,21 +2464,21 @@ Migy P., Reg.-Rath, Kreuzg. 162 s
 Milliet J.F.,Kanzl., Mrktg.51
 Minder R., Holzschuhm., Junkerng. 158
 — J.,Schr., Zeughg. 13
-— Schirmsab., Schpltzg. 195
-— gb.Hvrrisberger, Grempl., Schauplg. 219
+— Schirmfab., Schpltzg. 195
+— gb. Horrisberger, Grempl., Schauplg. 219
 Mining, Lehrer, Neueng. 86
 Mischler Ul., Kaminf., Schauplatzg. 225
 Mohni I., Schneid., Schg. 21S
 Moll A., Conditor, Neuengasse 111
-Mollet L.,Fruchthl.,Brg. 28
-— F.,Bäcker, Spitalg. 156
-— Metzger, Rathhausplatz104
+Mollet L., Fruchthl., Brg. 28
+— F., Bäcker, Spitalg. 156
+— Metzger, Rathhausplatz 104
 Mollinet A., Metzg., Metzg. 96
-Molo J., Tclegr., Metzg.94
-Mvlz F., Zuchthausprediger, Bollwerk 26ö
-Mvnteil I. E., Schirmfabrikant, Marktg. 91
+Molo J., Telegr., Metzg.94
+Molz F., Zuchthausprediger, Bollwerk 26ö
+Monteil I. E., Schirmfabrikant, Marktg. 91
 Morell B. L., gew. Spitaleinz., Billette 167 o
-— xErnst, Rent., Judeng. 129
+— -Ernst, Rent., Judeng. 129
 — -v. Wattenwyl, gew. Major in Neapel, Gerechtigkg. 89
 Mors Buchhalt., Kramg. 192
 — Frau, Haubenm., Stld. 18
@@ -2488,7 +2488,7 @@ Mori, Rentier, Schauplg. 234
 Mori S., Condit., Sptlg. 140
 Mörker J., Wagner, Anatg.14
 v. Morlot-Kern C. A. N., Sekretär der burgl. Feld- und Forstcomm., Junkg. 150
-— Asä. vr., Jkq. 150
+— Med. Dr., Jkg. 150
 — Karl Ad., Prof., Jkg. 150
 — -Crousaz, Ww., Kirchg.265
 — Fräul., Junkerng. 184
@@ -2498,13 +2498,13 @@ Moser L. M., Landw., Weißenstein 51
 — Frau, Schneid., Brg. 21
 — H., Bücksenm., Aarbg. 73
 — C. F., Müllerm., Sulgenbach 106
-- J. F., Schr., G-rbg.143
+- J. F., Schr., Gerbg. 143
 — F. R., Schn., Marktg. 52
 — H. U., Metzger, Gerbt. 112
 — geb. Lüthi, Anna, Weißnäherin, Keßlerg. 238
 — R. L., Bäcker, Neueng. 101
-— F., Rechenm., Schoßh.49
-— J., Eisendreber,Aarz. 70
+— F., Rechenm., Schoßh. 49
+— J., Eisendreher, Aarz. 70
 - N., Mod., Marktg. 40
 — Chr., Metzger, Aarz. 22
 — I., Leinweber, Schoßh. 74
@@ -2519,14 +2519,14 @@ Mosimann, Schuhm., Lgg. 243
 — F., Polizeid., Gerechg. 116
 — Frau, Spez., Gerechtg.116
 Mosmer J., Schirmfabr., Gerechtg. 77
-Mottaz C., Lingsre, Grchtg. 73
+Mottaz C., Lingère, Grchtg. 73
 Mottet, Instr.-Offiz., Arbg. 35
 Mouille geb. Depping, Kräm., Keßlerg. 334
 Mouillet, Jgf., Malerin, Kipchgasse 275
 Mühle U.,Mech., Aarbg. 18
 Mühlethaler I., Kondukt., Aarbergergasse 21
 — Joh., Steinh., Badl. 86
-— v. Mülinen-v. Mutach E. F>, Reut., Gercchtg.95
+— v. Mülinen-v. Mutach E. F., Rent., Gerechtg.95
 — Gurowsky, Rent., Gerechtigkcitsg. 96
 Müller F. E., gew. Ingenieur, Längg. 215 g
 — Pfarrer, Spitalgasse 132
@@ -2539,15 +2539,15 @@ Müller F. E., gew. Ingenieur, Längg. 215 g
 — -Häberli, Spez., Krmg. 191
 — Chr., Apoth., Kramg. 181
 — J. H., Schuhm., Postg. 26
-— I. Ül., Kräm., Brunng. 14
-— I., Büchsenschind., Schauplatzg. 208
-— K.F.,Büchsschm.,Stld. 6
+— J. Ul., Kräm., Brunng. 14
+— J., Büchsenschmd., Schauplatzg. 208
+— K.F., Büchsschm., Stld. 6
 — -Schärer, Frau, Krämerin, Stalden 6
 — H. Jb. Spezierer, Kramgasse 163
-— ^.Ü., Wagner, Holla. 142
+— H. U., Wagner, Holla. 142
 — geb. Schick, Glätt., Schauplatzg. 223
-— C.F., Buchb., Sptlg. 125
-— J.B., Glasmal., Schönegg
+— C. F., Buchb., Sptlg. 125
+— J. B., Glasmal., Schönegg
 — F., Kleiderhdl., Stald.3
 — -Schmid, Maler und Lackirer, Keßlerg. 256
 — S., Scidenwb., Aarz. 22
@@ -2560,7 +2560,7 @@ Müller A. M., Gärtnerin, Aarziehle 85
 — S.L., Amtsnot., Inselsekr., Aarbg. 47
 — H.A., Schr., Grchg. 81 u. 82
 — F., Schnd., Zeughg. 11
-— A., Schleifern. Rasiermes-händl., Matte 103
+— A., Schleifer u. Rasiermes.-händl., Matte 103
 — J., Spez., Brunng. 17
 — Jb., Schr., Matte 113
 — I., Schnd., Spitalg. 156
@@ -2571,7 +2571,7 @@ Müller A. M., Gärtnerin, Aarziehle 85
 — M., Schnd., ZwLlng. 40
 — J., Gppser, Schoßh. 53
 — A.CHr., Drechsl., Gchg.97
-— Gcbrd., Seidenfbk., Bollwerk 263 u
+— Gebrd., Seidenfbk., Bollwerk 263 u
 — D., OLerpost-Rev., Marktgasse 87
 — J. H., Glasml., Aarz. 8
 — J., Dachd., Brunng. 24
@@ -2588,16 +2588,16 @@ Mumprecht I. I., Spengler, Aarz. 39 b
 Münger A., Fuhrm., Lag. 222
 — Z., Oberst, Aarz. öö
 — Saager, im Dalmazi
-— I., Flachmaler, Aarz. 135
+— J., Flachmaler, Aarz. 135
 — N., Dachd., Aarba. 76
 — Jb., Gppser,Sptlg. 136
-— F.N., Schuhm., Äarbg.30
+— F. N., Schuhm., Aarbg. 30
 — C., Weihmüll., Spitlg. 148
 — A. F., Regt., Käfichg.28
 Munzinqer, Dr., Nydeckg. 198
 Mürset A. A., Postabw., Spitalg. 176
 Mützenberg S., Schn., Abg. 43
-— Kondukteur, Brunng. ^6
+— Kondukteur, Brunng. 16
 — I., Graveur, Aarbg. 32
 — -v. Muralt-du Houllcy, Frau, Junkerng. 168
 — -v. Kirchberger, D. F. C., Rent., Spitalg. 154
@@ -2609,8 +2609,8 @@ Mutterer, Schr., mittl. Slgbch.
 Mutti H. F., Buchh lt., Altb. 156
 — geb. Uebersax, Kostgeberin, Zeughg. 11
 — H., Küfer, Postg. 40
-— J.B.,Sattl., Ncueng.129
-Näff W.,B.-R.,zw.d.TH.182
+— J.B.,Sattl., Neueng.129
+Näff W.,B.-R., zw.d.TH.182
 Nagelt P., Regt., Zwbg. 62
 — -Friedli, Frau, Kramg.159
 Nast J. B., Musikl.Kramg.158
@@ -2622,7 +2622,7 @@ Nenninger J., Feilenh., Arz. 87
 Neuenschwander J. Jb., Goldarbeiter, Frick 69
 — Buchb., Junkg. 146
 Neuhaus G., Schlss., Metzg. 85
-— Chr., Schuhm., Brunnq.5
+— Chr., Schuhm., Brunng. 5
 - Ch. N., Schuhm., Salzmagazin 236
 — S.L., Uhrenm., Svtlg. 115
 — A., Postcommis, Metzg. 123
@@ -2652,27 +2652,27 @@ Nordemann B., Metzg. 131
 —H., Bandhdl., Keßlg. 283
 —Th., B andhd lg., Krm g. 199
 — -Weil, Regt., Kramg. 221
-Nordemann M., Band- u.Merceriehandlq., Spitalg. 127
+Nordemann M., Band- u. Merceriehandlg., Spitalg. 127
 — N., Regt., tzptlg. 161
 — Bandkandl., Marktg. 47
 Nörther Jb., Scknd., Postg. 23
 — M., Schnd., Ankenl. 334
 Noth I., Gypser, Zeughg. 9
-Nötbinger E., Kommiss., Spitalg. 160
-Nothegcn L., Rent., Nng. 1166
-Nüesck C. A., Drechsler, Keßlerg. 29!)
-— S.J., Kaminf., Stalb. 15
-— I. Chr., jgr., Kaminfeger, Marktg. 35
+Nöthinger E., Kommiss., Spitalg. 160
+Nothegen L., Rent., Nng. 1166
+Nüesch C. A., Drechsler, Keßlerg. 290
+— S. J., Kaminf., Stald. 15
+— J. Chr., jgr., Kaminfeger, Marktg. 35
 Nußbaum I. A., Brunng. 28
 — I., Bäcker, Müllerl. 26
 — M., Trödlerin, Marktg. 31
 — geb. Friedli, Spitalg. 142
 Nydegger I., Oeler, Mit. 102
 — I. R., Amtsnot., Läng. 201
-— I., Steinbrech., Matte121
-Nyffeler C. S., Schrb., Ilcuengasse 121
-— geb.Mori,Lumpcnsamml., Äarbg. 37
-— E., Schneid., Müller!. 26
+— I., Steinbrech., Matte 121
+Nyffeler C. S., Schrb., Neuengasse 121
+— geb. Mori, Lumpensamml., Aarbg. 37
+— E., Schneid., Müllerl. 26
 Nyffenegger, Schnd., Arbg. 38
 Oblaser I. A, Spcisewirth, Tiefenau
 Oberbolzer C., Schuhmacher, Metzg. 134
@@ -2695,28 +2695,28 @@ Oppermann Chr., Schneiderin, Marktg. 33
 — Jgfr. S., Ncg., Krmg. 147
 Oppliger I. Chr., Buchb., Arziebie 35
 — I. G. M.,Buchb.,Stld.6
-— P., Uhrcnm., Aarbg. 28
+— P., Uhrenm., Aarbg. 28
 — A. B., Kostgeb.,Zeughg. 9
 Ort F., Spez., Gerechtg. 141
 Ost F., Gastw., a. Bollw. 123
 Ostermann D., Speisewirth u. Weinhändl., Spitalg.170
-Osterrictb geb. Nägeli, Rent., Junkg. 181
+Osterrieth geb. Nägeli, Rent., Junkg. 181
 — L. F., Arch., Aarz. 2
-— L. >«ohn, Weinh., Jkg.161
+— L., Sohn, Weinh., Jkg. 161
 Oswald, Falkenw., Marktg. 87
 Oth Hauptm., a. Holzm. 244
-Ott G., Hammerschmied, Landeren 104 u und Mattenenge 128
+Ott G., Hammerschmied, Landeren 104 a und Mattenenge 128
 — Chr., Sekr., Metzg. 113
 — Schreiner, Speicherg. 10
-Otz R. S.,Schr., Aarbg. 31
-— I., Waagmcist., tläfg. 27
+Otz R. S., Schr., Aarbg. 31
+— I., Waagmeist., tläfg. 27
 — G. F., Mechan., Aarbg. 77
 — V., Schnd., Metzg. 70
 — B., Schr., Salzmag. 236
-— S., Schr., Anatg. 10 i>
+— S., Schr., Anatg. 10 b
 — M. C., Kräm., Marktg. 32
 — Frau, Bettm., Aarbg. 31
-Otzcnberger J. F.,Tap., Junkerng. 166
+Otzenberger J. F.,Tap., Junkerng. 166
 Ougspurger Ph. F., Bürgerschreiber, Marktg. 91
 — Ji. F. L., Friedensrichter, Schoßh. 47 u. Grchtg. 64
 Pabst C., Prof., Brückfeld 232
@@ -2725,13 +2725,13 @@ Pages A. S., Schnhm., Neuengasse 108
 Pagenstecher Jgfrn., Insg. 136
 Paroz I., Dir. d. neuen Mädchenschule, Stadtbach 178
 Pascboud, Crbschft., Gypshdl., Matte 101
-Pauli B., Küchler., Aarbg. 3?
+Pauli B., Küchler., Aarbg. 37
 — Frau, Wasch., Matte 117
 — I. E., Buchb., Käfichg. 104
-— S. G., Not., Langm.227<1
-— -Schmid, Ncgt., Mrktg. 32
-Panlik gcb. Löhrer, Lohnwasch., Matte 117 e
-Pearson geb. Hcnzi, Rent., Gerechtg. 110
+— S. G., Not., Langm. 227 d
+— -Schmid, Negt., Mrktg. 32
+Panlik geb. Löhrer, Lohnwasch., Matte 117 e
+Pearson geb. Henzi, Rent., Gerechtg. 110
 Pedrazzi, Fümiste, Grchtg. 110
 Pelligot J.S., Tanzt., Brg.36
 Pellet P., Bäcker, Stald. 207
@@ -2740,12 +2740,12 @@ Perty, Professor, Aarziele 1
 Peter geb. Ktoßncr, Krämerin, Kramg. 150
 — Cath., Lohnw., Marktg. 86
 — H,, Schneid., Metzg. 88
-Petitpierre Gz., alt-Ständer., Aarz. 15 » (Prairie)
+Petitpierre Gz., alt-Ständer., Aarz. 15 a (Prairie)
 # Date: 1861-04-15 Page: 1395960/106
 Petri I. L., Papierneg., Kornhauspl. 149 u. Marktg. 71
 Peyer Jb., Zahnarzt, Metzgergasse 106
 Petzold H., Lehrer, Schifft. 47
-Pfeffli A., Schhm., Vrunnq. 3
+Pfeffli A., Schhm., Brunng. 3
 — Chr., Schrn., Neueng.104
 Pfander I., Gerechtg. 128
 Pfenniger J., Sekr., Muesmtt.
@@ -2754,10 +2754,10 @@ Pfister Chr., Vürstbd., Schauplatzg. 233
 — -Kneubühler, Ngt., Marktgasse 40
 — J. Jb., Lhr., Schauplg. 205
 — I., Schreiber, Posig. 30
-— R., Schuhm.,unt.Thor223
+— R., Schuhm.,unt.Thor 223
 — I., Steinh., Aarbg. 66
 Pflick W. B., Buchb., Junkerngasse 155
-Pflugshaupt P. H., Lvhnbed., Gerechtg. 120
+Pflugshaupt P. H., Lohnbed., Gerechtg. 120
 Pfotenhauer, Prof., Hrg. 327
 Phsne, geb. Meißner, Privatlehrerin, Kramg. 173
 Piana I. A., Barometersabr., Metzg. 98
@@ -2768,7 +2768,7 @@ Plüß-Robr, eidgen. Aränvargehülfe, Gerechtg. 124
 Pochen I. F., Goldschmied, Kramg. 198
 Pölsterli I., Lehrer, Metzg. 73
 Ponti, Gebr., Ouincaillhdl., Kramg. 175
-Portcnier M. E., Schneiderin, Gerechtg. 74
+Portenier M. E., Schneiderin, Gerechtg. 74
 — Schriftsetzer, Gerechtg. 139
 Pohet Ch. L., Schnd.,Mktg. 36
 Prader G., Wirth, Zwiebg. 41
@@ -2787,43 +2787,43 @@ Pulver J. E. A., Architekt, Falkenpl. 217, Ablg. Sptg. 135
 — Chr., Schneider, Käfg. 100
 — Jb., Schhm., Slzmag. 236
 — J.Jb., Schhm., Schg.209
-Pünter I., Regt., Badlaube82
-de Queroain L., Regt., Kramgasse 153
-QuiÜet, Geschirrhdl., Mktg.50
+Pünter I., Regt., Badlaube 82
+de Quervain L., Regt., Kramgasse 153
+Quillet, Geschirrhdl., Mktg. 50
 Raaflaub E., Schrn., Bllw. 262 u. Falkenplätzli
 — I., Fürspr., Storchg. 159
-Rabe I. Christian, Hutmacher, Marktg. 67 und Ncueng. 85
+Rabe I. Christian, Hutmacher, Marktg. 67 und Neueng. 85
 v. Rachnitz geb. Steiger, Rent., Gerechtg. 114
 Räber E. F. , Pächter, Aarz. 47
 — A., Thierarzt, Neueng. 105
 Rämi C.A., Spgl., Längg.213
-Räubi F. Jb., Zimmer,nann, Schauplg. 230
+Räubi F. Jb., Zimmermann, Schauplg. 230
 # Date: 1861-04-15 Page: 1395961/107
 Rätzer C. L., Vater, Buchdruck., Judeng. 112
 — C. E., Sohn, Buchdrucker, Judeng.112
 — Töchtern, Schauplg. 203
 Räz B., Bäcker, Metzg 66
-— N.,Bäcker, Schutzmühlc21
+— N.,Bäcker, Schutzmühle 21
 Rahm, Weinhdl., Bollw. 268
 Ramseier G., Stnbrch., Neuengasse 119
-— gb. Spring, Rent., Brunngasse 22 ^
+— gb. Spring, Rent., Brunngasse 22
 Ramser Jb., Steinhauer, Stalden 17
 — B., Steinh., Heilig. 111
 — Rkl., Steinh., Worblaufen
 Ramsler, Elementarschul-Dir., Kirchg. 261
-Ramstein Ä.F., Schrn., Brunngasse lie
-Rappolv S. E., Tapezierer, Keßler«. 217
-Rau W., Ür. Nsci., Casinoplatz 131n
-— L. W., 8tnä. Ilvci., Casinoplatz 131n
-Real Louise, Lehrerin, Kolligen
+Ramstein A. F., Schrn., Brunngasse lie
+Rappold S. E., Tapezierer, Keßlerg. 247
+Rau W., Dr. Med., Casinoplatz 131a
+— L. W., 8tnä. Ilvci., Casinoplatz 131a
+Real Louise, Lehrerin, Holligen
 Reber Ros., Spez., Grchtg. 112
 — Elise,Kostgeb., Metzg. 123
-Rechsteiner, Schneid., Äarz. 7
+Rechsteiner, Schneid., Aarz. 7
 Reglin H., Gastwirth , Kramgasse 171
 — Jb., Kürschn., KLfg. 170
 Rehfues P. R., Goldschmied, Matte 17 u. Kramg. 166
 Reich H., Oberzollrcvis., Metzgerg.101
-— Jgsr., Lehrerin, Mtzg. 101
+— Jgfr., Lehrerin, Mtzg. 101
 Reichenbach N., Postg. 45
 Reinhard I., Thurmwächter, Münster
 — A., Negt., Zwiebg.39
@@ -2832,7 +2832,7 @@ Reinhard, Chr., Hirschenwirth, Neueng. 81
 — geb. Lanz, Spcisewirthin, Keßlg. 288
 — Marie, Schnd., Sptlg.166
 — I., Angestellter d. Justiz- u. Polizeidirektion, Bllw. 80
-— Chr., Schnd., Neucng.120
+— Chr., Schnd., Neueng. 120
 Reisinger-Durheim, C. A., Vater, Casino
 — C. R., Sohn, Guidenhptm., Wankdorf 108
 — Frln., zwisch. d. Thoren
@@ -2841,12 +2841,12 @@ Reist L., Lebküchler, Speichg. 4
 Rellstab I. A., Getreidchdl., zwisch. d. Thor. 280
 — I., Schuhm., Längg. 215s
 Remke F. P., Schreiner, Metzgerg. 81
-Rcmnnd Ä., Krm., Sptlg. 163
-Renaud, Fürspr.^ Kramg. 162
+Remund A., Krm., Sptlg. 163
+Renaud, Fürspr., Kramg. 162
 — Bankkassier, Herreng. 307
 Renfer N., Sattls, Schplg. 200
 Renz Jb., Schnd., Grchtg. 121
-Rettlg G., Prof., Postg. 87
+Rettig G., Prof., Postg. 87
 Reußer F., Lehrer, Längg. 202
 — Frau, Ellenwaarenhandl., Schauplg.207
 Reust C., Spez.,Mktg.90
@@ -2855,7 +2855,7 @@ Rhin C., Buchbd., Brunng. 23
 Rhiner F., Lumphdl., Kßg. 276
 — -Witschi, Schneid., Schulgasse 305
 Ribi V., Kostgeberin, Aarbergergasse 14
-— Ä. M., Hcbam., Aarbg. 41
+— A. M., Hebam., Aarbg. 41
 Richard F., Schreiber, Kßg. 280
 — J., Anqestellter b. Stempelamt, sstcueng. 91
 — F., Rent., Falkencgq 222
@@ -2870,20 +2870,20 @@ Richard Fr., Ouincailleriehdl., Kramg. 203
 Rieder-Spiegelberg, Regt., Marktgasse 41
 — P., Pächter, Schoßhld. 49
 Riedoz J., Musikus, Schg. 212
-Riedwnl R., Buchbd., Kß^g. 244
+Riedwyl R., Buchbd., Kßlg. 244
 Riesen I., Schhm., Sptlg. 126
 — I., Schneider, Sptlg. 177
 — F., Gärtner, Hollig. 142
-— E., Ärämerin, Schg. 233
-— N., Speisewirth, ^rtald.1
+— E., Krämerin, Schg. 233
+— N., Speisewirth, Stald. 1
 Rieter H., Seiden-Negt., Holligen 149
 Rindlisbacher, Müller, Müllerlaube 107
 — Bäcker, Metzg. 121
-— P. Milchhdl.,Metzg. 92
+— P., Milchhdl., Metzg. 92
 — Sattl., Schauplg. 204
 Ringgenburger I., Schuhm., Postg. 40
 Ris A. S., Kaminfeg., Mit. 10
-— C. L., Tffizial, Junkg. 173
+— C. L., Offizial, Junkg. 173
 — G. F., gw. Bäck., Altb.162
 — R. L., Ingen., Altenb. 162
 — Prof., Böhlenhaus, Aargauerstalden
@@ -2891,7 +2891,7 @@ Ris A. S., Kaminfeg., Mit. 10
 — R. M., Krämer.,Zwg. 39
 Risold J. F., Schrn., Kbg. 292
 Ritschard F. L., Schuhm., Müllerlaube 36
-Rochat, Jgsr., Giletmacherin, Brunng. 9
+Rochat, Jgfr., Giletmacherin, Brunng. 9
 Roder F. R. I., Vater, Metzg., Kramg. 218
 Roder F. D. W., Sohn, Metzg., Kramg. 212
 — Köhler, Kramg. 209
@@ -2910,11 +2910,11 @@ Rohr C. I., Dr. Heck., Junkerim. 153
 — Alb., Wettmacht., Kßlg. 236
 Rohrbach I., Kutscher u. Gastwirth, Metzg. 118
 — F.Jb., Schneider, Bubenbergrain 61
-— Jgsr., Modiste, Krmg.186
-Rohrer F. E., Negt., Krmg. 213 u.Keßlg.245
-— Frau, Äollw.82
+— Jgfr., Modiste, Krmg.186
+Rohrer F. E., Negt., Krmg. 213 u. Keßlg.245
+— Frau, Bollw. 82
 — Gypser u. Tapetenhändler, Gerechtg. 125
-Rolls Ed. ^ Wollenspinnerei u. Weberei, Matte 128
+Rolls Ed., Wollenspinnerei u. Weberei, Matte 128
 Rollier A., Postcm., Grchtg.77
 — Lehrer, Neueng. 113 b
 Romang I. Jb., Obergerichtsschreiber, Neueng. 113 b
@@ -3009,7 +3009,7 @@ Ruutz-Haller, H., Regt., Marktgasse 93
 Rychener, Standeswbl., Zeughausg. 14 u. Marktg. 47
 Ryf J. Jb., Speisew., Zghg. 6
 Ryffel Jb., Schneid., Sg. 11
-Ryser I., Schuhm,., Matte 34
+Ryser I., Schuhm., Matte 34
 — I., Schuhm., Altenbg. 146
 — S., Messerschmied, Aarbergerg. 34
 — Wittwe, Käfichg. 22
@@ -3024,9 +3024,9 @@ Salvisberg S., Amtsnotar, Schauplg. 199
 Salzmann I., Kostpferdhalter, Junkerng. 149
 — F., Schreiner, Neueng. 81
 — Frau, Wäscherin, Matte 79
-Sanvmcier C., Schrein., Kefilcrg. 289
-Sauser J., Instr.-Adj., Zqhg.5
-Sauter K., Porträtmaler, L>otellb.233, Ablg. Krmg.140
+Sandmeier C., Schrein., Keßlerg. 289
+Sauser J., Instr.-Adj., Zghg.5
+Sauter H., Porträtmaler, Hotellb.233, Ablg. Krmg. 140
 Saxer F. E., Rothsärb., Altenberg 165
 Schädel I. U., Schuhm., Keßlerg. 294
 Schädeli J. A., Sattler, beim Casino 131
@@ -3034,12 +3034,12 @@ Schädelin, geb. König, Wwe., Metzgerg. 130
 Schäfer F., Buchdrucker, äuß. Bollw. 263
 — Frau, Broderie u. Ressorts-Jüpons, Bollw. 263
 — Quincailleriehdlg., Mktg.64
-SchärJb., Sattl., Altnbg. 177
+Schär Jb., Sattl., Altnbg. 177
 — Frau, Kostpferdhalterin, Schauplg. 200
 — Jb., Geschäftsm., Ng. 102
 — P., Schuhm., Längg. 194
 — R., Schhslick.,Längg.2151,
-— Chr,, Kaminfeg., Brg. 16
+— Chr., Kaminfeg., Brg. 16
 — G., Zimmermann, Aarziehle 69
 — Chr. R., Drechsl.,Aarz. 22
 — Chr., Schuhm., Schg. 225
@@ -3056,11 +3056,11 @@ Schärer, Direkter d. Waldau
 — E., Ingen., Brückfeld 235b
 — Jb., Seiler, Stald. 6
 — R., Privatlehrer, Gerechtigkeitsg. 90
-Schäuble A., Flkcnw., Mktg. 67
+Schäuble A., Flkenw., Mktg. 67
 Schaibli M., Schneiderin, Hotellaube 232
 Schafroth, Wittwe, Speisew., Metzg. 117
 Schaffer J.A., Bandfabrikant, Schoßhalde 206
-Schaffter A., franz. Pfarrer, Herrcng. 324
+Schaffter A., franz. Pfarrer, Herreng. 324
 — Schwest., Keßlg. 257
 — R., Lehrerin, Judeng. 113e
 — I. I., Instruktor, Brg. 3
@@ -3084,7 +3084,7 @@ Scheidcgger gb. Fehlmann, M., Kleiderputzerin, Stld. 206
 Schenk C., Reg.-Rath, Maulbeerbaum, Ablage Spitalgasse 171
 — Ww., Schneid., Aarbg. 27
 — S., Zimmerm., Auß. Bollwerk 122
-— J.U., Wagner, Sptlq. 173
+— J.U., Wagner, Sptlg. 173
 — C. F. A., Goldarb., Stalden 216
 — Holzhdl., Spitalg. 173
 — P., Käshdl., Rcueng.106
@@ -3099,7 +3099,7 @@ Scherrer I. B., Lohnkutscher, Zeughg. 10
 Schertenleib J. Jb.,Schuhm., Aar. 22
 Scherz B., Schneid., Matte 48
 — I., Regierungsrath, Spitalg. 165
-— Wittwe u. Sohn Theod., Gercchtigk. 141
+— Wittwe u. Sohn Theod., Gerechtigk. 141
 Scheuch, Lhnbed., Judeng. 127
 Scheuermerster I. L., Uhrenm., Schauplg. 196
 Scheurer I. G. R., Zuckerbäck, Zwiebg. 39
@@ -3113,22 +3113,22 @@ Schieß I. 11., Bundeskanzler, Bundesrathhaus
 — Schieferdecker, Altbg.173n
 v. Schiserli C. M., Vr. Asä., Junkerng. 169
 Schiff M., Prof., Brückfeld 232
-— >6., Dozent, Brückfeld 232
+— H., Dozent, Brückfeld 232
 Schiffmann M., Kondukteur, Brunng. 17
 — R., Pdstcomm.,Zghpl.253
 — geb. Pfäffli, Spez., Neuengasse 122 0
 Schick P., Rechtsagt., Sohn, Kornhauspl. 152
 — Fr., Brunng. 7
-Schild J. D., vr. Prof., Kramgasse 183
+Schild J. D., Dr. Prof., Kramgasse 183
 Schilt P., Coiff., Siptalg. 123
 Schindler Chr., Büchsenschmd., Schauplg. 221
 — L. N., Müller, Schutzmühle 20
--I. II., Metzger, Junkg.195
+- J. U., Metzger, Junkg.195
 — A., Schlosser, Aarbg. 21
 — F. R., Dachdecker, Bubenbergsrain 61
 — F., Schhm., Schauplg. 227
 — R. M., Schneider., Ag. 75
-— Frau, Cafswrth., Mtzg. 121
+— Frau, Caféwrth., Mtzg. 121
 Schinz Emil, Dr., Lehrer, Altenberg 160
 Schläfli F. I., Brunneninstr., Aarz. 57
 — Chr., Kondukt., Grchg. 76
@@ -3137,12 +3137,12 @@ Schläfli F. I., Brunneninstr., Aarz. 57
 — I. F., Schreib., Grchtg. 76
 — B., Schneider, Gerbl. 19
 Schlopp U., Droguist, Gerechtigkeitsg. 108
-Schlapbach I. U., Schwemm., Altenberg 125
+Schlapbach I. U., Schweinm., Altenberg 125
 — I., Schreiber, Skalden 1
 — Elise, Schneid., Hrng. 321
-Schlapbach I. Lr., Ziinmerm., Länggaß 215
+Schlapbach I. S., Zimmerm., Länggaß 215
 — F. H., Vater, gw. Schweinmetzger, Neueng. 100
-— J., Sohn, Schweinmetzg., Neucng. 100
+— J., Sohn, Schweinmetzg., Neueng. 100
 Schläppi L., Schnd., Mtzg. 127
 Schlatter D., Kaminfcg., Keßlerg. 285
 — I- G., Flachmaler, Langmauer 227
@@ -3156,9 +3156,9 @@ Schluepp N., Küfer, Aarbg. 41
 — A. C., Schreiber, Mktg. 35
 Schlumpf geb. Pasteur, Leichenbitterin, Metzgerg. 125
 Schlupp J., Bäcker, unt. Thorbrücke 222
-— M., Lehrerin, «ptlg.161d
+— M., Lehrerin, Sptlg. 161d
 Schmalz, Bücksenm., Klosterh.
-Schund F.L., Banquier, Kraingaß 113 u. 213
+Schmid F. L., Banquier, Kramgaß 113 u. 213
 — -Beringer u. Comp., Eisenhandlung, Marktg. 62
 — E., Ingen., Nydeckg. 201
 — C. W., Buchhdl., Mktg. 81
@@ -3172,20 +3172,20 @@ Schund F.L., Banquier, Kraingaß 113 u. 213
 # Date: 1861-04-15 Page: 1395967/113
 Schmid-Flohr, Claviermacher, Monbijou 94
 — Musiklehrer, Kramg. 456
-— I. Jb., Matratzenmacher, Bärenpl. gegcnüb. d. Bärencafs
+— I. Jb., Matratzenmacher, Bärenpl. gegenüb. d. Bärencafé
 — I., Bäcker, Matte 22
 — geb. Stettler, Frau, Judeng. 122
 — Maler u. Gypser, Mtzg. 122
 — -Sprüngli, Wttwe, Kranigasie213
-Schmitz A., Sümeid., Bg. 24
-Schmutz I., Schwemm., Kestlerg. 291
+Schmitz A., Schneid., Bg. 24
+Schmutz I., Schweinm., Keßlerg. 291
 — Möbelhändler, Brunng. 28
-— geb. Hegg, Kostgeberin, Brun»gs25
+— geb. Hegg, Kostgeberin, Brunng. 25
 — Büchsenschmied, Kstg. 289
-— J., Cigarrcmnch., 2ög. 118
+— J., Cigarrenmch., Ng. 118
 — Bend., Lohnbed., Brg. 28
-Schnäbeli A., Schuln».,Bg.21
-Schneeberger I., Steinbauer, Marktg. 80
+Schnäbeli A., Schuhm., Bg.21
+Schneeberger I., Steinhauer, Marktg. 80
 — Z., Schirmfabr., Matte 1
 — geb. Wildi, Frau, Färber., Keßlerg. 286
 Schneering A., Schnd., Herrengasse 208
@@ -3203,7 +3203,7 @@ Schneider P., erst. Sekretär d. Finanzdep., Spitalg. 160
 — Wr.,Nudlen»i., Stald.10
 — O., Privatlehrer, Mktg. 71
 Schneider Joh., Oberförster, Kramg. 190
-Schneiter J. F., Wagner, Länggast 215
+Schneiter J. F., Wagner, Länggass 215
 — Jb., Schuhm., Grchtg. 74
 — I. Chr., Schleifer, Mtt. 69
 — F., Bäcker, Junkerng. 46
@@ -3222,11 +3222,11 @@ Schönt A.E., Kram., Lngg. 227
 — A. C., Schneid., Schg. 235
 — Regt., Keßler«. 252
 — Milchträger, Stald. 18
-— F., Hafner, Neucng. 104
+— F., Hafner, Neueng. 104
 — Buchbd., Scharfrichtg. 115
 Schonhcr F., Schuhm., Stalden 212
 Schorer S., Mnzbeamt., Postgasse 43u
-— geb. Glcther, Tapetcnhdl., Kramg. 172
+— geb. Glcther, Tapetenhdl., Kramg. 172
 Schort R., Bäcker, Marktg. 52
 — Bäcker, alt. Schwnmkt.251
 Schrämli I. Jb., Schuhmach., Brunng. 15
@@ -3235,7 +3235,7 @@ Schreier F., Schhm., Stld. 212
 # Date: 1861-04-15 Page: 1395968/114
 Schreiner, Wittwe, Schreiner, Schauplatzg. 228
 Schubert I. C., Barbier, Gerechtg. 86
-- B., Lehrerin, Grchtq. 127
+- B., Lehrerin, Grchtg. 127
 Schuhmacher F. E. H., Metzgermstr. u. Wirth in Hllg.
 — V., Buchbinder, Krmg. 169
 — I., Schuhm., Stald. 5
@@ -3302,7 +3302,7 @@ Selhofer, Wwe., Steindruck., Neueng. 113
 — Ww., Mehlhdl., Grchtg.140
 Senn N., Lehrer, Inselg. 136
 — F. N., Postoffiz., Schg. 235
-— F.. Fechtmstr., Schg. 215
+— F., Fechtmstr., Schg. 215
 Sesti A., Negt., Kramg. 185
 Shuttleworth, Rent., Bierhübeli 227
 — R. J., Dr., Bierhübeli 227
@@ -3331,12 +3331,12 @@ Simmen A., Wirth im Altenbergbad
 Simon, Notar u. Rechtsagent., Marktg. 68
 — Frau, z. Affen, Kramg. 184
 — F., Buchhalter, Krmg. 223
-— E. A.,Handelsmann, Junkerngasse 174
-— B., 1>r.gnr., Fürsprecher., Neuengasse 88
+— E. A., Handelsmann, Junkerngasse 174
+— B., Dr. jur., Fürsprecher., Neuengasse 88
 — F., Kunstmaler, Jdg. 118
 Sing I., Küfer, Speicherg. 1
 Singeisen, Chef d. Cent.-Pol.-Bureau, Casinoplatz 131
-v. Sinner-v. Kirchberger I.. Rent., Spitalg. 155
+v. Sinner-v. Kirchberger I., Rent., Spitalg. 155
 — -Sinner A. F. R., Rent., gew. Oberamtmann von Seftigen, Junkg. 178
 — -v. Wattenwyl C. F., Rent., Marktg. 72
 — -v. Fischer R. C. F., Rent., Kramg. 166
@@ -3364,7 +3364,7 @@ Spengler I. H., Schuhmacher, Marktg. 90
 Spicher R., Postcom., Mit. 127
 — J., Butterhdl., Brunng.19
 Spichtger C., Postadj., Bg. 3
-Spiegelberg L., Condt., Marktgasse 9^
+Spiegelberg L., Condt., Marktgasse 94
 — Fr., Buchbd., Käfichg. 91
 Spillmann A. G., Lederhdl., Metzg. 122
 — I. D., Gießer, Salzm. 238
@@ -3383,7 +3383,7 @@ Stadelmann P.,Neg., Mhg.89
 Städter S., Schneid., Mit. 115
 Stadlin C. M., Zinngießer, Altenbg. 161
 — A., Redaktor, Altenb. 161
-— M., Bdswbl.,Zwiebq. 39
+— M., Bdswbl., Zwiebg. 39
 Stahel J.U., Feilenh., 2tbg.71
 Stäheli, Regt., Marktg. 38
 — Frau, Ellenwaarenhandl., Kramg. 221
@@ -3397,7 +3397,7 @@ Stäbli-Groß, Revisor, Altenb. 160 k
 Stalder F., Glaser, Sptlg.117
 Stämpfli Jb. , Bunvesrath, Böhlenhaus 128
 — I. F. R., gcw. Küfermstr., Neueng. 90
-— S. G. R., Eiscnnegotiant
+— S. G. R., Eisennegotiant
 — C. G., Architekt, Metzg. 126
 — B.A., Spcz., Metzg. 126
 — W. S., Notar, Herreng.
@@ -3425,8 +3425,8 @@ Stauffer C. A., Drechsl., Zeughauspl. 218
 Stauffer, Tuchhdl., Mktg. 57
 - Günther, gew. Weinnegt., Sulgenbach 83
 — S. F., Brodbäck, Mktg. 30
-— F. R., Gastwrth z. Schmieden, Marktg. 54
-— Wwe. u. Sohn, Huimach., Kramg. IlD
+— F. R., Gastwirth z. Schmieden, Marktg. 54
+— Wwe. u. Sohn, Hutmach., Kramg. IlD
 — I. S. B., Schreiblehrer, Kramgasse 220
 — J. C. G. ZNot., Brunng.36
 — D., Schuhm., Schg. 2245
@@ -3473,7 +3473,7 @@ v. Sinner C. L. I., Oberbibliothekar, Sulgenb. 64
 — (v. Bümplitz) Bollw. 122 a
 — R. E., Kanzlist, Altenberg 173 5
 Steinegger Jb. R., Trödl., Altenberq 179
-— F., Spcngl., Altenbg. 179
+— F., Spengl., Altenbg. 179
 Steiner S. J. N., Vater, Müller, Matte 32
 — S., Tobn, Müller, Gemd.-Rath, Matte 32
 — G., Tobn, Müll., Matte 32
@@ -3482,7 +3482,7 @@ Steiner S. J. N., Vater, Müller, Matte 32
 - J., Musiklehr., Sptlg. 173
 — I., Speisewirth, Matte 14
 — J. M. N., Dachd., Matte 85
-— Chr., Dachdcck., Matte 130
+— Chr., Dachdeck., Matte 130
 — D. F., Klaviermach., Aarziele 29
 — D. L., Schuhmach., Zeughausgasse 12
 # Date: 1861-04-15 Page: 1395972/118
@@ -3504,7 +3504,7 @@ Stengel R., Kerzenfabrikant, Schütte 254 u. Brunng. 24
 — Chr. F. A., Arzt, Aarbergergasse 36
 — Frau, Spezierer, Stld. 212
 Sterchi F., Weißmüller, Altenberg 177
-Stettler F. R. C., Fürsprech, Ntzdcckg. 195 u. Krmg.175
+Stettler F. R. C., Fürsprech, Nydeckg. 195 u. Krmg.175
 — Zuchthausbuchhalt., Kramgasse 153
 — -Lauster, Blumenmagazin, Kramg. 153
 — geb. v. Graffenried, Frau, Kornhauspl. 150
@@ -3544,23 +3544,23 @@ Straßer E., Schuhm., Marktgasse 85
 # Date: 1861-04-15 Page: 1395973/119
 Sträßle, I. G., Condit., Spitalg. 142
 Sträßler, I. I., Pulvercontroll., Älpenegg 223
-Sträub, G.,Werkmeist, Metzg. 93
-— I., Seiler, Zeughg. 16
-— A. E>, Schneiderin, Keßlerg. 242
-Strciff, M., Regt., Mktg. 43
+Straub, G.,Werkmeist, Metzg. 93
+— J., Seiler, Zeughg. 16
+— A. E., Schneiderin, Keßlerg. 242
+Streiff, M., Regt., Mktg. 43
 Streit Jb., Trödler, Nng. 118
-— 6!., Sekr. d. Direktion des Innern, Grchtg. 89
-— A., Mnsiklchrer, Marktg.50
-— R., Kopist, Postg.29
-— Steindrucker, Brunn g. 21
+— G., Sekr. d. Direktion des Innern, Grchtg. 89
+— A., Mnsiklchrer, Marktg. 50
+— R., Kopist, Postg. 29
+— Steindrucker, Brunng. 21
 Strelin Gust., Handelsmann, Bierhübeli 272
 Strickler, Jb., Bierbrauer, Altenberg 156
 Strokofsky, Regt., Hrng. 309
 v. Struve, Legationsrath, Junkerng. 176
 Stuber, I. R., gcw. Brodbäck., Spitalg. 149
 — I. R., Fürsp., Krmg. 204
-— N., Speiscwirth,Bollw.85
-— A., Roßhaarfabr.,Mktg.35
+— N., Speisewirth, Bollw.85
+— A., Roßhaarfabr., Mktg.35
 — I., Küfer, Schpltzg. 201
 — S., Dachdecker, Aarbg. 77
 — R., Regt., b. Casino 131 a
@@ -3572,7 +3572,7 @@ Studer, B.F., Apoth., Spitalgasse 178
 — I. F., älter, Architekt, Judeng. 122
 — B. R., Prof. d.Mathem., Inselg. 132
 Studer-Lanterburg, Pelik. 230
-— -Hahn F. S. Gl, Forstkassa-Verwalter, Judeng. 114
+— -Hahn F. S. G., Forstkassa-Verwalter, Judeng. 114
 — S. G. R., Arzt, Kramg. 165
 — R., Weinnegt., Mktg. 81
 — F. R., jünger, Architekt, Marktg. 81
@@ -3590,36 +3590,36 @@ Stucki J.B., Küfer, Längg. 193
 — I., Sekretär, Käfichg. 95
 — Anna, Kleiderhändlerin, Schauplatzg. 232
 Stucky, I.,Optiker, Krmg. 189
-v. Stürler-v. Steiger, F.L.R., Architekt, Längg. 215 s.
+v. Stürler-v. Steiger, F. L. R., Architekt, Längg. 215 s.
 — -v. Mutach F. R., alt Amtstatthalter, Junkerng. 170
-— A., Oberst!., Junkg. 179
+— A., Oberstl., Junkg. 179
 — Moritz, Staatsschreiber, Junkerng. 188
 — R. Julius, Junkerng. 147
-— L. B. Hcinr., gew. Stadtpolizeiinspektor, Jkg. 195
+— L. B. Heinr., gew. Stadtpolizeiinspektor, Jkg. 195
 Stutzmann A. B., Bettmach., Herreng. 31l>
 Sulger C., Buchbind., Schauplatzgasse 229
-Sulzberger F.,Hafn.,Arbg.73
+Sulzberger F., Hafn., Arbg. 73
 Sulzer I., Bäcker, Zwblng. 58
-Surbcck, Jgfr., Schneiderin, Kramg. 156
+Surbeck, Jgfr., Schneiderin, Kramg. 156
 # Date: 1861-04-15 Page: 1395974/120
-SurberJ.J., Rechtsag.,Kramgasse 167
-— Frau, 6uto äs In koste, Kramg. 167
+Surber J. J., Rechtsag., Kramgasse 167
+— Frau, Café de la Poste, Kramg. 167
 Surer, Eisennegt., Jkg. 157
 Suri A., Schlosser, Ksichg. 165
 Suter F. A., Klavierm., Pg. 38
 — Weinhdl., Gerechtg. 109
 — Jb., Sattl. u. Speisewirth, Schauplatzg. 200
 — Marg., Stickerin, Matte 96
-— K., Zuckerbäck, Grchtg. 109
+— K., Zuckerbäck., Grchtg. 109
 — I., Metzger, Ankenl. 334
 Sutorius D., Musikl., Kramgasse 211
 Tanner Schwestern, Weißnäh., Bollw. 80
 Tännler I., Kondkt., Aarbg. 21
-v.TavelA., Redakt.,Sptlg. 123
+v.Tavel A., Redakt., Sptlg. 123
 — C. L., gewes. Oberst, Blumenrain 13 u. Kramg. 173
-— -v. Werdt L. N., Rentier, Spitalg. 126
-— -v. Stüicler Ä. V., Rent., Keßlerg. 258
-— geb. Wägnerhv. Frutigen), Spitalg. 123
+— -v. Werdt L. A., Rentier, Spitalg. 126
+— -v. Stürler A. V., Rent., Keßlerg. 258
+— geb. Wägner (v. Frutigen), Spitalg. 123
 Tellenbach F., Schm. Stld. 11
 Terrano, Gypser, Aarbg. 77
 Thaler Ww., Regt., Krmg. 196
@@ -3639,7 +3639,7 @@ Thormann-v. Wyttenbach F., W., (v. Gerzensee), Rent., Spitalg. 155
 — geb. o. Bären, Frau, Junkerng. 166
 — - v. Erlach, Präsid. d. Baukommission, Gerechtg. 86
 Thürner S., Darbd., Sptg. 139
-Tobler I. Jb., Schr., Bstbcnbergsrain 58
+Tobler I. Jb., Schr., Bubenbergsrain 58
 — Frau, Wasch., Matte 14
 — I., Registrator, Stald. 267
 Trabold B., Glaser, Nng. 111
@@ -3676,29 +3676,29 @@ v. Tscharner (v. Amsoldingen), Gutsbesitz., Spitalg. 152 n
 — -v. Wurstemberger, R. A., Präsident d. Burgerraths, Kramg. 177
 — -v. Sulgenbach, Krg. 143
 — so. Lohn), Kramg. 154
-— A. F. B., l>r. Neck., Junkerng. 182
-— -v.Bonstetten, gw. Rittmstr. in Oesterr., Junkg. 194
+— A. F. B., Dr. Med., Junkerng. 182
+— -v. Bonstetten, gw. Rittmstr. in Oesterr., Junkg. 194
 — -v. Wyttenbach C. B. N., gewes. Oberrichter, Junkerng. 166
 — (v. Signau) Fräul., Junkerng. 182
 - geb. Stettler, Wittwe des Prof., Junkg. 182
-— -Fellenberg Frau, Jkg.185
-— so. Bcllerive), Junkg. 194
-- -Frau so. Bümplitz), Marktgasse 45
+— -Fellenberg Frau, Jkg. 185
+— (v. Bcllerive), Junkg. 194
+- -Frau (v. Bümplitz), Marktgasse 45
 v. Tscharner, geb. v. Fischer, Frau, Junkerng. 154
 — Frl. Amalie, Kramg. 177
 Tscharner I. C., Redakt., äuß. Bollw. 267
 Tschiffeli F., Archit., Chef des Brandkorps, Stadtb. 177
-— R. S., Umbicter, Mtzg. 127
+— R. S., Umbieter, Mtzg. 127
 — gb. Christen, Frau, Photograph., Postg. 33
 Tüscher Jb., Klösterliw., Stld.
 — Abwart, Brunng. 29
 — Jb., Kondukt., Gerechtg. 76 u.
-Uebersax J.,Tanzlhr.,Bllw.11
+Uebersax J., Tanzlhr., Bllw. 11
 Ulemann A., Butterh., Schifflaube 52
 Uli F., Revisor u. Not., Kramgasse 174
 — Gebr., Leinwandhandlung, Kramg. 174
 Ulrich M., Schn., Neueng. 110
-Ungericht Chr., Kostpferdhalt., Zeughausg. 16 l>
+Ungericht Chr., Kostpferdhalt., Zeughausg. 16 h
 Urban Fr., Gärtner, Falkenegg
 Urech, Frau Barb., Käfichg. 104
 — I. C., Schr., Käfichg. 104
@@ -3719,13 +3719,13 @@ Vial J. M., Kerzenfabr., Metzgerg. 74
 Viande I. S., Parfm., Kramgasse 212
 Vogel I. N., Spez., Postg.35
 — Wirth zum Schweizerhof, ä. Bollw. 122 cl
-Vögeli N., Schrb., Ncueng.95
+Vögeli N., Schrb., Neueng.95
 — A., Corsetm., Neueng. 95
 Vogt F., Gärtner, Frick 69
 — N., Badw., Aarziele
 — E., Fürspr., Kramg. 205
 — L., Wirth z. Maulbeerb.
-— G., Chef d. eidg. statist. Bureau, Neucng. 122 n
+— G., Chef d. eidg. statist. Bureau, Neueng. 122 n
 — L., Wasch., Brunng. 17
 — A., Arzt, Marktg. 39
 — H. Gärtn., Herreng. 329 d
@@ -3736,21 +3736,21 @@ Vollenweider, Photograph, Gerechtg. 96
 Volmar, Dr. Prof., Sptlg. 159
 — P., Literat, Spitalg. 159
 Volz L.F., Hdlsm., Zghg. 16 u
-— C. R. ,Buchhlt. d. Cmwh.-Ersparnißk., Judeng. 114
+— C. R., Buchhlt. d. Einwh.-Ersparnißk., Judeng. 114
 Wäber Schwestern, Wollen u. Stickwaarenhdlg., Kramgasse 185
 — F., Eisennegotiant, vor d. ob. Thor 166 cl
 — C., Arch., v. d. ob. Th. 172
 — G. F. N., gew. Buchhalt. d. Strafanstalt, Matte 47
 — F. R., Messerschm. Marktgasse 80
 — Chr., Schuhm., Stld. 12
-— D. F., Zimmern!., Markt-
-— I., Uhrcnm., Matte 95
+— D. F., Zimmerm., Markt[gasse] [83]
+— I., Uhrenm., Matte 95
 Wachs N., Steinb., Metzg.122
-Wächter Frau,Galand., Neuengasse 113
+Wächter Frau, Galand., Neuengasse 113
 Wacker M., Näher. u. Schröpf., Schauplatzg. 219
 v. Wagner A. W. E., gw. Offiz. in Neapel, Längg. 215 n
-— -Steiger (v. Ortbühl), Gercchtg. 108
-Wagner C.L., Büchscnschmied, Kramg. 158
+— -Steiger (v. Ortbühl), Gerechtg. 108
+Wagner C.L., Büchsenschmied, Kramg. 158
 — Fr., Ingen., Junkg. 186
 — F.,Tapcz., Brunng. 17
 — gb. Siegfried, Frau, Kramgasse 177
@@ -3767,7 +3767,7 @@ Wahli B., Lohnk., Postg. 58
 # Date: 1861-04-15 Page: 1395977/123
 Waiblinger F., Schrifts., Kornhauspl. 149
 Wakker Chr., Schuhm., Stld. 12
-— Jb., Bäcker, Spitalq. 163
+— Jb., Bäcker, Spitalg. 163
 Walch A., Maler, Marktg. 40
 Wälchli I., Schuhm., Spitalgasse 160
 — Al., Bäcker, Aarbg. 64
@@ -3808,7 +3808,7 @@ v. Wattenwpl G. E., Rent. u. Gutsbes., zw. d. Th. 180
 — geb. Tscharner, Frau, Junkerng. 150
 — -v. Steiger D. N., Gutsbes. in Oberhof., Mrktg. 34
 — -ckskortsoB., Rt., Hg. 329
-— C. N., (v. Lcnzburg), Rt., Kramg. 171
+— C. N., (v. Lenzburg), Rt., Kramg. 171
 — (v. Rümligen), F. L., Rt., Junkerng. 167
 — -v. Frisching F. C. F., (v. Morillon) Rt., gw. Drag.-Maj., Junkg. 167
 — -Falconnet S. L. I., hv. Habstetten), Gutsbesitzer, Kramgasse 173
@@ -3844,7 +3844,7 @@ Weber C. M., Schuhmf, Metzgerg. 87
 — Jb., Postcommis, Marktgasse 95
 — Schwestern, Schneiderin., Zeughg. 10
 Weck S., Seim., Käfichg. 105
-Wegmüller B., Brillcnhändl., Brunng. 16
+Wegmüller B., Brillenhändl., Brunng. 16
 Wehrlin C. L.^, Lithogr., Aarbergergasse 36
 Wehren Schwestern, Weißnäh., Kornhauspl. 146
 Weibel J. A. C., Schnd., Gerechtg. 117
@@ -3855,7 +3855,7 @@ Weil Jb., Lehrer, inn.Bllw.13
 Weiler M., Neg., Marktg. 33
 — M., Speisew., Aarbg. 33
 Weiler Schwestern, Modist. u. Ling., Aarbg. 45
-— F.. Sohn, Reg., Aarbg. 52
+— F., Sohn, Reg., Aarbg. 52
 Weingart A., Buchdr., a. Bollwerk 263
 Weiß Jb. F., Gefangenwärter, Käfichthurm
 — Gebr., Schirmh., Mktg.67
@@ -3877,7 +3877,7 @@ Wenger G., Lehrer, Einwohn.polizei 337
 — I., Kondukt., Brunng. 3
 — Chr., Mehlh.,Aarbg. 22
 — G., Schuhm., GerbI. 141
-— geb. Leucnberger, Schnd., Metzg. 75
+— geb. Leuenberger, Schnd., Metzg. 75
 — Cath., Corsetmach., Gerechtigkcitsg. 126
 — G., Lohnbed. i. Bernerhof
 — G., Gemeinderath, Halligen 113 (Wochenheim), Ablage Spitalg. 159
@@ -3885,7 +3885,7 @@ Wenker I. W., Kondukt., Keßlerg. 276
 — geb. Studer, Hebam., Keßlerg. 276
 WenzelÄtw., Zuricht., Zeughausg. 15 o
 # Date: 1861-04-15 Page: 1395979/125
-Werbinet, Bildh., Neucng. 91
+Werbinet, Bildh., Neueng. 91
 Werchmann F., Buchbinder, Aarbg. 69
 — Speziererin, Aarbg. 63
 v. Werdt G. G. A., Amtsricht., Junkg. 180
@@ -3956,7 +3956,7 @@ Witschi J., Regt., Marktg. 54
 — N. Flachm., Aarbg. 29
 — Jb., Bäcker, Spitalg. 169
 Wittmer Chr., Lithogr., Zwiebelng. 57
-— Neg. u.Antiq., Marktg. 54
+— Neg. u. Antiq., Marktg. 54
 Wittnauer A., Färber, Marktgasse 33 (Depot)
 Wittwer, I., Zügler, Gbg. 143
 — I., Schrists., Gerbgr. 143
@@ -3964,8 +3964,8 @@ Wittwer, I., Zügler, Gbg. 143
 — Frau, Näherin, Grchtg. 64
 — R., Lehrer, Stalden 25
 Wißler, I. F., Not. u. Rechtsagent, Käfichg. 26
-— C.,Schn., Marktg. 33
-— G. G., Schrb..Gerchg.103
+— C., Schn., Marktg. 33
+— G. G., Schrb., Gerchg.103
 — M., Schr., Brunng. 30
 — K., Schuhm., Staid. 17
 — N. E., Schrb., Grchtg.112
@@ -4002,7 +4002,7 @@ Wydler H., Prof., Neueng. 90
 Wyler S., Kappenmach., Kramgasse 145
 — H. L., Konditor, Krmg. 163
 — H. N., Bürstenb., Bubenbergsrain 58
-Wymann Chr., Gypser,Anatomiegasse 10 b
+Wymann Chr., Gypser, Anatomiegasse 10 b
 — C., Schreib- u. Zeichnungslehrer, Marktgasse 47
 — Chr., Regt., Marktg. 36
 Wyniger, J., Fürtücherfabr., Holzmarkt 243
@@ -4056,17 +4056,17 @@ Wyttenbach F. E., Ingenieur, Kramg. 205
 — Chr., Küfer, Stald. 15
 — Commissionsbüreau, Rathhausplatz 104
 Zäh G. J., Schn., Spitlg. 173
-Zahler F., Schnitzl.., Postg. 35
+Zahler F., Schnitzl., Postg. 35
 — Schmied, Stald. 219
 Zahm geb. Moser, Spez., Aarberg. 77
 Zahn F., Flößer, Matte 44
 Zähner R., Mod., Krmg. 207
 — B., Maler, Neueng. 116
-Zahnd D., Präpar.. Flkpl. 222
-— E., Schnd., Schauplg.209
-— C., Metzger, Schpltzg.198
+Zahnd D., Präpar., Flkpl. 222
+— E., Schnd., Schauplg. 209
+— C., Metzger, Schpltzg. 198
 Zaugg Jb., Schn., Hollig. 168
-— A., Spez., Spitalg.147
+— A., Spez., Spitalg. 147
 — S., Steinh., Metzg. 90
 — I. U., Pulverwalt., Länggasse 223
 — F., Polizeidiener-Wachtm., Metzg. 73


### PR DESCRIPTION
After this change, 23 of 4077 records (0.6%) in the 1861 volume are still failing the tests of `check_charset.py`