### PR TITLE
Fix bad characters in 1861 scan

### DIFF
--- a/proofread/1861-04-15.txt
+++ b/proofread/1861-04-15.txt
@@ -270,7 +270,7 @@ Bieri A., Gypser, Altb. 157
 — U., Bettwaarenh., Kramg
 — Schwestern, Bettwaarenl., Kornhpl. 46
 — Jos., Schuhm., Postg. 32
-Bigler Chr. Instrumentmacher, Zeughg. 11
+Bigler Chr., Instrumentmacher, Zeughg. 11
 — J., Wirth, Metzg. 113
 — P., Lohnbed. und Trödler, Aarberg. 30
 — I., Schweinm., Aarbg. 50
@@ -594,7 +594,7 @@ Campbell, Miß, Sprachlehrerin , Kramg. 190
 Campler, L. Fr., Revis., Mrktgasse 46
 Cantadore u. Cazzini, Tuchncg., Kramp. 196
 Cart-Wilem, Wtw., Eisenhdl., Spitalg. 160
-de Chaffoy geb. Steiger, Reut., Neueng. 113a
+de Chaffoy geb. Steiger, Rent., Neueng. 113a
 Challandes J., eidg. Oberstlt., Aarz. 10 (Wannazhalde)
 Chard J., Postcondukt., Metzgerg. 125
 Chatelanaz F. G., Vergolder, Aarbg. 59
@@ -826,7 +826,7 @@ Ellenberger I., Schn., Schoßhalde 65
 — I., Schuhm., Metzg. 79
 Emmert C. vr., Prof., Htl. 229
 — W. vr., äuß. Bollwerk 268
-— geb. Dann, Rt., Krma. 181
+— geb. Dann, Rt., Krmg. 181
 Enchelmayer, Wwe., Silbergeschirrputz., Muesmatte
 Engel I. G., Spengl., Neuengasse 106
 — I. A., Schuhm., Sptg. 144
@@ -881,13 +881,13 @@ Faßnacht S., Werkmstr., schw. Thor 100
 — I., Schneider, Aarbg. 40
 — S. H., Schnd., Nng. 105
 — Frau, Hebamme, Aarbg. 40
-Fay, nordamerikan. Gesandter, Gerechtigkcitsgasse 85
+Fay, nordamerikan. Gesandter, Gerechtigkeitsgasse 85
 Fehlbaum, I., Kammmacher, Metzgerg. 76
 — A., Büreauchef, Grchtg. 76
-— I. S., Schreiner, Postg.57
+— I. S., Schreiner, Postg. 57
 Fehlmann A. M., Schneiderin, Schauplatzg. 213
 — Schuhm.,Schauplatzg.217
-Fehr I. C., Tel.-Büreauchef, Gerecktg. 70
+Fehr I. C., Tel.-Büreauchef, Gerechtg. 70
 — geb. Wäber, Ling., Kramgasse 203
 v. Fellenberg-Rivier, L. R., Prof., Rosenbühl 157 b
 — E. L., gew. Kuchthauspred., Junkerng. 185
@@ -913,7 +913,7 @@ Ferraris I., Gypser, Gchtg.116
 Ferrier A.R., Rt. Kornhpl.121
 Fetscherin A. A. Vater u. Sohn, Hafnerm., Aarbg. 68
 — C., Schlosserm.,Bllw. 262
-— E.,Buchbd., Reueng. 107
+— E.,Buchbd., Neueng. 107
 — -Ris Heinr., Kandelsm., Markst. 41
 — C. L., Rotar, Kästchg. 96
 — -Lichtenhahn G. W., Lehr., Salzbüchsli
@@ -932,7 +932,7 @@ Filippini-Pedrazzi, Fümiste, Gerechtg. 110
 # Date: 1861-04-15 Page: 1395932/78
 Finger A., Sckneid., Aarz. 26 u. Marktg. 92
 v. Fischer-Ooster A. F. R.,Hotell. 292
-— -Bondeli L. C. A., Bang., Spitalg. 129
+— -Bondeli L. C. A., Banq., Spitalg. 129
 — -Lüthard, C. F. E., Hotellaube 232
 — E. F. L., Dr., Professor, Bvllw. 264
 — (v. Reichenbach), I. M., Rent., Junkerng. 180
