### PR TITLE
Add pre-1882 street names to whitelist of known street names

### DIFF
--- a/src/cleanup/address_reform_1882/address_mapping.tsv
+++ b/src/cleanup/address_reform_1882/address_mapping.tsv
@@ -487,30 +487,30 @@ Gelbes Quartier	485	6	Zeughausgasse	17		35		Zeughausgasse	13
 Gelbes Quartier	486	6	Zeughausgasse	18	a	37		Zeughausgasse	13	
 Gelbes Quartier	487	6	Zeughausgasse	18	b	39		Zeughausgasse	13	
 Gelbes Quartier	488	6	Zeughausgasse	19	a	41		Zeughausgasse	13	
-Gelbes Quartier	489	6	Käflchgässchen	19	b	43		Zeughausgasse	13	
-Gelbes Quartier	490	6	Käflchgässchen	19	b	21		Waisenhausplatz	13	
-Gelbes Quartier	491	6	Käflchgässchen	19	c	7		Waaghausgasse	13	
-Gelbes Quartier	492	6	Käflchgässchen	20	a	20		Waaghausgasse	13	
-Gelbes Quartier	493	6	Käflchgässchen	20	a	19		Waisenhausplatz	13	
-Gelbes Quartier	494	6	Käflchgässchen	20	b	18		Waaghausgasse	13	
-Gelbes Quartier	495	6	Käflchgässchen	20	b	17		Waisenhausplatz	13	
-Gelbes Quartier	496	6	Käflchgässchen	21		16		Waaghausgasse	13	
-Gelbes Quartier	497	6	Käflchgässchen	21		15		Waisenhausplatz	13	
-Gelbes Quartier	498	6	Käflchgässchen	22		14		Waaghausgasse	13	
-Gelbes Quartier	499	6	Käflchgässchen	22		13		Waisenhausplatz	13	
-Gelbes Quartier	500	6	Käflchgässchen	23		12		Waaghausgasse	13	
-Gelbes Quartier	501	6	Käflchgässchen	23		11		Waisenhausplatz	13	
-Gelbes Quartier	502	6	Käflchgässchen	24		10		Waaghausgasse	13	
-Gelbes Quartier	503	6	Käflchgässchen	24		9		Waisenhausplatz	13	
-Gelbes Quartier	504	6	Käflchgässchen	25		8		Waaghausgasse	13	
-Gelbes Quartier	505	6	Käflchgässchen	25		7		Waisenhausplatz	13	
-Gelbes Quartier	506	6	Käflchgässchen	26		6		Waaghausgasse	13	
-Gelbes Quartier	507	6	Käflchgässchen	26		5		Waisenhausplatz	13	
-Gelbes Quartier	508	6	Käflchgässchen	27		4		Waaghausgasse	13	
-Gelbes Quartier	509	6	Käflchgässchen	27		3		Waisenhausplatz	13	
-Gelbes Quartier	510	6	Käflchgässchen	28		2		Waaghausgasse	13	
-Gelbes Quartier	511	6	Käflchgässchen	28		1		Waisenhausplatz	13	
-Gelbes Quartier	512	6	Käflchgässchen	29		67		Marktgasse	13	
+Gelbes Quartier	489	6	Käfichgässchen	19	b	43		Zeughausgasse	13	
+Gelbes Quartier	490	6	Käfichgässchen	19	b	21		Waisenhausplatz	13	
+Gelbes Quartier	491	6	Käfichgässchen	19	c	7		Waaghausgasse	13	
+Gelbes Quartier	492	6	Käfichgässchen	20	a	20		Waaghausgasse	13	
+Gelbes Quartier	493	6	Käfichgässchen	20	a	19		Waisenhausplatz	13	
+Gelbes Quartier	494	6	Käfichgässchen	20	b	18		Waaghausgasse	13	
+Gelbes Quartier	495	6	Käfichgässchen	20	b	17		Waisenhausplatz	13	
+Gelbes Quartier	496	6	Käfichgässchen	21		16		Waaghausgasse	13	
+Gelbes Quartier	497	6	Käfichgässchen	21		15		Waisenhausplatz	13	
+Gelbes Quartier	498	6	Käfichgässchen	22		14		Waaghausgasse	13	
+Gelbes Quartier	499	6	Käfichgässchen	22		13		Waisenhausplatz	13	
+Gelbes Quartier	500	6	Käfichgässchen	23		12		Waaghausgasse	13	
+Gelbes Quartier	501	6	Käfichgässchen	23		11		Waisenhausplatz	13	
+Gelbes Quartier	502	6	Käfichgässchen	24		10		Waaghausgasse	13	
+Gelbes Quartier	503	6	Käfichgässchen	24		9		Waisenhausplatz	13	
+Gelbes Quartier	504	6	Käfichgässchen	25		8		Waaghausgasse	13	
+Gelbes Quartier	505	6	Käfichgässchen	25		7		Waisenhausplatz	13	
+Gelbes Quartier	506	6	Käfichgässchen	26		6		Waaghausgasse	13	
+Gelbes Quartier	507	6	Käfichgässchen	26		5		Waisenhausplatz	13	
+Gelbes Quartier	508	6	Käfichgässchen	27		4		Waaghausgasse	13	
+Gelbes Quartier	509	6	Käfichgässchen	27		3		Waisenhausplatz	13	
+Gelbes Quartier	510	6	Käfichgässchen	28		2		Waaghausgasse	13	
+Gelbes Quartier	511	6	Käfichgässchen	28		1		Waisenhausplatz	13	
+Gelbes Quartier	512	6	Käfichgässchen	29		67		Marktgasse	13	
 Gelbes Quartier	513	6	Marktgasse	30		60		Marktgasse	13	
 Gelbes Quartier	514	6	Marktgasse	30		1		Waaghausgasse	13	
 Gelbes Quartier	515	6	Marktgasse	31	a-d	58		Marktgasse	13	Doubt in record
@@ -1488,26 +1488,26 @@ Weisses Quartier	1486	15	Stalden	229		2		Nydeckhof	22
 Weisses Quartier	1487	15	Stalden	230		12		Langmauerweg	22	
 Weisses Quartier	1488	15	Stalden	231		1		Nydeckgasse	22	
 Weisses Quartier	1489	15	Stalden	232		2		Nydeckgasse	22	
