### PR TITLE
Split titles in longest-to-shortest order

### DIFF
--- a/src/split.py
+++ b/src/split.py
@@ -209,7 +209,7 @@ class Splitter:
         return (maiden_name, rest)
 
     def split_title(self, text: str) -> (str, str):
-        for title in self.validator.titles:
+        for title in sorted(self.validator.titles, key=lambda x: -len(x)):
             if text.startswith(title):
                 rest = text.removeprefix(title)
                 if len(rest) == 0:

--- a/src/split_test.py
+++ b/src/split_test.py
@@ -141,6 +141,8 @@ def test_split_title(splitter):
     # https://github.com/brawer/bern-addresses/issues/422
     assert split("Drechsler, Jkg. 1") == ("", "Drechsler, Jkg. 1")
     assert split("Dr Echsler, Jkg. 1") == ("Dr", "Echsler, Jkg. 1")
+    assert split("Dr. Echsler, Jkg. 1") == ("Dr.", "Echsler, Jkg. 1")
+    assert split("Prof. Dr., Hotellaube 229") == ("Prof. Dr.", "Hotellaube 229")
     assert split("Droguist, Gg. 1") == ("", "Droguist, Gg. 1")
 
 


### PR DESCRIPTION
Before this change, `Dr.` got split into `Dr` and `.` because both `Dr` and `Dr.` are in the list of known titles, and the search order was not deterministic. After this change, we search titles in decreasing order of title length, so we try to split off `Dr.` first, before `Dr` is tried.

Fixes https://github.com/brawer/bern-addresses/issues/422.