@@ -1898,7 +1898,7 @@ Kocher F., gew. Eisennegt., Marktg. 70
 — C. L., Eisennegt., Idg.118
 — R. F., Apoth., Zeitgl. 228
 — Ingenieur, Bollw. 268
-Kochli, Schuhm., Reueng. 119
+Kochli, Schuhm., Neueng. 119
 — Chr., Müller, Junkg. 164u
 # Date: 1861-04-15 Page: 1395947/93
 Köchli Chr., Küchliw., Abg. 47
@@ -2173,7 +2173,7 @@ Leu F., Kanzlist, Brunng. 18
 Leuch R. L. F., Apoth., Kramgasse 193
 — N. G. R., Arzt u. gewes. Quart.-Aufs., Junkg. 158
 Leuenberger R. L. F., Schrb., Kirchg. 272
-— G., Papierhl., Krma. 166
+— G., Papierhl., Krmg. 166
 — I. I. U., Rentier, Hotellaube 234
 — I., Prof., Rabbenthal 155
 — I., Telegr., a. Boüw. 264
@@ -2248,9 +2248,9 @@ Loosli I., Schnd., Mrktg. 37
 Losenegger-Bay, Kramg. 186
 Luchsinger H., Wagn., Matte 6
 Lüçon H., Lehrer, Kramg. 159
-Ludwig E., Pfarrer a. ???, Herreng. 319
-— F. E., Buchh., ??? 83
-— M., Schnd., ??? 168
+Ludwig E., Pfarrer a. Münster, Herreng. 319
+— F. E., Buchh., [???] 83
+— M., Schnd., [???] 168
 Lüdi I., Trödler, Aarbg. 72
 Luginbühl, Spez., Aarbg. 54
 — Gypseru. Mal., Metzg. 128
@@ -2496,7 +2496,7 @@ Moser L. M., Landw., Weißenstein 51
 — Oberrichter, Keßlerg. 278
 — geb. Scheurer, Sptlg. 132
 — Frau, Schneid., Brg. 21
-— H., Bücksenm., Aarbg. 73
+— H., Büchsenm., Aarbg. 73
 — C. F., Müllerm., Sulgenbach 106
 - J. F., Schr., Gerbg. 143
 — F. R., Schn., Marktg. 52
@@ -2527,7 +2527,7 @@ Mühle U.,Mech., Aarbg. 18
 Mühlethaler I., Kondukt., Aarbergergasse 21
 — Joh., Steinh., Badl. 86
 — v. Mülinen-v. Mutach E. F., Rent., Gerechtg.95
-— Gurowsky, Rent., Gerechtigkcitsg. 96
+— Gurowsky, Rent., Gerechtigkeitsg. 96
 Müller F. E., gew. Ingenieur, Längg. 215 g
 — Pfarrer, Spitalgasse 132
 — Substitut auf d. Stadtpol., Längg. 215 g
@@ -2767,7 +2767,7 @@ Platel A. D., Weinngt., Kramgasse 218
 Plüß-Robr, eidgen. Aränvargehülfe, Gerechtg. 124
 Pochen I. F., Goldschmied, Kramg. 198
 Pölsterli I., Lehrer, Metzg. 73
-Ponti, Gebr., Ouincaillhdl., Kramg. 175
+Ponti, Gebr., Quincaillhdl., Kramg. 175
 Portenier M. E., Schneiderin, Gerechtg. 74
 — Schriftsetzer, Gerechtg. 139
 Pohet Ch. L., Schnd.,Mktg. 36
@@ -2861,7 +2861,7 @@ Richard F., Schreiber, Kßg. 280
 — F., Rent., Falkencgq 222
 — E.F.A., Uhrm., Kßg. 238
 # Date: 1861-04-15 Page: 1395962/108
-Richard Fr., Ouincailleriehdl., Kramg. 203
+Richard Fr., Quincailleriehdl., Kramg. 203
 — J. Chr., Krämer, Käfg. 103
 — E. G., Eisenbahnkondukt.
 — I., Kanzleiläuser, Kornhauspl.49
@@ -3105,18 +3105,18 @@ Scheuermerster I. L., Uhrenm., Schauplg. 196
 Scheurer I. G. R., Zuckerbäck, Zwiebg. 39
 — I., Gypser, Marktg. 77
 — Chr., Schneider, Aarz. 22