-Schwarzes Quartier	1490	15	ln der Enge	1		6		Mattenenge	22	
-Schwarzes Quartier	1491	15	ln der Enge	1		19		Nydeckhof	22	
-Schwarzes Quartier	1492	15	ln der Enge	2		8		Mattenenge	22	
-Schwarzes Quartier	1493	15	ln der Enge	2		17		Nydeckhof	22	
-Schwarzes Quartier	1494	15	ln der Enge	3		10		Mattenenge	22	
-Schwarzes Quartier	1495	15	ln der Enge	3		15		Nydeckhof	22	
-Schwarzes Quartier	1496	15	ln der Enge	4		12		Mattenenge	22	
-Schwarzes Quartier	1497	15	ln der Enge	4		13		Nydeckhof	22	
-Schwarzes Quartier	1498	15	ln der Enge	5		14		Mattenenge	22	
-Schwarzes Quartier	1499	15	ln der Enge	5		11		Nydeckhof	22	
-Schwarzes Quartier	1500	15	ln der Enge	6		16		Mattenenge	22	
-Schwarzes Quartier	1501	15	ln der Enge	6		9		Nydeckhof	22	
-Schwarzes Quartier	1502	16	ln der Enge	7		18		Mattenenge	23	
-Schwarzes Quartier	1503	16	ln der Enge	7		7		Nydeckhof	23	
-Schwarzes Quartier	1504	16	ln der Enge	8		20		Mattenenge	23	
-Schwarzes Quartier	1505	16	ln der Enge	8		5		Nydeckhof	23	
-Schwarzes Quartier	1506	16	ln der Enge	9	a	22		Mattenenge	23	
-Schwarzes Quartier	1507	16	ln der Enge	9	a	3		Nydeckhof	23	
-Schwarzes Quartier	1508	16	ln der Enge	9	c	1		Nydeckhof	23	
-Schwarzes Quartier	1509	16	ln der Enge	9	b	24		Mattenenge	23	
+Schwarzes Quartier	1490	15	In der Enge	1		6		Mattenenge	22	
+Schwarzes Quartier	1491	15	In der Enge	1		19		Nydeckhof	22	
+Schwarzes Quartier	1492	15	In der Enge	2		8		Mattenenge	22	
+Schwarzes Quartier	1493	15	In der Enge	2		17		Nydeckhof	22	
+Schwarzes Quartier	1494	15	In der Enge	3		10		Mattenenge	22	
+Schwarzes Quartier	1495	15	In der Enge	3		15		Nydeckhof	22	
+Schwarzes Quartier	1496	15	In der Enge	4		12		Mattenenge	22	
+Schwarzes Quartier	1497	15	In der Enge	4		13		Nydeckhof	22	
+Schwarzes Quartier	1498	15	In der Enge	5		14		Mattenenge	22	
+Schwarzes Quartier	1499	15	In der Enge	5		11		Nydeckhof	22	
+Schwarzes Quartier	1500	15	In der Enge	6		16		Mattenenge	22	
+Schwarzes Quartier	1501	15	In der Enge	6		9		Nydeckhof	22	
+Schwarzes Quartier	1502	16	In der Enge	7		18		Mattenenge	23	
+Schwarzes Quartier	1503	16	In der Enge	7		7		Nydeckhof	23	
+Schwarzes Quartier	1504	16	In der Enge	8		20		Mattenenge	23	
+Schwarzes Quartier	1505	16	In der Enge	8		5		Nydeckhof	23	
+Schwarzes Quartier	1506	16	In der Enge	9	a	22		Mattenenge	23	
+Schwarzes Quartier	1507	16	In der Enge	9	a	3		Nydeckhof	23	
+Schwarzes Quartier	1508	16	In der Enge	9	c	1		Nydeckhof	23	
+Schwarzes Quartier	1509	16	In der Enge	9	b	24		Mattenenge	23	
 Schwarzes Quartier	1510	16	Gerbernlaube	10		4		Gerbergasse	23	
 Schwarzes Quartier	1511	16	Gerbernlaube	11		6		Gerbergasse	23	
 Schwarzes Quartier	1512	16	Gerbernlaube	11		6	a	Gerbergasse	23	
@@ -1687,16 +1687,16 @@ Schwarzes Quartier	1685	17	Landeren	103		8		Wasserwerkstr.	24
 Schwarzes Quartier	1686	17	Landeren	104	a	10		Wasserwerkstr.	24	
 Schwarzes Quartier	1687	17	Landeren	104	b	12		Wasserwerkstr.	24	
 Schwarzes Quartier	1688	17	Landeren	104	c	14		Wasserwerkstr.	24	
-Schwarzes Quartier	1689	17	Schleifergässleln	105	a	7		Mühlenplatz	24	
-Schwarzes Quartier	1690	17	Schleifergässleln	105	b	5		Mühlenplatz	24	
-Schwarzes Quartier	1691	17	Schleifergässleln	106	b	15		Mühlenplatz	24	
-Schwarzes Quartier	1692	17	Schleifergässleln	106	b	11		Mühlenplatz	24	
-Schwarzes Quartier	1693	17	Schleifergässleln	106	b	13		Mühlenplatz	24	
-Schwarzes Quartier	1694	17	Schleifergässleln	106	b	20		Wasserwerkstr.	24	
-Schwarzes Quartier	1695	17	Schleifergässleln	106	b	22		Wasserwerkstr.	24	
-Schwarzes Quartier	1696	17	Schleifergässleln	106	c	16		Mühlenplatz	24	
-Schwarzes Quartier	1697	17	Schleifergässleln	106	c	1		Schifflaube	24	
-Schwarzes Quartier	1698	17	Schleifergässleln	106	d	3		Schifflaube	24	
+Schwarzes Quartier	1689	17	Schleifergässlein	105	a	7		Mühlenplatz	24	
+Schwarzes Quartier	1690	17	Schleifergässlein	105	b	5		Mühlenplatz	24	
+Schwarzes Quartier	1691	17	Schleifergässlein	106	b	15		Mühlenplatz	24	
+Schwarzes Quartier	1692	17	Schleifergässlein	106	b	11		Mühlenplatz	24	
+Schwarzes Quartier	1693	17	Schleifergässlein	106	b	13		Mühlenplatz	24	
+Schwarzes Quartier	1694	17	Schleifergässlein	106	b	20		Wasserwerkstr.	24	
+Schwarzes Quartier	1695	17	Schleifergässlein	106	b	22		Wasserwerkstr.	24	
+Schwarzes Quartier	1696	17	Schleifergässlein	106	c	16		Mühlenplatz	24	
+Schwarzes Quartier	1697	17	Schleifergässlein	106	c	1		Schifflaube	24	
+Schwarzes Quartier	1698	17	Schleifergässlein	106	d	3		Schifflaube	24	
 Schwarzes Quartier	1699	17	Müllerläublein	107	a	43		Gerbergasse	24	
 Schwarzes Quartier	1700	17	Müllerläublein	107	a	1		Müllerplatz	24	
 Schwarzes Quartier	1701	17	Müllerläublein	107	b	43	a	Gerbergasse	24	
@@ -4138,174 +4138,174 @@ Stadtbezirk untenaus	4134	18	Lorraine-Strasse	43	b	23	b	Lorrainestrasse	45
 Stadtbezirk untenaus	4135	18	Lorraine-Strasse	43	c	23	a	Lorrainestrasse	45	
 Stadtbezirk untenaus	4136	18	Lorraine-Strasse	45	a	27		Lorrainestrasse	45	
 Stadtbezirk untenaus	4137	18	Lorraine-Strasse	45	b	27	a	Lorrainestrasse	45	
