### PR TITLE
- Allow Jgfr. affix.

### DIFF
--- a/src/process.py
+++ b/src/process.py
@@ -27,6 +27,7 @@ class Processor(object):
           "Frl.": True,
           "Gebr.": True,
           "Gebrüder": True,
+          "Jgfr.": True,
           "Schwest.": True,
           "Schwestern": True,
           "Wittwe": True,


### PR DESCRIPTION
records: input 1891636 -> output 473949 = 25%
family names: total 603521; known: 302140 = 50%
firstnames: total 1107845; known: 835202 = 75%
