### PR TITLE
Do not crash if an OCRed line has no position

### DIFF
--- a/proofread/1863-06-30.txt
+++ b/proofread/1863-06-30.txt
@@ -330,7 +330,7 @@ Bodmer B., Steinh., Lorraine 43 (Schneiderhaus)  # 1151,2387,513,37
 # Date: 1863-06-30 Page: 29210314/81
 Bögli Jb., Schneider, Bg. 23  # 256,333,628,66
 - B, Spengler, Aarbg. 24  # 278,383,563,63
-Böhlen, Gebr., Müller, Postpferdhalter 2c., Matte 109 
+Böhlen, Gebr., Müller, Postpferdhalter 2c., Matte 109  # 250,420,550,65
 - u. Strickler, Bierbrauerei, Altenberg 156  # 348,483,534,66;341,530,540,59;347,581,442,48
 Böhme F., Glaser, Neueng. 95  # 250,622,628,67
 Bohren P., Speisewirth beim Cafino 131 a  # 249,667,622,69;345,725,265,46
@@ -785,7 +785,7 @@ v. Ernst J. N. 2., Banquier, Postg. 47  # 1093,1827,638,42;1192,1880,202,37
 - Stellvert. d. Bahnhofvorst.  # 1182,1922,550,41
 Escher Alb., Münzdir., Münze  # 1095,1974,637,36
 - Photogr., Postg. 47  # 1183,2023,437,40
-Eschmann J., Gärtner, Altenb. 160 b, Ablage b. Lauteroburg, Posamenter, 
+Eschmann J., Gärtner, Altenb. 160 b  # 1095,2060,500,50
 Eßlinger geb. Rüchonnet, Lingère, Zeughg. 9  # 1196,2122,542,34;1169,2171,417,35;1100,2217,645,45;1201,2271,320,37
 Eymann Joh., Lorraine 120  # 1103,2319,598,27
 # Date: 1863-06-30 Page: 29210322/89
@@ -873,7 +873,7 @@ Finger A., marchand-tailleur, Kramg. 149 u. 151  # 437,1700,638,42;535,1749,400,
 v. Fischer-Doster A. F. R., Ho80% tell. 232  # 438,1842,638,43;430,1893,286,35
 - -Bondeli L. C. A., Banq., Spitalg. 129 und Schoßhaldendr. 93  # 461,1936,614,47;539,1992,538,37;535,2036,279,45
 - Lüthard, C. F. E., Hotel23. laube 232  # 521,2082,558,46;433,2135,315,36
-- E. F. 2., Dr., Professor, im botanischen Garten
+- E. F. 2., Dr., Professor, im botanischen Garten  # 520,2170,550,50
 - (v. Reichenbach) Ldw., gw. Reg.-Rath, Abl. bei J. J. Stettler, Spitalg. 129  # 539,2376,471,46
 - (v. Reichenbach), Moriz, Rent., Judeng. 128  # 526,2426,555,43;540,2474,406,43
 gen., eidgen. Oberstlieut., Marktg. 50  # 1209,421,537,39;1210,470,238,44
@@ -886,7 +886,7 @@ gen., eidgen. Oberstlieut., Marktg. 50  # 1209,421,537,39;1210,470,238,44
 - v. Sinner, Frau, Gerechtigkeitsg. 105 und Schoßhaldendr. 93 (Schönburg)  # 1217,1001,535,42;1213,1050,542,44;1214,1100,543,43
 - Frl. Louise, Junkerng. 188, Schoßhalde 66  # 1182,1150,574,39;1218,1199,298,41;541,2235,473,37
 - geb. v. Büren, Junkg. 166  # 1206,1253,554,33
-Fischer Frz., Offiz., Keßlg. 246
+Fischer Frz., Offiz., Keßlg. 246  # 1130,1280,540,45
 - A., Schreiner, Aarbg. 30  # 1116,1285,803,47;1206,1345,512,39
 - G., Messerschm. Grchtg. 80  # 1208,1393,550,38
 - F., Messerschm., Mezg. 71  # 1155,1445,603,40
@@ -927,7 +927,7 @@ Flügel C., Notar, Keßlerg. 282  # 257,1329,630,48
 - Jgfr., Mod., Kornhpl. 151  # 344,1570,541,44
 Fluri L., Lehrer, Zeughpl. 251  # 255,1618,628,47
 - Feuerwerk., Auff. d. Nak.Fabrik, Marz. 42  # 70,1663,817,55;349,1716,381,40
