### PR TITLE
deleted "Professor", "Prof.", "Prof. Dr.", "Dr. Prof.", "Dr. Professo…

### DIFF
--- a/src/titles.csv
+++ b/src/titles.csv
@@ -18,8 +18,6 @@ Dr. med.,,Doctor medicinae
 Dr. J.,,Doctor juris
 Dr. M.,,Doctor medicinae
 Dr. Med.,,Doctor medicinae
-Dr. Prof.,,Doktor Professor
-Dr. Professor,,
 Dr. phil.,,Doctor philosophiae
 Dr. theol.,,Doctor theologiae
 elektr.,,elektrisch
@@ -75,12 +73,6 @@ Nachf.,,Nachfolger
 phil.,,philosophiae
 pol.,,politicarum
 prakt.,,praktizierend
-Prof.,M,Professor
-Professor,M,Professor
-Prof. Dr.,M,Professor Doktor
-Professor Dr.,M,Professor Doktor
-Prof. Dr. Med.,M,Professor Doctor Medicinae
-Professor und Doktor der Rechte,M,Professor und Doktor der Rechte
 rer.,,rerum
 Ritter,M,Ritter
 Schw.,F,Schwester/n
@@ -117,5 +109,5 @@ Wtw.,F,Witwe
 Wwe,F,Witwe
 Wwe.,F,Witwe
 Wwe. u. Sohn,,Witwe und Sohn
-Wwe. und Tochter,Witwe und Tochter
+Wwe. und Tochter,,Witwe und Tochter
 Ww.,F,Witwe


### PR DESCRIPTION
…r" from this list

Professor is an occupation (see occupations.csv), Dr. a title. Erasing titles like "Dr. Professor", "Prof." and "Prof. Dr." from this list assures that this strings a correctly splitted.