-— Cs, Tapez., Keßlg. 258
+— C., Tapez., Keßlg. 258
 — Frau, Schneid., Junkg.146
 — C. A., Amtsnotar, Spitalgasse 130
 # Date: 1861-04-15 Page: 1395966/112
-Schieß I. 11., Bundeskanzler, Bundesrathhaus
-— Schieferdecker, Altbg.173n
-v. Schiserli C. M., Vr. Asä., Junkerng. 169
+Schieß J. U., Bundeskanzler, Bundesrathhaus
+— Schieferdecker, Altbg. 173a
+v. Schiferli C. M., Dr. Med., Junkerng. 169
 Schiff M., Prof., Brückfeld 232
 — H., Dozent, Brückfeld 232
 Schiffmann M., Kondukteur, Brunng. 17
-— R., Pdstcomm.,Zghpl.253
-— geb. Pfäffli, Spez., Neuengasse 122 0
+— R., Postcomm., Zghpl. 253
+— geb. Pfäffli, Spez., Neuengasse 122 e
 Schick P., Rechtsagt., Sohn, Kornhauspl. 152
 — Fr., Brunng. 7
 Schild J. D., Dr. Prof., Kramgasse 183
@@ -3157,13 +3157,13 @@ Schluepp N., Küfer, Aarbg. 41
 Schlumpf geb. Pasteur, Leichenbitterin, Metzgerg. 125
 Schlupp J., Bäcker, unt. Thorbrücke 222
 — M., Lehrerin, Sptlg. 161d
-Schmalz, Bücksenm., Klosterh.
+Schmalz, Büchsenm., Klosterh.
 Schmid F. L., Banquier, Kramgaß 113 u. 213
 — -Beringer u. Comp., Eisenhandlung, Marktg. 62
 — E., Ingen., Nydeckg. 201
 — C. W., Buchhdl., Mktg. 81
 — Schmiedmeister, Aarbg. 72
-— geb. Steffen, Spez., Äg.39
+— geb. Steffen, Spez., Ag. 39
 — Wttw., Lithogr., Metzg. 92
 — A., Goldschm., Marktg. 56
 — U., Zimmermann, Müllerlaube 21
@@ -3194,13 +3194,13 @@ Schneider P., erst. Sekretär d. Finanzdep., Spitalg. 160
 — F., Tanzlehrer, Kestlg. 290
 — Chr., Gasaufs., Aarbg. 66
 — F., Schlosser, Bollw. 80
-— F. J.,Buchdr.,Mktg.46
+— F. J., Buchdr., Mktg. 46
 — C. A., Barbier, Käfg. 107
 — A. M., Lehrerin, Aarz.83
 — P., Schuhm., Aarbg. 41
 — G., Gärtner, Aarz. 86
-— Wit wc, Neueng. 91
-— Wr.,Nudlen»i., Stald.10
+— Wittwe, Neueng. 91
+— Wr., Nudlenm., Stald. 10
 — O., Privatlehrer, Mktg. 71
 Schneider Joh., Oberförster, Kramg. 190
 Schneiter J. F., Wagner, Länggass 215
@@ -3209,10 +3209,10 @@ Schneiter J. F., Wagner, Länggass 215
 — F., Bäcker, Junkerng. 46
 Schnell A. E., gew. Banquier, Keßlg. 252
 — F. R.,Schhm., Grchtg. 140
-Schnepf J.F.,Musiker, Schauplatzg. 193
-Schnorf Joh., Epezierer, bei der Reitschule
+Schnepf J. F., Musiker, Schauplatzg. 193
+Schnorf Joh., Spezierer, bei der Reitschule
 Schnyder Sophie, Grchtg. 101
-— u. Gaudard,Manufakthdl., Marktg. 68
+— u. Gaudard, Manufakthdl., Marktg. 68
 — -Düfresne, Frau, Bollwerk 266
 Schoch R., Gärtner, bei der Schanze 185
 Schöch J.F., Schuhm., Mtt. 70
@@ -3220,15 +3220,15 @@ Scholl Gebr., Tabakfbr., Länggass 233
 Schönemann Jb., Musiker, Brunng. 21
 Schönt A.E., Kram., Lngg. 227
 — A. C., Schneid., Schg. 235
-— Regt., Keßler«. 252
+— Regt., Keßlerg. 252
 — Milchträger, Stald. 18
 — F., Hafner, Neueng. 104
 — Buchbd., Scharfrichtg. 115
 Schonhcr F., Schuhm., Stalden 212