-Stadtbezirk untenaus	4138	19	Lorraine -Quartier	46		3		Schmidweg	46	
-Stadtbezirk untenaus	4139	19	Lorraine -Quartier	47		4		Schmidweg	46	
-Stadtbezirk untenaus	4140	19	Lorraine -Quartier	47	b	31		Lorrainestrasse	46	
-Stadtbezirk untenaus	4141	19	Lorraine -Quartier	47	b	2		Schmidweg	46	
-Stadtbezirk untenaus	4142	19	Lorraine -Quartier	48		33		Lorrainestrasse	46	
-Stadtbezirk untenaus	4143	19	Lorraine -Quartier	51	b	51		Lorrainestrasse	46	
-Stadtbezirk untenaus	4144	19	Lorraine -Quartier	51	c	51	a	Lorrainestrasse	46	
-Stadtbezirk untenaus	4145	19	Lorraine -Quartier	52	a	61		Lorrainestrasse	46	
-Stadtbezirk untenaus	4146	19	Lorraine -Quartier	52	b	59		Lorrainestrasse	46	
-Stadtbezirk untenaus	4147	19	Lorraine -Quartier	52	c	57		Lorrainestrasse	46	
-Stadtbezirk untenaus	4148	19	Lorraine -Quartier	52	d	63		Lorrainestrasse	46	
-Stadtbezirk untenaus	4149	19	Lorraine -Quartier	54	a	71		Lorrainestrasse	46	
-Stadtbezirk untenaus	4150	19	Lorraine -Quartier	54	a	3		Thalweg	46	
-Stadtbezirk untenaus	4151	19	Lorraine -Quartier	54	a	3	a	Thalweg	46	
-Stadtbezirk untenaus	4152	19	Lorraine -Quartier	54	b	68		Thalweg	46	
-Stadtbezirk untenaus	4153	19	Lorraine -Quartier	54	d	68	a	Lorrainestrasse	46	
-Stadtbezirk untenaus	4154	19	Lorraine -Quartier	57		32		Jurastrasse	46	
-Stadtbezirk untenaus	4155	19	Lorraine -Quartier	58	a	43		Lorrainestrasse	46	
-Stadtbezirk untenaus	4156	19	Lorraine -Quartier	58	b	36		Jurastrasse	46	
-Stadtbezirk untenaus	4157	19	Lorraine -Quartier	58	b	38		Jurastrasse	46	
-Stadtbezirk untenaus	4158	19	Lorraine -Quartier	58	c	49		Lorrainestrasse	46	
-Stadtbezirk untenaus	4159	19	Lorraine -Quartier	58	h	45		Lorrainestrasse	46	
-Stadtbezirk untenaus	4160	19	Lorraine -Quartier	58	b	41		Lorrainestrasse	46	
-Stadtbezirk untenaus	4161	19	Lorraine -Quartier	58	e	40		Jurastrasse	46	
-Stadtbezirk untenaus	4162	19	Lorraine -Quartier	58	k	13		Thalweg	46	
-Stadtbezirk untenaus	4163	19	Lorraine -Quartier	59		28		Jurastrasse	46	
-Stadtbezirk untenaus	4164	19	Lorraine -Quartier	62	a	6		Schmidweg	46	
-Stadtbezirk untenaus	4165	19	Lorraine -Quartier	63	a	7		Schmidweg	46	
-Stadtbezirk untenaus	4166	19	Lorraine -Quartier	64	a	14		Jurastrasse	46	
-Stadtbezirk untenaus	4167	19	Lorraine -Quartier	65	b	4		Platanenweg	46	
-Stadtbezirk untenaus	4168	19	Lorraine -Quartier	65		4	a	Platanenweg	46	Doubt in record
-Stadtbezirk untenaus	4169	19	Lorraine -Quartier	66	b	8		Platanenweg	46	
-Stadtbezirk untenaus	4170	19	Lorraine -Quartier	66		8		Platanenweg	46	Doubt in record
-Stadtbezirk untenaus	4171	19	Lorraine -Quartier	66	b	15		Jurastrasse	46	
-Stadtbezirk untenaus	4172	19	Lorraine -Quartier	67	a	12		Platanenweg	46	
-Stadtbezirk untenaus	4173	19	Lorraine -Quartier	67	b	10		Platanenweg	46	
-Stadtbezirk untenaus	4174	19	Lorraine -Quartier	67	c	10	a	Platanenweg	46	
-Stadtbezirk untenaus	4175	19	Lorraine -Quartier	70	a	29		Jurastrasse	46	
-Stadtbezirk untenaus	4176	19	Lorraine -Quartier	70	b	29	a	Jurastrasse	46	
-Stadtbezirk untenaus	4177	19	Lorraine -Quartier	71	a	35		Jurastrasse	46	
-Stadtbezirk untenaus	4178	19	Lorraine -Quartier	71	b	35	a	Jurastrasse	46	
-Stadtbezirk untenaus	4179	19	Lorraine -Quartier	72		37		Jurastrasse	46	
-Stadtbezirk untenaus	4180	19	Lorraine -Quartier	75	a	47		Jurastrasse	46	
-Stadtbezirk untenaus	4181	19	Lorraine -Quartier	75	b	47	a	Jurastrasse	46	
-Stadtbezirk untenaus	4182	19	Lorraine -Quartier	76	a	55		Jurastrasse	46	
-Stadtbezirk untenaus	4183	19	Lorraine -Quartier	76	b	57		Jurastrasse	46	
-Stadtbezirk untenaus	4184	19	Lorraine -Quartier	76	c	51		Jurastrasse	46	
-Stadtbezirk untenaus	4185	19	Lorraine -Quartier	77		59		Jurastrasse	46	
-Stadtbezirk untenaus	4186	19	Lorraine -Quartier	79		65		Jurastrasse	46	
-Stadtbezirk untenaus	4187	19	Lorraine -Quartier	80	a	69		Jurastrasse	46	
-Stadtbezirk untenaus	4188	19	Lorraine -Quartier	80	c	69	a	Jurastrasse	46	
-Stadtbezirk untenaus	4189	19	Lorraine -Quartier	80	b	71		Jurastrasse	46	
-Stadtbezirk untenaus	4190	19	Lorraine -Quartier	81		77		Jurastrasse	46	
-Stadtbezirk untenaus	4191	19	Lorraine -Quartier	82		77	a	Jurastrasse	46	
-Stadtbezirk untenaus	4192	19	Lorraine -Quartier	84	a	99		Jurastrasse	46	
-Stadtbezirk untenaus	4193	19	Lorraine -Quartier	84	b	95		Jurastrasse	46	
-Stadtbezirk untenaus	4194	19	Lorraine -Quartier	84	c	91		Jurastrasse	46	
-Stadtbezirk untenaus	4195	19	Lorraine -Quartier	84	d	89		Jurastrasse	46	
-Stadtbezirk untenaus	4196	19	Lorraine -Quartier	85	a	58		Jurastrasse	46	
-Stadtbezirk untenaus	4197	19	Lorraine -Quartier	85	b	60		Jurastrasse	46	
-Stadtbezirk untenaus	4198	19	Lorraine -Quartier	88		44		Jurastrasse	46	
-Stadtbezirk untenaus	4199	19	Lorraine -Quartier	89		42		Jurastrasse	46	
-Stadtbezirk untenaus	4200	19	Lorraine -Quartier	93	a	1		Haldenweg	46	
-Stadtbezirk untenaus	4201	19	Lorraine -Quartier	93	a	1	b	Haldenweg	46	
-Stadtbezirk untenaus	4202	19	Lorraine -Quartier	93	b	1	a	Haldenweg	46	
-Stadtbezirk untenaus	4203	19	Lorraine -Quartier	95	a	12		Thalweg	46	
-Stadtbezirk untenaus	4204	19	Lorraine -Quartier	95	b	12	a	Thalweg	46	
-Stadtbezirk untenaus	4205	19	Lorraine -Quartier	95	c	12	b	Thalweg	46	
-Stadtbezirk untenaus	4206	19	Lorraine -Quartier	115	a	16		Haldenweg	46	
-Stadtbezirk untenaus	4207	19	Lorraine -Quartier	115	b	18		Haldenweg	46	
-Stadtbezirk untenaus	4208	19	Lorraine -Quartier	115	c	23		Polygonweg	46	
-Stadtbezirk untenaus	4209	19	Lorraine -Quartier	116		19		Polygonweg	46	
-Stadtbezirk untenaus	4210	19	Lorraine -Quartier	117	a	15		Polygonweg	46	
-Stadtbezirk untenaus	4211	19	Lorraine -Quartier	117	b	13		Polygonweg	46	
-Stadtbezirk untenaus	4212	19	Lorraine -Quartier	118	a	11		Polygonweg	46	
-Stadtbezirk untenaus	4213	19	Lorraine -Quartier	118	b	9		Polygonweg	46	
-Stadtbezirk untenaus	4214	19	Lorraine -Quartier	117	c	6		Polygonweg	46	
-Stadtbezirk untenaus	4215	19	Lorraine -Quartier	118	c	10		Polygonweg	46	
-Stadtbezirk untenaus	4216	19	Lorraine -Quartier	119		8		Haldenweg	46	
-Stadtbezirk untenaus	4217	19	Lorraine -Quartier	119		6		Haldenweg	46	
-Stadtbezirk untenaus	4218	19	Lorraine -Quartier	119	b	6		Haldenweg	46	Doubt in record
-Stadtbezirk untenaus	4219	19	Lorraine -Quartier	119	c	1		Polygonweg	46	
-Stadtbezirk untenaus	4220	19	Lorraine -Quartier	119	d	3		Polygonweg	46	
-Stadtbezirk untenaus	4221	19	Lorraine -Quartier	120	a	66		Lorrainestrasse	46	
-Stadtbezirk untenaus	4222	19	Lorraine -Quartier	120	b	66	a	Lorrainestrasse	46	
-Stadtbezirk untenaus	4223	19	Lorraine -Quartier	121	a	62		Lorrainestrasse	46	
-Stadtbezirk untenaus	4224	19	Lorraine -Quartier	121	a	62	a	Lorrainestrasse	46	
-Stadtbezirk untenaus	4225	19	Lorraine -Quartier	121	a	62	b	Lorrainestrasse	46	
-Stadtbezirk untenaus	4226	19	Lorraine -Quartier	121	b	62		Lorrainestrasse	46	
-Stadtbezirk untenaus	4227	19	Lorraine -Quartier	121	b	62	a	Lorrainestrasse	46	
-Stadtbezirk untenaus	4228	19	Lorraine -Quartier	121	b	62	b	Lorrainestrasse	46	
-Stadtbezirk untenaus	4229	19	Lorraine -Quartier	128		23		Dammweg	46	
-Stadtbezirk untenaus	4230	19	Lorraine -Quartier	130		19		Quartierhof	46	
-Stadtbezirk untenaus	4231	19	Lorraine -Quartier	130		48		Lorrainestrasse	46	
-Stadtbezirk untenaus	4232	19	Lorraine -Quartier	131		50		Lorrainestrasse	46	
-Stadtbezirk untenaus	4233	19	Lorraine -Quartier	132		16		Quartierhof	46	
-Stadtbezirk untenaus	4234	19	Lorraine -Quartier	133		14		Quartierhof	46	
-Stadtbezirk untenaus	4235	19	Lorraine -Quartier	134		12		Quartierhof	46	
-Stadtbezirk untenaus	4236	19	Lorraine -Quartier	135		8		Quartierhof	46	
-Stadtbezirk untenaus	4237	19	Lorraine -Quartier	136		6		Quartierhof	46	
-Stadtbezirk untenaus	4238	19	Lorraine -Quartier	137		4		Quartierhof	46	
-Stadtbezirk untenaus	4239	19	Lorraine -Quartier	137		21		Dammweg	46	
-Stadtbezirk untenaus	4240	19	Lorraine -Quartier	138		19		Dammweg	46	
-Stadtbezirk untenaus	4241	19	Lorraine -Quartier	139		2		Quartierhof	46	
-Stadtbezirk untenaus	4242	19	Lorraine -Quartier	140		10		Quartierhof	46	
-Stadtbezirk untenaus	4243	19	Lorraine -Quartier	140		10	a	Quartierhof	46	
-Stadtbezirk untenaus	4244	19	Lorraine -Quartier	141		1		Quartierhof	46	
-Stadtbezirk untenaus	4245	19	Lorraine -Quartier	112		3		Quartierhof	46	
-Stadtbezirk untenaus	4246	19	Lorraine -Quartier	143		5		Quartierhof	46	
-Stadtbezirk untenaus	4247	19	Lorraine -Quartier	144		7		Quartierhof	46	
-Stadtbezirk untenaus	4248	19	Lorraine -Quartier	115		9		Quartierhof	46	
-Stadtbezirk untenaus	4249	19	Lorraine -Quartier	146		11		Quartierhof	46	
-Stadtbezirk untenaus	4250	19	Lorraine -Quartier	147		13		Quartierhof	46	
-Stadtbezirk untenaus	4251	19	Lorraine -Quartier	148		15		Quartierhof	46	
-Stadtbezirk untenaus	4252	19	Lorraine -Quartier	149		17		Quartierhof	46	
-Stadtbezirk untenaus	4253	19	Lorraine -Quartier	149		46		Lorrainestrasse	46	
-Stadtbezirk untenaus	4254	19	Lorraine -Quartier	150		31		Quartiergasse	46	
-Stadtbezirk untenaus	4255	19	Lorraine -Quartier	149	d	31		Quartiergasse	46	
-Stadtbezirk untenaus	4256	19	Lorraine -Quartier	151		29		Quartiergasse	46	
-Stadtbezirk untenaus	4257	19	Lorraine -Quartier	152		27		Quartiergasse	46	
-Stadtbezirk untenaus	4258	19	Lorraine -Quartier	153		25		Quartiergasse	46	
-Stadtbezirk untenaus	4259	19	Lorraine -Quartier	154		23		Quartiergasse	46	
-Stadtbezirk untenaus	4260	19	Lorraine -Quartier	155		21		Quartiergasse	46	
-Stadtbezirk untenaus	4261	19	Lorraine -Quartier	156		19		Quartiergasse	46	
-Stadtbezirk untenaus	4262	19	Lorraine -Quartier	157		17		Quartiergasse	46	
-Stadtbezirk untenaus	4263	20	Lorraine -Quartier	158		15		Quartiergasse	47	
-Stadtbezirk untenaus	4264	20	Lorraine -Quartier	159		13		Quartiergasse	47	
-Stadtbezirk untenaus	4265	20	Lorraine -Quartier	160		11		Quartiergasse	47	
-Stadtbezirk untenaus	4266	20	Lorraine -Quartier	161		9		Quartiergasse	47	
-Stadtbezirk untenaus	4267	20	Lorraine -Quartier	162		7		Quartiergasse	47	
-Stadtbezirk untenaus	4268	20	Lorraine -Quartier	163		5		Quartiergasse	47	
-Stadtbezirk untenaus	4269	20	Lorraine -Quartier	163		5	a	Quartiergasse	47	
-Stadtbezirk untenaus	4270	20	Lorraine -Quartier	164		3		Quartiergasse	47	
-Stadtbezirk untenaus	4271	20	Lorraine -Quartier	165	a	13		Dammweg	47	
-Stadtbezirk untenaus	4272	20	Lorraine -Quartier	166		3		Blumenweg	47	
-Stadtbezirk untenaus	4273	20	Lorraine -Quartier	166	b	3	a	Blumenweg	47	
-Stadtbezirk untenaus	4274	20	Lorraine -Quartier	170	a	9		Dammweg	47	
-Stadtbezirk untenaus	4275	20	Lorraine -Quartier	170	b	9	a	Dammweg	47	
-Stadtbezirk untenaus	4276	20	Lorraine -Quartier	172	a	29		Centralweg	47	
-Stadtbezirk untenaus	4277	20	Lorraine -Quartier	172	b	27		Centralweg	47	
-Stadtbezirk untenaus	4278	20	Lorraine -Quartier	172	c	25		Centralweg	47	
-Stadtbezirk untenaus	4279	20	Lorraine -Quartier	172	d	23		Centralweg	47	
-Stadtbezirk untenaus	4280	20	Lorraine -Quartier	172	e	21		Centralweg	47	
-Stadtbezirk untenaus	4281	20	Lorraine -Quartier	172	f	19		Centralweg	47	
-Stadtbezirk untenaus	4282	20	Lorraine -Quartier	188	a	2	a	Lagerweg	47	
-Stadtbezirk untenaus	4283	20	Lorraine -Quartier	188	b	2		Lagerweg	47	
-Stadtbezirk untenaus	4284	20	Lorraine -Quartier	188	c	2	b	Lagerweg	47	
-Stadtbezirk untenaus	4285	20	Lorraine -Quartier	188	d	2	c	Lagerweg	47	
-Stadtbezirk untenaus	4286	20	Lorraine -Quartier	193	a	11		Lagerweg	47	
-Stadtbezirk untenaus	4287	20	Lorraine -Quartier	193	b	9		Lagerweg	47	
-Stadtbezirk untenaus	4288	20	Lorraine -Quartier	194	a	7		Lagerweg	47	
-Stadtbezirk untenaus	4289	20	Lorraine -Quartier	204		38		Lorrainestrasse	47	
-Stadtbezirk untenaus	4290	20	Lorraine -Quartier	205		36		Lorrainestrasse	47	
-Stadtbezirk untenaus	4291	20	Lorraine -Quartier	206		34		Lorrainestrasse	47	
-Stadtbezirk untenaus	4292	20	Lorraine -Quartier	207	a	32		Lorrainestrasse	47	
-Stadtbezirk untenaus	4293	20	Lorraine -Quartier	207	b	11		Hofweg	47	
-Stadtbezirk untenaus	4294	20	Lorraine -Quartier	207	b	11	a	Hofweg	47	
-Stadtbezirk untenaus	4295	20	Lorraine -Quartier	207	b	11	b	Hofweg	47	
-Stadtbezirk untenaus	4296	20	Lorraine -Quartier	207	c	10		Lagerweg	47	
-Stadtbezirk untenaus	4297	20	Lorraine -Quartier	207	c	10	a	Lagerweg	47	
-Stadtbezirk untenaus	4298	20	Lorraine -Quartier	208	a	26		Lorrainestrasse	47	
-Stadtbezirk untenaus	4299	20	Lorraine -Quartier	208	b	28		Lorrainestrasse	47	
-Stadtbezirk untenaus	4300	20	Lorraine -Quartier	208	c	12	a	Lagerweg	47	
-Stadtbezirk untenaus	4301	20	Lorraine -Quartier	208	e	12		Lagerweg	47	
-Stadtbezirk untenaus	4302	20	Lorraine -Quartier	209		22		Lorrainestrasse	47	
-Stadtbezirk untenaus	4303	20	Lorraine -Quartier	210		20		Lorrainestrasse	47	
-Stadtbezirk untenaus	4304	20	Lorraine -Quartier	211	a	18		Lorrainestrasse	47	
-Stadtbezirk untenaus	4305	20	Lorraine -Quartier	211	b	18	a	Lorrainestrasse	47	
-Stadtbezirk untenaus	4306	20	Lorraine -Quartier	212	a	16		Lorrainestrasse	47	
-Stadtbezirk untenaus	4307	20	Lorraine -Quartier	212	c	16	b	Lorrainestrasse	47	
-Stadtbezirk untenaus	4308	20	Lorraine -Quartier	212	b	16	a	Lorrainestrasse	47	
+Stadtbezirk untenaus	4138	19	Lorraine-Quartier	46		3		Schmidweg	46	
+Stadtbezirk untenaus	4139	19	Lorraine-Quartier	47		4		Schmidweg	46	
+Stadtbezirk untenaus	4140	19	Lorraine-Quartier	47	b	31		Lorrainestrasse	46	
+Stadtbezirk untenaus	4141	19	Lorraine-Quartier	47	b	2		Schmidweg	46	
+Stadtbezirk untenaus	4142	19	Lorraine-Quartier	48		33		Lorrainestrasse	46	
+Stadtbezirk untenaus	4143	19	Lorraine-Quartier	51	b	51		Lorrainestrasse	46	
+Stadtbezirk untenaus	4144	19	Lorraine-Quartier	51	c	51	a	Lorrainestrasse	46	
+Stadtbezirk untenaus	4145	19	Lorraine-Quartier	52	a	61		Lorrainestrasse	46	
+Stadtbezirk untenaus	4146	19	Lorraine-Quartier	52	b	59		Lorrainestrasse	46	
+Stadtbezirk untenaus	4147	19	Lorraine-Quartier	52	c	57		Lorrainestrasse	46	
+Stadtbezirk untenaus	4148	19	Lorraine-Quartier	52	d	63		Lorrainestrasse	46	
+Stadtbezirk untenaus	4149	19	Lorraine-Quartier	54	a	71		Lorrainestrasse	46	
+Stadtbezirk untenaus	4150	19	Lorraine-Quartier	54	a	3		Thalweg	46	
+Stadtbezirk untenaus	4151	19	Lorraine-Quartier	54	a	3	a	Thalweg	46	
+Stadtbezirk untenaus	4152	19	Lorraine-Quartier	54	b	68		Thalweg	46	
+Stadtbezirk untenaus	4153	19	Lorraine-Quartier	54	d	68	a	Lorrainestrasse	46	
+Stadtbezirk untenaus	4154	19	Lorraine-Quartier	57		32		Jurastrasse	46	
+Stadtbezirk untenaus	4155	19	Lorraine-Quartier	58	a	43		Lorrainestrasse	46	
+Stadtbezirk untenaus	4156	19	Lorraine-Quartier	58	b	36		Jurastrasse	46	
+Stadtbezirk untenaus	4157	19	Lorraine-Quartier	58	b	38		Jurastrasse	46	
+Stadtbezirk untenaus	4158	19	Lorraine-Quartier	58	c	49		Lorrainestrasse	46	
+Stadtbezirk untenaus	4159	19	Lorraine-Quartier	58	h	45		Lorrainestrasse	46	
+Stadtbezirk untenaus	4160	19	Lorraine-Quartier	58	b	41		Lorrainestrasse	46	
+Stadtbezirk untenaus	4161	19	Lorraine-Quartier	58	e	40		Jurastrasse	46	
+Stadtbezirk untenaus	4162	19	Lorraine-Quartier	58	k	13		Thalweg	46	
+Stadtbezirk untenaus	4163	19	Lorraine-Quartier	59		28		Jurastrasse	46	
+Stadtbezirk untenaus	4164	19	Lorraine-Quartier	62	a	6		Schmidweg	46	
+Stadtbezirk untenaus	4165	19	Lorraine-Quartier	63	a	7		Schmidweg	46	
+Stadtbezirk untenaus	4166	19	Lorraine-Quartier	64	a	14		Jurastrasse	46	
+Stadtbezirk untenaus	4167	19	Lorraine-Quartier	65	b	4		Platanenweg	46	
+Stadtbezirk untenaus	4168	19	Lorraine-Quartier	65		4	a	Platanenweg	46	Doubt in record
+Stadtbezirk untenaus	4169	19	Lorraine-Quartier	66	b	8		Platanenweg	46	
+Stadtbezirk untenaus	4170	19	Lorraine-Quartier	66		8		Platanenweg	46	Doubt in record
+Stadtbezirk untenaus	4171	19	Lorraine-Quartier	66	b	15		Jurastrasse	46	
+Stadtbezirk untenaus	4172	19	Lorraine-Quartier	67	a	12		Platanenweg	46	
+Stadtbezirk untenaus	4173	19	Lorraine-Quartier	67	b	10		Platanenweg	46	
+Stadtbezirk untenaus	4174	19	Lorraine-Quartier	67	c	10	a	Platanenweg	46	
+Stadtbezirk untenaus	4175	19	Lorraine-Quartier	70	a	29		Jurastrasse	46	
+Stadtbezirk untenaus	4176	19	Lorraine-Quartier	70	b	29	a	Jurastrasse	46	
+Stadtbezirk untenaus	4177	19	Lorraine-Quartier	71	a	35		Jurastrasse	46	
+Stadtbezirk untenaus	4178	19	Lorraine-Quartier	71	b	35	a	Jurastrasse	46	
+Stadtbezirk untenaus	4179	19	Lorraine-Quartier	72		37		Jurastrasse	46	
+Stadtbezirk untenaus	4180	19	Lorraine-Quartier	75	a	47		Jurastrasse	46	
+Stadtbezirk untenaus	4181	19	Lorraine-Quartier	75	b	47	a	Jurastrasse	46	
+Stadtbezirk untenaus	4182	19	Lorraine-Quartier	76	a	55		Jurastrasse	46	
+Stadtbezirk untenaus	4183	19	Lorraine-Quartier	76	b	57		Jurastrasse	46	
+Stadtbezirk untenaus	4184	19	Lorraine-Quartier	76	c	51		Jurastrasse	46	
+Stadtbezirk untenaus	4185	19	Lorraine-Quartier	77		59		Jurastrasse	46	
+Stadtbezirk untenaus	4186	19	Lorraine-Quartier	79		65		Jurastrasse	46	
+Stadtbezirk untenaus	4187	19	Lorraine-Quartier	80	a	69		Jurastrasse	46	
+Stadtbezirk untenaus	4188	19	Lorraine-Quartier	80	c	69	a	Jurastrasse	46	
+Stadtbezirk untenaus	4189	19	Lorraine-Quartier	80	b	71		Jurastrasse	46	
+Stadtbezirk untenaus	4190	19	Lorraine-Quartier	81		77		Jurastrasse	46	
+Stadtbezirk untenaus	4191	19	Lorraine-Quartier	82		77	a	Jurastrasse	46	
+Stadtbezirk untenaus	4192	19	Lorraine-Quartier	84	a	99		Jurastrasse	46	
+Stadtbezirk untenaus	4193	19	Lorraine-Quartier	84	b	95		Jurastrasse	46	
+Stadtbezirk untenaus	4194	19	Lorraine-Quartier	84	c	91		Jurastrasse	46	
+Stadtbezirk untenaus	4195	19	Lorraine-Quartier	84	d	89		Jurastrasse	46	
+Stadtbezirk untenaus	4196	19	Lorraine-Quartier	85	a	58		Jurastrasse	46	
+Stadtbezirk untenaus	4197	19	Lorraine-Quartier	85	b	60		Jurastrasse	46	
+Stadtbezirk untenaus	4198	19	Lorraine-Quartier	88		44		Jurastrasse	46	
+Stadtbezirk untenaus	4199	19	Lorraine-Quartier	89		42		Jurastrasse	46	
+Stadtbezirk untenaus	4200	19	Lorraine-Quartier	93	a	1		Haldenweg	46	
+Stadtbezirk untenaus	4201	19	Lorraine-Quartier	93	a	1	b	Haldenweg	46	
+Stadtbezirk untenaus	4202	19	Lorraine-Quartier	93	b	1	a	Haldenweg	46	
+Stadtbezirk untenaus	4203	19	Lorraine-Quartier	95	a	12		Thalweg	46	
+Stadtbezirk untenaus	4204	19	Lorraine-Quartier	95	b	12	a	Thalweg	46	
+Stadtbezirk untenaus	4205	19	Lorraine-Quartier	95	c	12	b	Thalweg	46	
+Stadtbezirk untenaus	4206	19	Lorraine-Quartier	115	a	16		Haldenweg	46	
+Stadtbezirk untenaus	4207	19	Lorraine-Quartier	115	b	18		Haldenweg	46	
+Stadtbezirk untenaus	4208	19	Lorraine-Quartier	115	c	23		Polygonweg	46	
+Stadtbezirk untenaus	4209	19	Lorraine-Quartier	116		19		Polygonweg	46	
+Stadtbezirk untenaus	4210	19	Lorraine-Quartier	117	a	15		Polygonweg	46	
+Stadtbezirk untenaus	4211	19	Lorraine-Quartier	117	b	13		Polygonweg	46	
+Stadtbezirk untenaus	4212	19	Lorraine-Quartier	118	a	11		Polygonweg	46	
+Stadtbezirk untenaus	4213	19	Lorraine-Quartier	118	b	9		Polygonweg	46	
+Stadtbezirk untenaus	4214	19	Lorraine-Quartier	117	c	6		Polygonweg	46	
+Stadtbezirk untenaus	4215	19	Lorraine-Quartier	118	c	10		Polygonweg	46	
+Stadtbezirk untenaus	4216	19	Lorraine-Quartier	119		8		Haldenweg	46	
+Stadtbezirk untenaus	4217	19	Lorraine-Quartier	119		6		Haldenweg	46	
+Stadtbezirk untenaus	4218	19	Lorraine-Quartier	119	b	6		Haldenweg	46	Doubt in record
+Stadtbezirk untenaus	4219	19	Lorraine-Quartier	119	c	1		Polygonweg	46	
+Stadtbezirk untenaus	4220	19	Lorraine-Quartier	119	d	3		Polygonweg	46	
+Stadtbezirk untenaus	4221	19	Lorraine-Quartier	120	a	66		Lorrainestrasse	46	
+Stadtbezirk untenaus	4222	19	Lorraine-Quartier	120	b	66	a	Lorrainestrasse	46	
+Stadtbezirk untenaus	4223	19	Lorraine-Quartier	121	a	62		Lorrainestrasse	46	
+Stadtbezirk untenaus	4224	19	Lorraine-Quartier	121	a	62	a	Lorrainestrasse	46	
+Stadtbezirk untenaus	4225	19	Lorraine-Quartier	121	a	62	b	Lorrainestrasse	46	
+Stadtbezirk untenaus	4226	19	Lorraine-Quartier	121	b	62		Lorrainestrasse	46	
+Stadtbezirk untenaus	4227	19	Lorraine-Quartier	121	b	62	a	Lorrainestrasse	46	
+Stadtbezirk untenaus	4228	19	Lorraine-Quartier	121	b	62	b	Lorrainestrasse	46	
+Stadtbezirk untenaus	4229	19	Lorraine-Quartier	128		23		Dammweg	46	
+Stadtbezirk untenaus	4230	19	Lorraine-Quartier	130		19		Quartierhof	46	
+Stadtbezirk untenaus	4231	19	Lorraine-Quartier	130		48		Lorrainestrasse	46	
+Stadtbezirk untenaus	4232	19	Lorraine-Quartier	131		50		Lorrainestrasse	46	
+Stadtbezirk untenaus	4233	19	Lorraine-Quartier	132		16		Quartierhof	46	
+Stadtbezirk untenaus	4234	19	Lorraine-Quartier	133		14		Quartierhof	46	
+Stadtbezirk untenaus	4235	19	Lorraine-Quartier	134		12		Quartierhof	46	
+Stadtbezirk untenaus	4236	19	Lorraine-Quartier	135		8		Quartierhof	46	
+Stadtbezirk untenaus	4237	19	Lorraine-Quartier	136		6		Quartierhof	46	
+Stadtbezirk untenaus	4238	19	Lorraine-Quartier	137		4		Quartierhof	46	
+Stadtbezirk untenaus	4239	19	Lorraine-Quartier	137		21		Dammweg	46	
+Stadtbezirk untenaus	4240	19	Lorraine-Quartier	138		19		Dammweg	46	
+Stadtbezirk untenaus	4241	19	Lorraine-Quartier	139		2		Quartierhof	46	
+Stadtbezirk untenaus	4242	19	Lorraine-Quartier	140		10		Quartierhof	46	
+Stadtbezirk untenaus	4243	19	Lorraine-Quartier	140		10	a	Quartierhof	46	
+Stadtbezirk untenaus	4244	19	Lorraine-Quartier	141		1		Quartierhof	46	
+Stadtbezirk untenaus	4245	19	Lorraine-Quartier	112		3		Quartierhof	46	
+Stadtbezirk untenaus	4246	19	Lorraine-Quartier	143		5		Quartierhof	46	
+Stadtbezirk untenaus	4247	19	Lorraine-Quartier	144		7		Quartierhof	46	
+Stadtbezirk untenaus	4248	19	Lorraine-Quartier	115		9		Quartierhof	46	
+Stadtbezirk untenaus	4249	19	Lorraine-Quartier	146		11		Quartierhof	46	
+Stadtbezirk untenaus	4250	19	Lorraine-Quartier	147		13		Quartierhof	46	
+Stadtbezirk untenaus	4251	19	Lorraine-Quartier	148		15		Quartierhof	46	
+Stadtbezirk untenaus	4252	19	Lorraine-Quartier	149		17		Quartierhof	46	
+Stadtbezirk untenaus	4253	19	Lorraine-Quartier	149		46		Lorrainestrasse	46	
+Stadtbezirk untenaus	4254	19	Lorraine-Quartier	150		31		Quartiergasse	46	
+Stadtbezirk untenaus	4255	19	Lorraine-Quartier	149	d	31		Quartiergasse	46	
+Stadtbezirk untenaus	4256	19	Lorraine-Quartier	151		29		Quartiergasse	46	
+Stadtbezirk untenaus	4257	19	Lorraine-Quartier	152		27		Quartiergasse	46	
+Stadtbezirk untenaus	4258	19	Lorraine-Quartier	153		25		Quartiergasse	46	
+Stadtbezirk untenaus	4259	19	Lorraine-Quartier	154		23		Quartiergasse	46	
+Stadtbezirk untenaus	4260	19	Lorraine-Quartier	155		21		Quartiergasse	46	
+Stadtbezirk untenaus	4261	19	Lorraine-Quartier	156		19		Quartiergasse	46	
+Stadtbezirk untenaus	4262	19	Lorraine-Quartier	157		17		Quartiergasse	46	
+Stadtbezirk untenaus	4263	20	Lorraine-Quartier	158		15		Quartiergasse	47	
+Stadtbezirk untenaus	4264	20	Lorraine-Quartier	159		13		Quartiergasse	47	
+Stadtbezirk untenaus	4265	20	Lorraine-Quartier	160		11		Quartiergasse	47	
+Stadtbezirk untenaus	4266	20	Lorraine-Quartier	161		9		Quartiergasse	47	
+Stadtbezirk untenaus	4267	20	Lorraine-Quartier	162		7		Quartiergasse	47	
+Stadtbezirk untenaus	4268	20	Lorraine-Quartier	163		5		Quartiergasse	47	
+Stadtbezirk untenaus	4269	20	Lorraine-Quartier	163		5	a	Quartiergasse	47	
+Stadtbezirk untenaus	4270	20	Lorraine-Quartier	164		3		Quartiergasse	47	
+Stadtbezirk untenaus	4271	20	Lorraine-Quartier	165	a	13		Dammweg	47	
+Stadtbezirk untenaus	4272	20	Lorraine-Quartier	166		3		Blumenweg	47	
+Stadtbezirk untenaus	4273	20	Lorraine-Quartier	166	b	3	a	Blumenweg	47	
+Stadtbezirk untenaus	4274	20	Lorraine-Quartier	170	a	9		Dammweg	47	
+Stadtbezirk untenaus	4275	20	Lorraine-Quartier	170	b	9	a	Dammweg	47	
+Stadtbezirk untenaus	4276	20	Lorraine-Quartier	172	a	29		Centralweg	47	
+Stadtbezirk untenaus	4277	20	Lorraine-Quartier	172	b	27		Centralweg	47	
+Stadtbezirk untenaus	4278	20	Lorraine-Quartier	172	c	25		Centralweg	47	
+Stadtbezirk untenaus	4279	20	Lorraine-Quartier	172	d	23		Centralweg	47	
+Stadtbezirk untenaus	4280	20	Lorraine-Quartier	172	e	21		Centralweg	47	
+Stadtbezirk untenaus	4281	20	Lorraine-Quartier	172	f	19		Centralweg	47	
+Stadtbezirk untenaus	4282	20	Lorraine-Quartier	188	a	2	a	Lagerweg	47	
+Stadtbezirk untenaus	4283	20	Lorraine-Quartier	188	b	2		Lagerweg	47	
+Stadtbezirk untenaus	4284	20	Lorraine-Quartier	188	c	2	b	Lagerweg	47	
+Stadtbezirk untenaus	4285	20	Lorraine-Quartier	188	d	2	c	Lagerweg	47	
+Stadtbezirk untenaus	4286	20	Lorraine-Quartier	193	a	11		Lagerweg	47	
+Stadtbezirk untenaus	4287	20	Lorraine-Quartier	193	b	9		Lagerweg	47	
+Stadtbezirk untenaus	4288	20	Lorraine-Quartier	194	a	7		Lagerweg	47	
+Stadtbezirk untenaus	4289	20	Lorraine-Quartier	204		38		Lorrainestrasse	47	
+Stadtbezirk untenaus	4290	20	Lorraine-Quartier	205		36		Lorrainestrasse	47	
+Stadtbezirk untenaus	4291	20	Lorraine-Quartier	206		34		Lorrainestrasse	47	
+Stadtbezirk untenaus	4292	20	Lorraine-Quartier	207	a	32		Lorrainestrasse	47	
+Stadtbezirk untenaus	4293	20	Lorraine-Quartier	207	b	11		Hofweg	47	
+Stadtbezirk untenaus	4294	20	Lorraine-Quartier	207	b	11	a	Hofweg	47	
+Stadtbezirk untenaus	4295	20	Lorraine-Quartier	207	b	11	b	Hofweg	47	
+Stadtbezirk untenaus	4296	20	Lorraine-Quartier	207	c	10		Lagerweg	47	
+Stadtbezirk untenaus	4297	20	Lorraine-Quartier	207	c	10	a	Lagerweg	47	
+Stadtbezirk untenaus	4298	20	Lorraine-Quartier	208	a	26		Lorrainestrasse	47	
+Stadtbezirk untenaus	4299	20	Lorraine-Quartier	208	b	28		Lorrainestrasse	47	
+Stadtbezirk untenaus	4300	20	Lorraine-Quartier	208	c	12	a	Lagerweg	47	
+Stadtbezirk untenaus	4301	20	Lorraine-Quartier	208	e	12		Lagerweg	47	
+Stadtbezirk untenaus	4302	20	Lorraine-Quartier	209		22		Lorrainestrasse	47	
+Stadtbezirk untenaus	4303	20	Lorraine-Quartier	210		20		Lorrainestrasse	47	
+Stadtbezirk untenaus	4304	20	Lorraine-Quartier	211	a	18		Lorrainestrasse	47	
+Stadtbezirk untenaus	4305	20	Lorraine-Quartier	211	b	18	a	Lorrainestrasse	47	
+Stadtbezirk untenaus	4306	20	Lorraine-Quartier	212	a	16		Lorrainestrasse	47	
+Stadtbezirk untenaus	4307	20	Lorraine-Quartier	212	c	16	b	Lorrainestrasse	47	
+Stadtbezirk untenaus	4308	20	Lorraine-Quartier	212	b	16	a	Lorrainestrasse	47	

