### PR TITLE
Fix regexp to properly output pagenumber when [] present.

### DIFF
--- a/src/process.py
+++ b/src/process.py
@@ -92,7 +92,7 @@ class Processor(object):
     def process_proofread(self):
         dirpath = os.path.join(os.path.dirname(__file__), '..', 'proofread')
         page_re = re.compile(
-            r'^# Date: (\d{4}-\d\d-\d\d) Page: (\d+)/([\[\]\d]+)$')
+            r'^# Date: (\d{4}-\d\d-\d\d) Page: (\d+)/[\[]?([\d]+)[\]]?$')
         for filename in sorted(os.listdir(dirpath)):
             if not filename.endswith('.txt'):
                 continue


### PR DESCRIPTION
Example diff:
-Ad.,Ackermann,1943-12-15,Schläflirain,3,3013,Bern,46.956362,7.449957,,26033207,[1]
+Ad.,Ackermann,1943-12-15,Schläflirain,3,3013,Bern,46.956362,7.449957,,26033207,1