-Schorer S., Mnzbeamt., Postgasse 43u
-— geb. Glcther, Tapetenhdl., Kramg. 172
+Schorer S., Mnzbeamt., Postgasse 43a
+— geb. Grether, Tapetenhdl., Kramg. 172
 Schort R., Bäcker, Marktg. 52
-— Bäcker, alt. Schwnmkt.251
+— Bäcker, alt. Schwnmkt. 251
 Schrämli I. Jb., Schuhmach., Brunng. 15
 Schreier F., Schhm., Stld. 212
 — J.F., Schuhm., Schg.205
@@ -3290,11 +3290,11 @@ Schweizer, Karl, Amtsnotar, Kramg. 185
 — I., Quincailleriehndlung, Marktg. 94
 — F., Schreiner u. Speisew., äuß. Bollw. 268
 Schwitz B., Roßhaarfabrikant, Altenbg. 120
-Schwpzer Jb., Ngt., Altbg.274
+Schwyzer Jb., Ngt., Altbg.274
 Seeger I., Modiste, Käfg. 23
 Segessenmann, Einnehmer im Bahnhof
 Seewer Jgfr., Schnd., Ag. 61
-Seiler M., Spez., Ng. 113 »
+Seiler M., Spez., Ng. 113 a
 # Date: 1861-04-15 Page: 1395969/115
 Seiler gb. Gautschi, M., Bäurischschneid. u. Häublimach., Kramgasse 156
 Selhofer, Wwe., Steindruck., Neueng. 113
@@ -3321,7 +3321,7 @@ Siegfried C. F., Angest. a. d. eidg. Kursbureau, Speicherg. 8
 — I. Jb., Papierngt., Marktgasse 81 u. Aarz. 26
 — I., Schuhm., Hollig. 141
 — L. M., Schneid., Mtzg. 127
-Siegler, Bäcker, Gerecktg. 145
+Siegler, Bäcker, Gerechtg. 145
 Siegrist B., Spengl., Krg. 151
 Sigrist, geb. Kubli, Wittwe, Kornhausplatz 118
 — A., Spcz., Schg. 226
@@ -3439,23 +3439,23 @@ Stauffer, Tuchhdl., Mktg. 57
 — Luise, Schneid., Aarbg. 67
 Steiler I., Schrein., Stald. 3
 — N., Amtsnot., Zeughausplatz 251 u. 252
-Steck L. F. I., Spitalbcrwalt., zwisch. d. Thor. 274
-— C.F. R.,Amtsnot., Inselgasse 136 e
-— Ä., Fürspr., Aarberg. 55
+Steck L. F. I., Spitalverwalt., zwisch. d. Thor. 274
+— C. F. R., Amtsnot., Inselgasse 136 c
+— A., Fürspr., Aarberg. 55
 Steffen Schwest., Schneider., Storcheng.
-— Wirth z. Storch., Sptg.157
-— S., Bäcker, Schutzmüüle20
-Stegmann J.F., Hafn., Äg.41
+— Wirth z. Storch., Sptg. 157
+— S., Bäcker, Schutzmühle 20
+Stegmann J. F., Hafn., Ag. 41
 — F., Modiste, Aarbergg. 41
 — I., im Bahnhof
 Stehli, Frau, Schnd., Mktg. 44
-Steiger Jb., Sattl., Mtzg-109
+Steiger Jb., Sattl., Mtzg. 109
 — R., Bäcker, Spitalg. 175
 — G., Buchbinder, Frick 74
 — H., Schneid., Aarberg. 65
-— Elise, Glätt., Brunng.25
-— ^Cöleste, Ling., Brunng.25
-v. Steiger F. A., Feldkassäverwalter, Neueng. 122 u. 117
+— Elise, Glätt., Brunng. 25
+— Cöleste, Ling., Brunng. 25
+v. Steiger F. A., Feldkassaverwalter, Neueng. 122 u. 117
 v. Steiger R. L. A., Banquier, Spitalgasse 127
 — F.A., gew. Offizier in Holland, Spitalg. 131
 — Frau, Rathsh., Sptlg. 127
@@ -3509,7 +3509,7 @@ Stettler F. R. C., Fürsprech, Nydeckg. 195 u. Krmg.175
 — -Lauster, Blumenmagazin, Kramg. 153
 — geb. v. Graffenried, Frau, Kornhauspl. 150
 — S., gew. Notar, Aarbergerg. 53