--- a/src/street_abbrevs.csv
+++ b/src/street_abbrevs.csv
@@ -9,6 +9,7 @@ Aargst.,Aargauerstalden
 Aargstld.,Aargauerstalden
 Aarstr.,Aarstrasse
 Aarz.,Aarziele
+Aarzieledrittel,Aarziele
 Aarzhl.,Aarziele
 Aarzhle,Aarziele
 Aarziehle,Aarziele
@@ -29,6 +30,7 @@ Altb.,Altenberg
 Altbg.,Altenberg
 Altenb.,Altenberg
 Altenberg,Altenberg
+Altenberg-Drittel,Altenberg
 Altenbergstr.,Altenbergstrasse
 Altenbg.,Altenberg
 Altenbgstr.,Altenbergstrasse
@@ -44,15 +46,18 @@ Anatg.,Anatomiegäßchen
 Anatomg.,Anatomiegäßchen
 Anatomieg.,Anatomiegäßchen
 Anatomiegasse,Anatomiegäßchen
+Anatomiegässchen,Anatomiegäßchen
 Ankenl.,Ankenlaube
 Arbg.,Aarbergergasse
 Archivstr.,Archivstrasse
 Arz.,Aarziele
 Arziehle,Aarziele
 Arziele,Aarziele
+Arziele-Drittel,Aarziele
 Attinghausenstr.,Attinghausenstrasse
 äuß. Bollw.,Äußeres Bollwerk
 äuß. Bollwerk,Äußeres Bollwerk
