### PR TITLE
Fix 1882 address reform mappings without new address

### DIFF
--- a/src/cleanup/address_reform_1882/address_mapping.tsv
+++ b/src/cleanup/address_reform_1882/address_mapping.tsv
@@ -2744,7 +2744,7 @@ Stadtbezirk obenaus	2742	8	Länggass-Drittel	207	h	40	d	Länggasse	35
 Stadtbezirk obenaus	2743	8	Länggass-Drittel	207	k	40	b	Länggasse	35	
 Stadtbezirk obenaus	2744	8	Länggass-Drittel	207	l	40	c	Länggasse	35	
 Stadtbezirk obenaus	2745	8	Länggass-Drittel	207	b	42		Länggasse	35	
-Stadtbezirk obenaus	2746	8	Länggass-Drittel	207	c			Länggasse	35	
+Stadtbezirk obenaus	2746	8	Länggass-Drittel	207	c				35	
 Stadtbezirk obenaus	2747	8	Länggass-Drittel	207	g	44		Länggasse	35	
 Stadtbezirk obenaus	2748	8	Länggass-Drittel	208	a	37		Länggasse	35	
 Stadtbezirk obenaus	2749	8	Länggass-Drittel	208	a	37	a	Länggasse	35	
@@ -3348,7 +3348,7 @@ Stadtbezirk obenaus	3344	12	Länggass-Drittel	405	a	12		Fabrikstrasse	39
 Stadtbezirk obenaus	3345	12	Länggass-Drittel	405	b	8		Fabrikstrasse	39	
 Stadtbezirk obenaus	3346	12	Länggass-Drittel	406	a	13		Fabrikstrasse	39	
 Stadtbezirk obenaus	3347	12	Länggass-Drittel	406	b	15		Fabrikstrasse	39	
-Stadtbezirk obenaus	3348	12	Länggass-Drittel	406	c			Fabrikstrasse	39	
+Stadtbezirk obenaus	3348	12	Länggass-Drittel	406	c				39	
 Stadtbezirk obenaus	3349	12	Länggass-Drittel	407	a	14		Fabrikstrasse	39	
 Stadtbezirk obenaus	3350	12	Länggass-Drittel	407	a	14	a	Fabrikstrasse	39	
 Stadtbezirk obenaus	3351	12	Länggass-Drittel	407	a	14	b	Fabrikstrasse	39	


### PR DESCRIPTION
These two mapping actually do not even list a street. Checked against the scanned PDFs.