-— C.G., Reut., Obstberg 51
+— C.G., Rent., Obstberg 51
 — I., Gypser, Postg. 24
 — S., Gärtner, Längg. 210
 Stettler (v. Trachselwald) Frl., Junkerng. 188
@@ -3532,7 +3532,7 @@ Still, S. A., Uhrenm., Krmg. 204
 Stöckli, Jb., Steinh., Schauplatzg. 221
 Stell, Jb., Küfer, Speichg. 6
 — A., Kanzlist, Neueng.113 d
-Stooß, S. C., gew. Reg.-Rath, Äetzgerg. 101
+Stooß, S. C., gew. Reg.-Rath, Metzgerg. 101
 — Schwestern, Grchtg. 102
 — I. F., Metzgerm., Kramg. 164
 — S. A., Spez., Kramg. 164
@@ -3543,14 +3543,14 @@ Stram, E., Krämerin, Zghg. 10
 Straßer E., Schuhm., Marktgasse 85
 # Date: 1861-04-15 Page: 1395973/119
 Sträßle, I. G., Condit., Spitalg. 142
-Sträßler, I. I., Pulvercontroll., Älpenegg 223
-Straub, G.,Werkmeist, Metzg. 93
+Sträßler, I. I., Pulvercontroll., Alpenegg 223
+Straub, G., Werkmeist, Metzg. 93
 — J., Seiler, Zeughg. 16
 — A. E., Schneiderin, Keßlerg. 242
 Streiff, M., Regt., Mktg. 43
 Streit Jb., Trödler, Nng. 118
 — G., Sekr. d. Direktion des Innern, Grchtg. 89
-— A., Mnsiklchrer, Marktg. 50
+— A., Musiklchrer, Marktg. 50
 — R., Kopist, Postg. 29
 — Steindrucker, Brunng. 21
 Strelin Gust., Handelsmann, Bierhübeli 272
@@ -3585,7 +3585,7 @@ Stucki J.B., Küfer, Längg. 193
 — Gbr. L., Steinh., Längg. 193
 — Ar., Bäcker, Längg. 215 d
 — S., Mehlhändl., Metzg. 74
-— geb. Plattner, Krämerin, Reueng. 111
+— geb. Plattner, Krämerin, Neueng. 111
 — I., Gypser, Junkerng. 197
 — I., Sekretär, Käfichg. 95
 — Anna, Kleiderhändlerin, Schauplatzg. 232
@@ -3596,7 +3596,7 @@ v. Stürler-v. Steiger, F. L. R., Architekt, Längg. 215 s.
 — Moritz, Staatsschreiber, Junkerng. 188
 — R. Julius, Junkerng. 147
 — L. B. Heinr., gew. Stadtpolizeiinspektor, Jkg. 195
-Stutzmann A. B., Bettmach., Herreng. 31l>
+Stutzmann A. B., Bettmach., Herreng. 310
 Sulger C., Buchbind., Schauplatzgasse 229
 Sulzberger F., Hafn., Arbg. 73
 Sulzer I., Bäcker, Zwblng. 58
@@ -3661,28 +3661,28 @@ Trolltet R., Hufschm., Arbg. 35
 Trüb I., Kamt. u. Spezierer, Müllerl. 107
 Trümpler I., Barb., Arbg. 63
 Trümpy A., Commission., Inselgasse 133
-Trüßel Joh., Kettelim., Speicher^. 9
-Tschaggclar M., Kräm., Metzgerg. 101
-v.TschannV., Bang., Krg. 145
+Trüßel Joh., Kettelim., Speicherg. 9
+Tschaggelar M., Kräm., Metzgerg. 101
+v.Tschann V., Banq., Krg. 145
 Tschanen Chr. , Steinhauer, Spitalg. 158
 — Wtw., Bäcker, Aarbg. 60
 Tschantre I., Schn., Nng. 89
 Tschanz N., Instrukt., Abg. 70
-— A. Chr., Schuhmach., Gerbern«. 141
+— A. Chr., Schuhmach., Gerberng. 141
 — geb. Fues, Hebam., Brunngasse 6 u. 7
 — Jb., Bäcker, Stald. 206
 — Chr., Zeughsarb., Schauplatzg. 221
 v. Tscharner (v. Amsoldingen), Gutsbesitz., Spitalg. 152 n
 — -v. Wurstemberger, R. A., Präsident d. Burgerraths, Kramg. 177
 — -v. Sulgenbach, Krg. 143