+Aeusseres Bollwerk,Äußeres Bollwerk
 äußeres Bollwerk,Äußeres Bollwerk
 äußere Villette,Äußere Villette
 Az.,Aarziele
@@ -65,6 +70,7 @@ b. Casino,Beim Casino
 b. d. Schanze,Bei der Schanze
 b. d. Sch.,Bei der Schanze
 b. d. Schuzmühle,Bei der Schutzmühle
+B. d. Schutzmühle,Bei der Schutzmühle
 Beaulieustr.,Beaulieustrasse
 Beaumontw.,Beaumontweg
 bei der kl. Schanze,Bei der kleinen Schanze
@@ -104,6 +110,7 @@ Brückf.,Brückfeld
 Brückfeldstr.,Brückfeldstrasse
 Brung.,Brunngasse
 Brunnad.,Brunnadern
+Brunnadern-Drittel,Brunnadern
 Brunnadernstr.,Brunnadernstrasse
 Brünnenstr.,Brünnenstrasse
 Brunng,Brunngasse
@@ -222,6 +229,7 @@ Hllig.,Holligen
 Hlzm.,Holzmarkt
 Hochfeldstr.,Hochfeldstrasse
 Hollg.,Holligen
+Holligen-Drittel,Holligen
 Holligenstr.,Holligenstrasse
 Hollig.,Holligen
 Holzm.,Holzmarkt