-Fogg George, amerik. Gesandter
+Fogg George, amerik. Gesandter  # 252,1710,640,55
 Follen, Jgfr. Emma, Lehrer, Herreng. 326  # 252,1761,634,52;349,1816,70,39;252,1857,633,48;348,1910,268,38
 Fontanellaz, D., Weinhändl., Metzg. 126 u. Kramg. 158  # 253,1956,630,48;353,2005,529,45
 v. Forer E. C. A., gew. Hptm. in Neapel, Judeng. 125  # 252,2050,630,46;349,2098,486,49
@@ -955,7 +955,7 @@ Freudenreich-Falconnet A., Nt., Spitalg. 154  # 934,1658,631,56;1036,1716,263,42
 Freudiger Jb., Schuhmacher, Stalden 12  # 934,1761,630,52;1031,1810,242,35
 Frey-Herosee, Bundesrath, Gerechtg. 132  # 932,1857,633,48;1030,1911,218,34
 - C., Stabsmaj. u. eidg. Bausekretär, Gerechtg. 127  # 1014,1953,551,48;1024,2003,491,40
-- A., Tel.-Insp., Gerchtg. 65 
+- A., Tel.-Insp., Gerchtg. 65  # 1000,2000,600,50
 - und Affolter, Agentur der schweizer. Rentenanst. 2c., Bollwerk, neues Postgeb.  # 957,2048,606,47;1017,2096,548,48;1027,2143,537,50;1030,2195,531,45
 - geb. Hubacher, Glas-, Kristall-, Steingut- u. Porzellanhdlg. Kramg. 222  # 988,2243,573,44;1025,2289,541,47;1025,2338,484,46
 - Wittwe des Lohnk., Schauplatzgasse 191  # 1014,2381,547,53;1025,2441,274,36
@@ -1385,21 +1385,22 @@ Heller, Broderie- u. Musikdos.handlg., Christoffelg. 186  # 162,1306,630,56;255,
 - Wwe., Glashandl., Kramgasse 177 und 178  # 247,1453,545,50;260,1501,387,44
 Hemmann F. E., Quartieraufseher, Brunng. 35  # 203,1599,419,45
 - Ad., Buchbind., Keßlg. 282  # 208,1641,582,54
-Hemmerling-Heim M. u. Comp., Broderien- u. Wollenw.8 Handlg., Marktg. 57  # 258,1741,529,52;184,1793,512,48
-Hemund Bend., Krämer, Zeug08 hausg. 12  # 158,1836,628,52;184,1888,271,45
-Herrmann A. N., Unterweibel, Hermingard, Elise, Sptlg. 139, Schauplg. 204  # 839,1748,631,54;838,1935,633,63;259,1982,292,47
-Herrenschwand, Jgfr., Bollw.  # 836,1988,632,49
-Hendrich C. F., Schreiner, 
-Henzi J. F., Gutsbes., gew. Ammann, Stadtbach 181, v.-geb. May, Frau, Insg. 136  # 255,2078,535,59;841,2083,632,60
-Ablage Marktg. 63  # 253,2125,394,54
+Hemmerling-Heim M. u. Comp., Broderien- u. Wollenw.-Handlg., Marktg. 57  # 258,1741,529,52;184,1793,512,48
+Hemund Bend., Krämer, Zeughausg. 12  # 158,1836,628,52
+Herrmann A. N., Unterweibel,  # 839,1748,631,54
+Hermingard, Elise, Sptlg. 139  # 838,1935,633,63
+Herrenschwand, Jgfr., Bollw. 263c  # 836,1988,632,49
+Hendrich C. F., Schreiner, Schauplg. 204  # 259,1982,292,47
+Henzi J. F., Gutsbes., gew. Ammann, Stadtbach 181  # 259,2020,292,50
+v. Herrenschwand geb. May, Frau, Insg. 136  # 255,2078,535,59;841,2083,632,60
 Herndl M., Schuhm., Brg. 3  # 839,2131,596,56
-Ww. d. Prof., Insg. 136b  # 246,2174,545,54
-Hert Nikl., Caféwirth, KramHertel Frd., Feilenh. Stald. 10  # 841,2178,632,55;838,2272,634,54
+- Ww. d. Prof., Insg. 136b  # 246,2174,545,54
+Hert Nikl., Caféwirth, Kram  # 841,2178,632,55
+Hertel Frd., Feilenh. Stald. 10  # 838,2272,634,54
 - R., Dr. med., Inselg. 136b  # 212,2221,577,51
 - geb. Hofmann, Wittwe d. od Pulververw., Rabbth. 156  # 214,2269,575,53;188,2314,599,58
 Herter, geb. Roth, Gastwirthin zum Affen, Kramg. 184 1864.  # 838,2320,629,59;926,2366,732,50