-— so. Lohn), Kramg. 154
+— (v. Lohn), Kramg. 154
 — A. F. B., Dr. Med., Junkerng. 182
 — -v. Bonstetten, gw. Rittmstr. in Oesterr., Junkg. 194
 — -v. Wyttenbach C. B. N., gewes. Oberrichter, Junkerng. 166
 — (v. Signau) Fräul., Junkerng. 182
 - geb. Stettler, Wittwe des Prof., Junkg. 182
 — -Fellenberg Frau, Jkg. 185
-— (v. Bcllerive), Junkg. 194
+— (v. Bellerive), Junkg. 194
 - -Frau (v. Bümplitz), Marktgasse 45
 v. Tscharner, geb. v. Fischer, Frau, Junkerng. 154
 — Frl. Amalie, Kramg. 177
@@ -3755,13 +3755,13 @@ Wagner C.L., Büchsenschmied, Kramg. 158
 — F.,Tapcz., Brunng. 17
 — gb. Siegfried, Frau, Kramgasse 177
 — u. Sohn, Ellenwaarenhdl., Kramg. 182
-— M., Ecsentrödl., Mrktg.33
+— M., Eisentrödl., Mrktg.33
 — C., Schn., Schaupltzg.232
 — Wwe., Tuchscheerer, Matte 111
 Wahlen, geb. Sommer, Mod., b. d. kl. Schanze 186
 Wahli B., Lohnk., Postg. 58
 — I., Thierarzt, Holllg. 132
-— I., Speise«., Keßlg. 292
+— I., Speisew., Keßlg. 292
 — Cath., Schnd., Matte 129
 — geb. König, Küchluv., Gerechtg. 146
 # Date: 1861-04-15 Page: 1395977/123
@@ -3790,7 +3790,7 @@ Walther L. D., Kupferschm., Metzg. 123
 — I. Müller, Matte 22
 — A., Schn., Metzg. 92
 — E., Lohnwasch., Brng. 82
-Wälti F., Gcschäftsm., Stld. 3
+Wälti F., Geschäftsm., Stld. 3
 — R., Schuhm., Sptlg. 152
 — I. R., Bäcker, Grchtg. 145
 — R.,Mod., a.Bollw. 266
@@ -3800,19 +3800,19 @@ Wälti F., Gcschäftsm., Stld. 3
 Wanner N., Speisew., Speicherg. 5ck
 — I., Sattler, b. obern Thor. 123
 Wanner F., Schn., Matte 96
-Wanzenricd N., Wagn., Arz. 89
+Wanzenried N., Wagn., Arz. 89
 v. Wartburg I. U., Schreiner, Matte 76
 — gb. Nobs, Frau, Zuckerbck., Aarberg. 31
 Wasserfallen Frau, Hebamme, Keßlerg. 286
-v. Wattenwpl G. E., Rent. u. Gutsbes., zw. d. Th. 180
+v. Wattenwyl G. E., Rent. u. Gutsbes., zw. d. Th. 180
 — geb. Tscharner, Frau, Junkerng. 150
 — -v. Steiger D. N., Gutsbes. in Oberhof., Mrktg. 34
-— -ckskortsoB., Rt., Hg. 329
-— C. N., (v. Lenzburg), Rt., Kramg. 171
+— -de Portes B., Rt., Hg. 329
+— C. R., (v. Lenzburg), Rt., Kramg. 171
 — (v. Rümligen), F. L., Rt., Junkerng. 167
 — -v. Frisching F. C. F., (v. Morillon) Rt., gw. Drag.-Maj., Junkg. 167
-— -Falconnet S. L. I., hv. Habstetten), Gutsbesitzer, Kramgasse 173
-— (v.Dicßbachl Frl., Jkg.171
+— -Falconnet S. L. J., (v. Habstetten), Gutsbesitzer, Kramgasse 173
+— (v. Dießbach) Frl., Jkg. 171
 — -Lombach, Wwe., Jkg. 172
 - -WildEd., Pred.,Jkg. 199
 — -v. Pourtalss L. F., gewes. Offiz. in Oesterr., Schoßhalde 72
@@ -3824,10 +3824,10 @@ v. Wattenwpl G. E., Rent. u. Gutsbes., zw. d. Th. 180
 — L. N. Alb., Gemeinderath, Marktg. 49
 — -v. Mülinen, Judeng. 117
 # Date: 1861-04-15 Page: 1395978/124
-v.Wattenwyl-Fischersv.Mont-benah), zw. d. Thoren IM
+v.Wattenwyl-Fischers (v.Montbenay), zw. d. Thoren 180
 — -Wattenwyl L. S. F., (v. Murifeld), Gerechtg. 90
 Weber C. M., Schuhmf, Metzgerg. 87