@@ -240,6 +248,7 @@ i. Bollw.,Inneres Bollwerk
 im Pelikan,Im Pelikan
 in. Bollwerk,Inneres Bollwerk
 in. Bollw.,Inneres Bollwerk
+In der Enge,Enge
 Inselg.,Inselgasse
 Insg.,Inselgasse
 ir Längg.,Länggasse
@@ -314,8 +323,8 @@ Kyburgstr.,Kyburgstrasse
 Ladenwandstr.,Ladenwandstrasse
 Landoltstr.,Landoltstrasse
 Länggaß,Länggasse
-Länggassstrasse,Länggasse
-Länggassstr.,Länggasse
+Länggass-Drittel,Länggasse
+Länggassstr.,Länggassstrasse
 Längg.,Länggasse
 Läng,Länggasse
 Läng.,Länggasse
@@ -331,8 +340,10 @@ Lg.,Länggasse
 Lgm.,Längmauer
 Lngg.,Länggasse
 Loraine,Lorraine
+Lorraine-Quartier,Lorraine
 Lorbeerstr.,Lorbeerstrasse
-Lorrainestr.,Lorraine
+Lorrainestr.,Lorrainestrasse
+Lorraine-Strasse,Lorrainestrasse
 Lorr.,Lorraine
 Luisenstr.,Luisenstrasse
 Marienstr.,Marienstrasse