-- F. S., Ktsbuchhlt., StadtAbach 178 g (Wildhain)  # 181,2365,609,50;183,2410,532,58
-bach 178 g (Wildhain)  # 949,400,483,56
+- F. S., Ktsbuchhlt., Stadtbach 178 g (Wildhain)  # 181,2365,609,50;183,2410,532,58
 - R. F., Amtsnt., Bllw. 263a  # 934,451,548,46
 Bureau Kramg. 216  # 947,497,404,55
 - S., Schuhhdl., Krmg. 159  # 888,545,592,54
@@ -1571,8 +1572,8 @@ Hummel G., Buchbind. u. Paes peteriehdl., Marktg. 35  # 439,2251,640,49;434,2296
 - Jb., Bäcker, Neueng. 122b  # 521,2438,556,53
 Hummel G., Mezg., Keßlg. 282  # 1115,349,663,58
 Hunsperger Jb., Schuhmacher, Keßlg. 246  # 1141,402,635,53;1241,457,222,42
-- Dachdecker, in d. Loraine.
-Hüntensperger J., Kunstbleichebefizer, Längg. 277  # 1237,600,396,45
+- Dachdecker, in d. Loraine.  # 1237,555,396,45
+Hüntensperger J., Kunstbleichebesitzer, Längg. 277  # 1237,600,396,45
 Hunziker J. A., Rnt., Läng. 214  # 1139,649,637,44
 - Not. u. Fürsp., Sptg. 174 a  # 1227,699,549,46
 - M., Lehrerin, Zwiebg. 56  # 1227,748,526,47
@@ -1600,7 +1601,7 @@ Jäggi Eman. Fried., Amtsnot., Pelikan 230 u. Kirchg. 268  # 1133,2251,634,49;12
 - M., Waisenvater, Waisenh.  # 1178,2444,588,49
 # Date: 1863-06-30 Page: 29210336/103
 Jäggi-Gruner, Hotellaube 229  # 278,375,654,50
-- -Chariatte, Schnd., MarktHolligen 147gasse 44  # 242,423,670,46;1058,424,269,42;373,476,166,38
+- -Chariatte, Schnd., Marktgasse 44  # 242,423,670,46;373,476,166,38
 Jaggi Chr., Strohutausputer, Postg. 35  # 276,566,633,53;378,618,200,41
 - Frau, Feinwasch., Bg. 25  # 369,666,515,45
 - J., Haufirer, Gerechtg. 67  # 367,711,545,51
@@ -1622,14 +1623,14 @@ Jecker-Stähli, Pos., Mrktg. 44  # 270,1816,634,49
 v. Jenner B. L. N., Gemdrth., Gerechtg. 100  # 270,1912,633,53;367,1962,275,45
 - -Marcuard C. D. F., Bnq., 851 Spitalg. 126  # 291,2009,608,48;256,2056,373,48
 - -v. Herrenschwand, Frau, Junkerng. 184  # 292,2105,607,50;367,2155,290,43
-- J. E. R., Schreib. Lgg. 277  # 324,2202,575,51
+- J. E. R., Schreib., Lgg. 277  # 324,2202,575,51
 - J. E. F., Papierhändler u. Buchbd., Gerechtg. 91  # 324,2247,575,48;363,2300,437,46
 - Sophie, Bettm., Grchtg. 91  # 354,2346,546,49
 - Jgfr. Jülie, Marktg. 57  # 328,2391,525,49
-- Igf., Ling., Gerechtg. 109  # 346,2441,553,46
-Jenner, R. G. G., Zuckerbäck
-Jenni R., Buchdrucker u. Anti01--Lauterburg, Kramg. 189  # 932,375,654,50;961,470,633,41;243,520,609,47
-quar, Gerechtg. 115  # 1057,521,397,41
+- Jgf., Ling., Gerechtg. 109  # 346,2441,553,46
+Jenner, R. G. G., Zuckerbäck, Holligen 147  # 1058,424,269,42
+Jenni R., Buchdrucker u. Antiquar, Gerechtg. 115  # 1057,521,397,41
+- -Lauterburg, Kramg. 189  # 932,375,654,50;961,470,633,41;243,520,609,47
 - N., Bäcker, Nydeckbrck. 234  # 1046,569,547,37
 - F., Buchbd., Postg. 23  # 1047,615,473,46
 - A., Drechsler, Keßlerg. 285  # 1044,665,548,47
@@ -1877,8 +1878,8 @@ Kopp J. J., Rent., gew. Vergolder, Kramg. 159  # 269,2146,626,48;360,2198,404,43
 - Lehrer, Junkerng. 195  # 302,2338,498,52
 - Verwalter der Strafanst., Bollwerk 260 sindast  # 345,2384,547,50;357,2436,288,36;731,2109,152,27
 mauer 230 u. Gerechtg. 94  # 1058,417,535,50