-— ., Ouincaillhdlg., Kramgasse 754
+— J., Quincaillhdlg., Kramgasse 754
 — H., Schuhm., Hotell. 229
 — I., Kanzlist, Kornhvl. 150
 — I., gew. Oberricht., b. d. Schanze 185
@@ -3845,7 +3845,7 @@ Weber C. M., Schuhmf, Metzgerg. 87
 — Schwestern, Schneiderin., Zeughg. 10
 Weck S., Seim., Käfichg. 105
 Wegmüller B., Brillenhändl., Brunng. 16
-Wehrlin C. L.^, Lithogr., Aarbergergasse 36
+Wehrlin C. L., Lithogr., Aarbergergasse 36
 Wehren Schwestern, Weißnäh., Kornhauspl. 146
 Weibel J. A. C., Schnd., Gerechtg. 117
 — I., gew. Kreuzw., Abg. 78
@@ -3861,16 +3861,16 @@ Weiß Jb. F., Gefangenwärter, Käfichthurm
 — Gebr., Schirmh., Mktg.67
 — Fr., Bärenw., Spitlg.242
 - J.Jb.,Spengl., Kßg.280
-— C., Quincaillh., Krma. 222
+— C., Quincaillh., Krmg. 222
 Weißenbach, Vater und Sohn, Zeugschm., Matte Müllerlaube 107
 Weißkopf Jb., Schuhm., Zeughausg. 249
-Welti A., Reuengasse 91
-Wendel Jb., Dresckst., Krg. 91
+Welti A., Neuengasse 91
+Wendel Jb., Dreschl., Krg. 91
 — I. F., Kamm., Kramg.179
 Wenger G., Lehrer, Einwohn.polizei 337
 — Chr., Lehrer, Keßg. 243
 — Chr., Regt., Aarbg. 29
-— Wtw., Cvnsts.,Kramg.194
+— Wtw., Confis., Kramg. 194
 — N., Tap., Marktg. 55
 — Chr., Buchb., z. d. Th. 180
 — Chr., Polizeid., Keßg. 237
@@ -3878,12 +3878,12 @@ Wenger G., Lehrer, Einwohn.polizei 337
 — Chr., Mehlh.,Aarbg. 22
 — G., Schuhm., GerbI. 141
 — geb. Leuenberger, Schnd., Metzg. 75
-— Cath., Corsetmach., Gerechtigkcitsg. 126
+— Cath., Corsetmach., Gerechtigkeitsg. 126
 — G., Lohnbed. i. Bernerhof
 — G., Gemeinderath, Halligen 113 (Wochenheim), Ablage Spitalg. 159
 Wenker I. W., Kondukt., Keßlerg. 276
 — geb. Studer, Hebam., Keßlerg. 276
-WenzelÄtw., Zuricht., Zeughausg. 15 o
+Wenzel Wtw., Zuricht., Zeughausg. 15 c
 # Date: 1861-04-15 Page: 1395979/125
 Werbinet, Bildh., Neueng. 91
 Werchmann F., Buchbinder, Aarbg. 69
@@ -4125,7 +4125,7 @@ Zumbrunn-Rohrbach, Spezier., Spitalg. 162
 Zumstein geb. Hagemann, Zimmerverleiherin, Mrktg. 33
 — J. Jb., Buchb., Metzg. 92
 — J., Substitut a. d. Stadtpolizei, Gerechtg. 115
-Zünde! I., Prof., a. Bllw. 266
+Zündel I., Prof., a. Bllw. 266
 Zurbrügg, J., Schuhm., Brn.gasse 32
 — P., Schuhm., Brunng. 32
 — I., Schn., Schpltzg. 207


### PR DESCRIPTION
After this change, 2 of 4077 records (0.0%) in the 1861 volume are still failing the tests of `check_charset.py`. These seem to be damaged in the printed original and cannot be deciphered.