@@ -365,6 +376,9 @@ Monbijoustr.,Monbijoustrasse
 Morgenstr.,Morgenstrasse
 Morillonstr.,Morillonstrasse
 Moserstr.,Moserstrasse
+Müllerl.,Müllerlaube
+Müllerläublein,Müllerlaube
+Müllerläubli,Müllerlaube
 Mrkg.,Marktgasse
 Mrktgasse,Marktgasse
 Mrktg.,Marktgasse
@@ -461,6 +475,7 @@ Schönburg,Schönburg
 Schönburgstr.,Schönburgstrasse
 Schöneckweg,Schöneggweg
 Schosshaldenstr.,Schosshaldenstrasse
+Schosshalden-Drittel,Schosshalde
 Schoßhalde,Schosshalde
 Schoß-Halde,Schosshalde
 Schoßhld.,Schosshalde
@@ -476,6 +491,7 @@ Schrfrg.,Scharfrichtergasse
 Schßh.,Schosshalde
 Schtzm.,Schutzmühle
 Schulg.,Schulgasse
+Schulgässchen,Schulgasse
 Schützeng.,Schützengäßlein
 Schützengßl.,Schützengäßlein
 Schützenmattstr.,Schützenmattstrasse
@@ -603,3 +619,4 @@ Zwiebg.,Zwiebelngäßlein
 zwisch. den Thoren,Zwischen den Thoren
 zwisch. d. Thoren,Zwischen den Thoren
 zwisch. d. Thor.,Zwischen den Thoren
