### PR TITLE
Revert "[CI] Build and publish artifacts after tagging a release"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,5 @@ jobs:
           python-version: 3.12
       - name: Check out sources
         uses: actions/checkout@v4
-      - name: Build release artifacts
+      - name: Build release files
         run: python3 src/build_release.py
-      - name: Publish release artifacts
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: Berner_Adressbuch.zip
-          asset_name: Adressbuch
-          tag: ${{ github.ref }}
-          overwrite: true


### PR DESCRIPTION
GitHub fails because of a permission problem: The GitHub runner uses a token that is not actually allowed to create a new release. Unfortunately, I couldn’t figure out how to create a suitable access token that won’t expire within a few weeks. We don’t cut releases that often, so let’s go back to a manual process.

This reverts commit 97e27376a8591a2ef785fa21fa102bb80c44829a.