### PR TITLE
Remove check for unused occupations

### DIFF
--- a/src/validator.py
+++ b/src/validator.py
@@ -115,9 +115,6 @@ class Validator:
         print("%s:%s:%s: %s" % (pos[0], pos[1], entry["Scan"], message))
 
     def report(self):
-        for occ in self.occupations:
-            if occ not in self._occupation_counts:
-                print('src/occupatons.csv: unused entry "%s"' % occ)
         if self._missing_family_names:
             print("Missing family names")
             print("--------------------")


### PR DESCRIPTION
Eventually, a human will have to go over the occupations list manually, and at that time we’ll count how oftern each occupation is being listed. But it does not make much sense to generate this list when building a release data file, hence removing this check.