+Zwischen d. Thoren,Zwischen den Thoren

--- a/src/streets.csv
+++ b/src/streets.csv
@@ -216,6 +216,7 @@ Gryphenhübeliweg
 Gurtengasse
 Gutenbergstrasse
 Güterstrasse
+Gypsreibe
 Habsburgstrasse
 Haldenweg
 Hallerstrasse
@@ -261,6 +262,7 @@ Junkerngasse
 Jurastrasse
 Justingerweg
 Käfichgäßlein
+Käfichgässli
 Käfiggässchen
 Kalcheggweg
 Kanonenweg
@@ -303,6 +305,7 @@ Landoltstrasse
 Ländteweg
 Landweg
 Länggasse
+Länggassstrasse
 Längmauer
 Langmauerweg
 Laubeckstrasse
@@ -461,6 +464,7 @@ Schifflaube
 Schillingstrasse
 Schläflirain
 Schläflistrasse
+Schleifergässlein
 Schlößli
 Schlösslistrasse
 Schmidweg
@@ -538,6 +542,7 @@ Tannenweg
 Taubenstrasse
 Tavelweg
 Terrassenweg
+Theatergasse
 Theaterplatz
 Thormannstrasse
 Thunstrasse


### PR DESCRIPTION
Unless they are typos or OCR errors, in which case we fix them.