-- H., S ohn, Brunnad. 11 d (Gryphenhübeli), Agentur f. Nähmasch. Gerechtg. 99  # 1053,512,539,52;1055,558,534,54
-Kraft E., Wirth z. Europ. Hof, 
+- H., Sohn, Brunnad. 11 d (Gryphenhübeli), Agentur f. Nähmasch. Gerechtg. 99  # 1053,512,539,52;1055,558,534,54
+Kraft E., Wirth z. Europ. Hof, Bärenplatz 242  # 960,500,620,120
 - F., Pfisternwirth, Kornhauspl. 51  # 960,607,626,55;1042,706,545,47;1053,755,220,41
 - J., Wirth z. Bernerhof  # 1044,799,493,51
 Krähenbühl G., Schrein., Holligen 155  # 959,850,627,50;1051,900,194,39
@@ -1888,7 +1889,7 @@ Krähenbühl G., Schrein., Holligen 155  # 959,850,627,50;1051,900,194,39
 - Jb., Schn., Schauplg. 226  # 1044,1136,544,54
 Kramer J., Schuhmch., Schauplatzg. 233  # 956,1182,629,55;1049,1239,228,35
 Kräuchi Jb., Metzger, Aarbergergasse 29 u. 67  # 953,1282,630,50;1052,1336,342,36
-- N., Nechtsag., Nng. 102  # 1046,1382,489,48
+- N., Rechtsag., Nng. 102  # 1046,1382,489,48
 Krager Fr., Postcommis, Bollwerk 82  # 952,1423,632,53;1051,1478,152,31
 Krebs-Bönzli, K., Kramg. 169  # 953,1520,633,53
 - Geschw., Schauplg. 219  # 1037,1567,500,55
@@ -3296,9 +3297,9 @@ Spätig F., Instr.-Off., Zeughausgasse, Caserne Nr. 1  # 953,2143,630,59;1045,21
 Spengler J. H., Schuhmacher, Marktg. 89  # 951,2236,631,64;1046,2291,225,43
 Spear I W., Zahnarzt, Gerechtg. 89  # 1044,2390,196,40
 # Date: 1863-06-30 Page: 29210365/132
-rechtigkeitsgasse 83  # 540,347,398,41
-Spiegelberg 2., Condt., Markt
-Spillmann A. G., Lederhdl., gasse 92 u. 94, Metzg. 122  # 444,398,641,35;226,489,856,44;542,448,284,31;539,548,226,25
+Spichiger E., Postadjunkt, Gerechtigkeitsgasse 83  # 540,347,398,41
+Spiegelberg L., Condt., Marktgasse 92 u. 94  # 542,448,284,31
+Spillmann A. G., Lederhdl., Metzg. 122  # 444,398,641,35;226,489,856,44;539,548,226,25
 - J. D., Gießer, Salzm. 238  # 488,593,598,30
 Spöri B., Schneider, Zeughausplatz 250  # 445,636,640,41;539,689,291,30
 Spörnli, Lohnbed., Marktg. 51  # 442,736,640,37
@@ -3791,8 +3792,8 @@ Weber C. M., Schuhm., Metzgerg. 87  # 1098,1256,642,52;1195,1322,169,24
 - Jost, eidg. Zollrevisor, Gerechtg. 70  # 1168,2318,577,43;1200,2367,195,39
 - Jak., Baumwollenw.- u. Cigarrenhdlg., Aarbg. 26  # 1192,2415,554,38;1205,2463,544,42
 # Date: 1863-06-30 Page: 29210374/141
-Weber Bernh., Fürspr., Meg
-- Sigm. Schrein. u. Pressenmacher, Postg. 32  # 210,299,663,39;304,371,549,68;312,442,362,43
+Weber Bernh., Fürspr., Metzgergasse 69  # 210,290,663,80
+- Sigm. Schrein. u. Pressenmacher, Postg. 32  # 304,371,549,68;312,442,362,43
 Weck Jgfr. Schn., Käfichg. 105  # 212,487,636,49
 Wegmüller, Wwe. d. Brillenhändl., Brunng. 17  # 214,540,636,36;310,587,420,43
 - Küfer, Marz. 31  # 307,635,331,39

--- a/src/split.py
+++ b/src/split.py
@@ -71,6 +71,10 @@ def split(vol, validator):
             row = 2
             image = fetch_jpeg(page_id)
             continue
+        if '#' not in line:
+            msg = "%s:%d: Line should contain a # character" % input_pos
+            print(msg)
+            raise ValueError(msg)
         p, pos, *score = line.split("#", 2)
         pos = ",".join([str(x) for x in simplify_pos(int(page_id), pos)])
         if score:


### PR DESCRIPTION
Instead of crashing, print an meaningful error.
Also, fix this problem in the 1863 data file.

https://github.com/brawer/bern-addresses/issues/326